### PR TITLE
restore type message listener

### DIFF
--- a/src/components/Notification.js
+++ b/src/components/Notification.js
@@ -45,7 +45,7 @@ const Notification = () => {
 	}, [notification]);
 
 	useEffect(() => {
-		const unregisterMessageListener = () => onMessageListener()
+		const unregisterMessageListener = onMessageListener()
 			.then((payload) => {
 				setNotification({ title: payload?.notification?.title, body: payload?.notification?.body });
 			})


### PR DESCRIPTION
I restored unregisterMessageListener type as it was causing problems with notifications. Additionally, it appeared that this type wasn't properly connected to the resolved error page.