### PR TITLE
Optimize dev Dockerfile for rebuild speed and readonly filesystem

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,10 @@
 node_modules
 build
+dist
 .env
+.git
+.gitattributes
+.gitignore
+.npmrc.template
+.vscode
+README.md

--- a/development.Dockerfile
+++ b/development.Dockerfile
@@ -1,15 +1,22 @@
-FROM node:16-bullseye-slim AS development
+FROM node:16-bullseye-slim as dependencies
 
-WORKDIR /home/node/app
-COPY package.json .
-COPY yarn.lock .
-RUN mkdir -p /home/node/app/node_modules
-COPY --chown=node:node . .
+WORKDIR /dependencies
 
+# Install dependencies first so rebuild of these layers is only needed when dependencies change
+COPY package.json yarn.lock .npmrc .
 RUN yarn install && yarn cache clean -f
 
+
+FROM node:16-bullseye-slim as development
+
+ENV NODE_PATH=/node_modules
+COPY --from=dependencies /dependencies/node_modules /node_modules
+
+WORKDIR /app
 ENV NODE_ENV development
-RUN chown -R node:node  /home/node/app/node_modules
+CMD [ "yarn", "start-docker" ]
+
+# Set user last so everything is readonly by default
 USER node
 
-CMD [ "yarn", "start" ]
+# Don't need the rest of the sources since they'll be mounted from host

--- a/development.Dockerfile
+++ b/development.Dockerfile
@@ -16,7 +16,9 @@ WORKDIR /app
 ENV NODE_ENV development
 CMD [ "yarn", "start-docker" ]
 
+# src/ and public/ will be mounted from host, but we need some config files in the image for startup
+COPY . .
+RUN rm .npmrc
+
 # Set user last so everything is readonly by default
 USER node
-
-# Don't need the rest of the sources since they'll be mounted from host

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "start-docker": "npx react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
This restructures the development Dockerfile to put `node_modules` in a readonly filesystem and to make maximal use of the Docker build cache. This makes the installed dependencies consistently determined by the Docker image alone, independent of any runtime state held in volumes. The optimized layer order also enables using `docker-compose up --build` in the parent project to automatically rebuild the image on any changes to dependencies.