### PR TITLE
Hide PRF compatibility link while browser support portal is shown

### DIFF
--- a/src/components/BrowserSupport.tsx
+++ b/src/components/BrowserSupport.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, createContext, useContext, useEffect, useState } from 'react';
+import React, { ReactNode, createContext, useContext } from 'react';
 import { UAParser } from 'ua-parser-js';
 
 import { useSessionStorage } from './useStorage';

--- a/src/components/BrowserSupport.tsx
+++ b/src/components/BrowserSupport.tsx
@@ -13,7 +13,7 @@ const noWarnPlatforms = [
 	{ browser: /brave/ui, not: { os: /ios/ui } },
 ];
 
-export default function CheckBrowserSupport({
+export function BrowserSupportWarningPortal({
 	children,
 	classes,
 }: {
@@ -42,20 +42,20 @@ export default function CheckBrowserSupport({
 	return (
 		<>
 			<h2 className="text-lg font-bold leading-tight tracking-tight text-gray-900 text-center dark:text-white">
-				<FaExclamationTriangle className="text-2xl inline-block text-red-600 mr-2" /> 
-				{ t('CheckBrowserSupport.heading') }
+				<FaExclamationTriangle className="text-2xl inline-block text-red-600 mr-2" />
+				{ t('BrowserSupportWarningPortal.heading') }
 			</h2>
 
-			<p className="text-sm">{t('CheckBrowserSupport.intro')}</p>
+			<p className="text-sm">{t('BrowserSupportWarningPortal.intro')}</p>
 
-			<p className="text-sm">{t('CheckBrowserSupport.supportedList.intro')}</p>
+			<p className="text-sm">{t('BrowserSupportWarningPortal.supportedList.intro')}</p>
 			<ul className="ml-4 list-none text-sm">
 				<li className="flex justify-start items-center" style={{ textAlign: 'left' }}>
 						<div className="w-1/12">
 								<FaCheckCircle className="text-md text-green-500" />
 						</div>
-						<div className="w-11/12 pl-1"> 
-								{t('CheckBrowserSupport.supportedList.windows')}
+						<div className="w-11/12 pl-1">
+								{t('BrowserSupportWarningPortal.supportedList.windows')}
 						</div>
 				</li>
 				<li className="flex justify-start items-center">
@@ -63,7 +63,7 @@ export default function CheckBrowserSupport({
 								<FaCheckCircle className="text-md text-green-500" />
 						</div>
 						<div className="w-11/12 pl-1">
-								{t('CheckBrowserSupport.supportedList.macos')}
+								{t('BrowserSupportWarningPortal.supportedList.macos')}
 						</div>
 				</li>
 				<li className="flex justify-start items-center">
@@ -71,7 +71,7 @@ export default function CheckBrowserSupport({
 								<FaCheckCircle className="text-md text-green-500" />
 						</div>
 						<div className="w-11/12 pl-1">
-								{t('CheckBrowserSupport.supportedList.android')}
+								{t('BrowserSupportWarningPortal.supportedList.android')}
 						</div>
 				</li>
 				<li className="flex justify-start items-center">
@@ -79,14 +79,14 @@ export default function CheckBrowserSupport({
 								<FaCheckCircle className="text-md text-green-500" />
 						</div>
 						<div className="w-11/12 pl-1">
-								{t('CheckBrowserSupport.supportedList.linux')}
+								{t('BrowserSupportWarningPortal.supportedList.linux')}
 						</div>
 				</li>
 			</ul>
 
 			<p className="text-sm">
 				<Trans
-					i18nKey="CheckBrowserSupport.moreDetails"
+					i18nKey="BrowserSupportWarningPortal.moreDetails"
 					components={{
 						docLink: <a
 							href="https://github.com/wwWallet/wallet-frontend#prf-compatibility" target='blank_'
@@ -96,14 +96,14 @@ export default function CheckBrowserSupport({
 				/>
 			</p>
 
-			<p className="text-sm">{t('CheckBrowserSupport.outro')}</p>
+			<p className="text-sm">{t('BrowserSupportWarningPortal.outro')}</p>
 
 			<button
 				className={`w-full text-white bg-gray-300 hover:bg-gray-400 focus:ring-4 focus:outline-none focus:ring-gray-400 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-gray-300 dark:hover:bg-gray-400 dark:focus:ring-gray-400 ${classes || ""}`}
 				onClick={() => setBypass(true)}
 				type="button"
 			>
-				{t('CheckBrowserSupport.continueAnyway')}
+				{t('BrowserSupportWarningPortal.continueAnyway')}
 			</button>
 		</>
 	);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -27,6 +27,8 @@
 	"enterconfirmPasswordLabel": "Enter your confirm password",
 	"fillInFieldsError": "Please fill in all required fields",
 	"incorrectCredentialsError": "Incorrect username or password",
+	"learnMorepart1": "Learn more about",
+	"learnMorepart2": "PRF compatibility regarding browser support and supported operating systems.",
 	"lockPasskeyManagement": "Lock passkey management",
 	"login": "Login",
 	"loginAsUser": "Log in as {{name}}",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,5 +1,5 @@
 {
-	"CheckBrowserSupport": {
+	"BrowserSupportWarningPortal": {
 		"continueAnyway": "Continue anyway",
 		"moreDetails": "For more details, please see <docLink>this compatibility table</docLink>.",
 		"heading": "Unsupported platform",

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -10,7 +10,7 @@ import * as api from '../../api';
 import { useLocalStorageKeystore } from '../../services/LocalStorageKeystore';
 import logo from '../../assets/images/logo.png';
 // import LanguageSelector from '../../components/LanguageSelector/LanguageSelector'; // Import the LanguageSelector component
-import CheckBrowserSupport from '../../components/CheckBrowserSupport';
+import { BrowserSupportWarningPortal } from '../../components/BrowserSupport';
 import SeparatorLine from '../../components/SeparatorLine';
 
 const loginWithPassword = process.env.REACT_APP_LOGIN_WITH_PASSWORD ?
@@ -493,7 +493,7 @@ const Login = () => {
 						</a>
 					</p> 
 					<div className="p-6 space-y-4 md:space-y-6 sm:p-8 bg-white rounded-lg shadow dark:border">
-						<CheckBrowserSupport>
+						<BrowserSupportWarningPortal>
 							<h1 className="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl text-center dark:text-white">
 								{isLogin ? t('login') : t('signUp')}
 							</h1>
@@ -568,7 +568,7 @@ const Login = () => {
 									{isLogin ? t('signUp') : t('login')}
 								</a>
 							</p>
-						</CheckBrowserSupport>
+						</BrowserSupportWarningPortal>
 					</div>
 				</div>
 			</div>

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -1,10 +1,9 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { FaUser, FaLock, FaEye, FaEyeSlash } from 'react-icons/fa';
+import { FaEye, FaExclamationTriangle, FaEyeSlash, FaInfoCircle, FaLock, FaUser } from 'react-icons/fa';
 import { GoPasskeyFill, GoTrash } from 'react-icons/go';
 import { AiOutlineUnlock } from 'react-icons/ai';
 import { useTranslation } from 'react-i18next'; // Import useTranslation hook
-import { FaInfoCircle } from 'react-icons/fa';
 
 import * as api from '../../api';
 import { useLocalStorageKeystore } from '../../services/LocalStorageKeystore';
@@ -482,18 +481,26 @@ const Login = () => {
 					{/* <div className="absolute top-2 right-2">
 						<LanguageSelector />
 					</div> */}
-					<CheckBrowserSupport.IfSupported>
-						<p className="text-sm font-light text-gray-500 dark:text-gray-400 italic mb-2">
-							<FaInfoCircle className="text-md inline-block text-gray-500 mr-2" />
-							Learn more about{' '}
-							<a
-								href="https://github.com/wwWallet/wallet-frontend#prf-compatibility" target='blank_'
-								className="font-medium text-custom-blue hover:underline dark:text-blue-500"
-							>
-								PRF compatibility regarding browser support and supported operating systems.
-							</a>
-						</p>
-					</CheckBrowserSupport.IfSupported>
+					<CheckBrowserSupport.Ctx>
+						<CheckBrowserSupport.If test={(ctx) => !ctx.showWarningPortal}>
+							<p className="text-sm font-light text-gray-500 dark:text-gray-400 italic mb-2">
+								<CheckBrowserSupport.If test={(ctx) => ctx.browserSupported}>
+									<FaInfoCircle className="text-md inline-block text-gray-500 mr-2" />
+								</CheckBrowserSupport.If>
+								<CheckBrowserSupport.If test={(ctx) => !ctx.browserSupported}>
+									<FaExclamationTriangle className="text-md inline-block text-orange-600 mr-2" />
+								</CheckBrowserSupport.If>
+
+								Learn more about{' '}
+								<a
+									href="https://github.com/wwWallet/wallet-frontend#prf-compatibility" target='blank_'
+									className="font-medium text-custom-blue hover:underline dark:text-blue-500"
+								>
+									PRF compatibility regarding browser support and supported operating systems.
+								</a>
+							</p>
+						</CheckBrowserSupport.If>
+					</CheckBrowserSupport.Ctx>
 					<div className="p-6 space-y-4 md:space-y-6 sm:p-8 bg-white rounded-lg shadow dark:border">
 						<CheckBrowserSupport.WarningPortal>
 							<h1 className="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl text-center dark:text-white">

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -491,12 +491,12 @@ const Login = () => {
 									<FaExclamationTriangle className="text-md inline-block text-orange-600 mr-2" />
 								</CheckBrowserSupport.If>
 
-								Learn more about{' '}
+								{t('learnMorepart1')}{' '}
 								<a
 									href="https://github.com/wwWallet/wallet-frontend#prf-compatibility" target='blank_'
 									className="font-medium text-custom-blue hover:underline dark:text-blue-500"
 								>
-									PRF compatibility regarding browser support and supported operating systems.
+									{t('learnMorepart2')}
 								</a>
 							</p>
 						</CheckBrowserSupport.If>

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -482,20 +482,18 @@ const Login = () => {
 					{/* <div className="absolute top-2 right-2">
 						<LanguageSelector />
 					</div> */}
-					<CheckBrowserSupport.Ctx>
-						<CheckBrowserSupport.IfSupported>
-							<p className="text-sm font-light text-gray-500 dark:text-gray-400 italic mb-2">
-								<FaExclamationTriangle className="text-md inline-block text-orange-600 mr-2" />
-								Learn more about{' '}
-								<a
-									href="https://github.com/wwWallet/wallet-frontend#prf-compatibility" target='blank_'
-									className="font-medium text-custom-blue hover:underline dark:text-blue-500"
-								>
-									PRF compatibility regarding browser support and supported operating systems.
-								</a>
-							</p>
-						</CheckBrowserSupport.IfSupported>
-					</CheckBrowserSupport.Ctx>
+					<CheckBrowserSupport.IfSupported>
+						<p className="text-sm font-light text-gray-500 dark:text-gray-400 italic mb-2">
+							<FaExclamationTriangle className="text-md inline-block text-orange-600 mr-2" />
+							Learn more about{' '}
+							<a
+								href="https://github.com/wwWallet/wallet-frontend#prf-compatibility" target='blank_'
+								className="font-medium text-custom-blue hover:underline dark:text-blue-500"
+							>
+								PRF compatibility regarding browser support and supported operating systems.
+							</a>
+						</p>
+					</CheckBrowserSupport.IfSupported>
 					<div className="p-6 space-y-4 md:space-y-6 sm:p-8 bg-white rounded-lg shadow dark:border">
 						<CheckBrowserSupport.WarningPortal>
 							<h1 className="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl text-center dark:text-white">

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -10,7 +10,7 @@ import * as api from '../../api';
 import { useLocalStorageKeystore } from '../../services/LocalStorageKeystore';
 import logo from '../../assets/images/logo.png';
 // import LanguageSelector from '../../components/LanguageSelector/LanguageSelector'; // Import the LanguageSelector component
-import { BrowserSupportWarningPortal } from '../../components/BrowserSupport';
+import * as CheckBrowserSupport from '../../components/BrowserSupport';
 import SeparatorLine from '../../components/SeparatorLine';
 
 const loginWithPassword = process.env.REACT_APP_LOGIN_WITH_PASSWORD ?
@@ -493,7 +493,7 @@ const Login = () => {
 						</a>
 					</p> 
 					<div className="p-6 space-y-4 md:space-y-6 sm:p-8 bg-white rounded-lg shadow dark:border">
-						<BrowserSupportWarningPortal>
+						<CheckBrowserSupport.WarningPortal>
 							<h1 className="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl text-center dark:text-white">
 								{isLogin ? t('login') : t('signUp')}
 							</h1>
@@ -568,7 +568,7 @@ const Login = () => {
 									{isLogin ? t('signUp') : t('login')}
 								</a>
 							</p>
-						</BrowserSupportWarningPortal>
+						</CheckBrowserSupport.WarningPortal>
 					</div>
 				</div>
 			</div>

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -482,16 +482,20 @@ const Login = () => {
 					{/* <div className="absolute top-2 right-2">
 						<LanguageSelector />
 					</div> */}
-					<p className="text-sm font-light text-gray-500 dark:text-gray-400 italic mb-2">
-					<FaExclamationTriangle className="text-md inline-block text-orange-600 mr-2" />
-						Learn more about{' '}
-						<a
-							href="https://github.com/wwWallet/wallet-frontend#prf-compatibility" target='blank_'
-							className="font-medium text-custom-blue hover:underline dark:text-blue-500"
-						>
-							PRF compatibility regarding browser support and supported operating systems.
-						</a>
-					</p> 
+					<CheckBrowserSupport.Ctx>
+						<CheckBrowserSupport.IfSupported>
+							<p className="text-sm font-light text-gray-500 dark:text-gray-400 italic mb-2">
+								<FaExclamationTriangle className="text-md inline-block text-orange-600 mr-2" />
+								Learn more about{' '}
+								<a
+									href="https://github.com/wwWallet/wallet-frontend#prf-compatibility" target='blank_'
+									className="font-medium text-custom-blue hover:underline dark:text-blue-500"
+								>
+									PRF compatibility regarding browser support and supported operating systems.
+								</a>
+							</p>
+						</CheckBrowserSupport.IfSupported>
+					</CheckBrowserSupport.Ctx>
 					<div className="p-6 space-y-4 md:space-y-6 sm:p-8 bg-white rounded-lg shadow dark:border">
 						<CheckBrowserSupport.WarningPortal>
 							<h1 className="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl text-center dark:text-white">

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -4,7 +4,7 @@ import { FaUser, FaLock, FaEye, FaEyeSlash } from 'react-icons/fa';
 import { GoPasskeyFill, GoTrash } from 'react-icons/go';
 import { AiOutlineUnlock } from 'react-icons/ai';
 import { useTranslation } from 'react-i18next'; // Import useTranslation hook
-import { FaExclamationTriangle } from 'react-icons/fa';
+import { FaInfoCircle } from 'react-icons/fa';
 
 import * as api from '../../api';
 import { useLocalStorageKeystore } from '../../services/LocalStorageKeystore';
@@ -484,7 +484,7 @@ const Login = () => {
 					</div> */}
 					<CheckBrowserSupport.IfSupported>
 						<p className="text-sm font-light text-gray-500 dark:text-gray-400 italic mb-2">
-							<FaExclamationTriangle className="text-md inline-block text-orange-600 mr-2" />
+							<FaInfoCircle className="text-md inline-block text-gray-500 mr-2" />
 							Learn more about{' '}
 							<a
 								href="https://github.com/wwWallet/wallet-frontend#prf-compatibility" target='blank_'


### PR DESCRIPTION
Currently, the PRF compatibility hints are arguably duplicated when the compatibility warning is shown. These changes hide the PRF hint outside the content box while the compatibility warning portal is shown in the content box.

## Before
![Hint outside content box also shown with login view](https://github.com/wwWallet/wallet-frontend/assets/1367758/c2120429-68b5-4206-8047-4a5e34beca8e)

The hint outside the content box is shown with the login view.

![Hint outside content box shown with compatibility warning view](https://github.com/wwWallet/wallet-frontend/assets/1367758/965a3801-8fd9-4545-a932-9d8e7fdd8826)

The hint outside the content box is also shown with the compatibility warning view.


## After

![Hint outside content box still shown with login view](https://github.com/wwWallet/wallet-frontend/assets/1367758/17894b31-6dc9-4f9a-a814-e1e1df3af889)

The hint outside the content box is still shown with the login view.

![Hint outside content box not shown with compatibility warning view](https://github.com/wwWallet/wallet-frontend/assets/1367758/d7f1b474-fad8-4de9-9c7c-caa863c502d3)

The hint outside the content box is no longer shown with the compatibility warning view.
