### PR TITLE
Add 'required' Attribute to Name Field

### DIFF
--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -61,6 +61,7 @@ const FormInputField = ({
 				value={value}
 				onChange={onChange}
 				aria-label={ariaLabel}
+				required={name === "name"}
 			/>
 
 			{type === 'password' && (


### PR DESCRIPTION
Added the 'required' attribute to the 'name' input field in the signup form to make it mandatory for users to provide their name before submitting the form.