### PR TITLE
Add error message if authenticator does not support PRF

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -278,6 +278,7 @@ type SignupWebauthnError = (
 	| 'passkeySignupFailedTryAgain'
 	| 'passkeySignupFinishFailedServerError'
 	| 'passkeySignupKeystoreFailed'
+	| 'passkeySignupPrfNotSupported'
 	| { errorId: 'prfRetryFailed', retryFrom: SignupWebauthnRetryParams }
 );
 type SignupWebauthnRetryParams = { beginData: any, credential: PublicKeyCredential };
@@ -357,6 +358,8 @@ export async function signupWebauthn(
 			} catch (e) {
 				if (e?.errorId === "prf_retry_failed") {
 					return Err({ errorId: 'prfRetryFailed', retryFrom: { credential, beginData } });
+				} else if (e?.errorId === "prf_not_supported") {
+					return Err('passkeySignupPrfNotSupported');
 				} else {
 					return Err('passkeySignupKeystoreFailed');
 				}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -47,6 +47,7 @@
 	"passkeySignupFailedTryAgain": "Passkey creation failed, please try again.",
 	"passkeySignupFinishFailedServerError": "Failed to finalize passkey creation, please try again later.",
 	"passkeySignupKeystoreFailed": "Failed to initialize wallet key store, please try again.",
+	"passkeySignupPrfNotSupported": "This browser or security key is not supported. Please make sure that your browser supports the WebAuthn PRF extension and your security key, if any, supports the \"hmac-secret\" extension. <docLink>Learn more here</docLink>.",
 	"passwordLabel": "Password",
 	"passwordLength": "Minimum length: 8 characters",
 	"passwordsNotMatchError": "Passwords do not match",

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -198,6 +198,20 @@ const WebauthnSignupLogin = ({
 						setError(t('passkeySignupKeystoreFailed'));
 						break;
 
+					case 'passkeySignupPrfNotSupported':
+						setError(
+							<Trans
+								i18nKey ="passkeySignupPrfNotSupported"
+								components={{
+									docLink: <a
+										href="https://github.com/wwWallet/wallet-frontend#prf-compatibility" target='blank_'
+										className="font-medium text-custom-blue hover:underline dark:text-blue-500"
+									/>
+								}}
+							/>
+						);
+						break;
+
 					default:
 						if (result.val?.errorId === 'prfRetryFailed') {
 							setRetrySignupFrom(result.val?.retryFrom);


### PR DESCRIPTION
Adds an error message in case the browser is PRF compatible but the authenticator (security key) is not, as described in https://github.com/wwWallet/wallet-frontend/issues/81#issuecomment-1825522910 .

![screenshot-2023-11-24T12:27:06+01:00](https://github.com/wwWallet/wallet-frontend/assets/1367758/3305078b-8134-43a2-a2fe-a0d66e4c01ee)

The "learn more" link leads to the PRF compatibility documentation.

## Testing

To test this, you'll either need an authenticator that supports passkeys but not the `hmac-secret` extension (so an iPhone would probably work?), or to run this snippet in the developer console before clicking the "Sign up with passkey" button:

```js
origCreate = navigator.credentials.create;
navigator.credentials.create = async function(options) {
  options.publicKey.authenticatorSelection.residentKey = "discouraged";
  options.publicKey.authenticatorSelection.userVerification = "discouraged";
  const pkc = await origCreate.call(this, options);
  return {
    authenticatorAttachment: pkc.authenticatorAttachment,
    id: pkc.id,
    rawId: pkc.rawId,
    response: pkc.response,
    type: pkc.type,
    getClientExtensionResults: () => ({ prf: { enabled: false } }),
  };
}
```

This snippet simulates the incompatibility by overriding the PRF extension output with what it would look like if the browser supports PRF but the authenticator does not.

Alternatively, if you have a pre-FIDO2 (U2F) security key (for example a YubiKey NEO), you can use this snippet instead:

```js
origCreate = navigator.credentials.create;
navigator.credentials.create = function(options) {
  options.publicKey.authenticatorSelection.residentKey = "discouraged";
  options.publicKey.authenticatorSelection.userVerification = "discouraged";
  return origCreate.call(this, options);
}
```

This instead disables the requirement that the security key must support passkeys (PIN and discoverable keys), which results in a `PublicKeyCredential` result that genuinely reflects what happens if the browser supports PRF but the security key does not support the `hmac-secret` CTAP extension.