### PR TITLE
Fix logout being very slow sometimes

### DIFF
--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -345,7 +345,7 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 
 			return {
 				close: async (): Promise<void> => {
-					idb.destroy(); // This is sometimes slow (~several seconds or longer), so we don't await it
+					await idb.destroy();
 					clearLocalStorage();
 					clearSessionStorage();
 				},


### PR DESCRIPTION
The individual commits tell a bigger story than the overall diff here:

- Commit 1d854fc adds some logging that reveals that it is the IndexedDB deletion that sometimes causes logout to hang. I've observed this take ~4 seconds on my machine. Please feel free to check out this commit and verify that you see similar results when logout hangs.
- The following commits remove the `await` on the IndexedDB deletion promise and remove the debug output. Please feel free to check out the head commit and verify that you no longer see the issue with logout hanging.