### PR TITLE
Fix WebSocket duplication in handleServerMessagesGuard

### DIFF
--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -1,25 +1,26 @@
-import React from 'react';
-import { Navigate, useLocation } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import { Navigate, useLocation, useNavigate } from 'react-router-dom';
 
 import { useApi } from '../api';
 
-
 const PrivateRoute = ({ children }) => {
-	const api = useApi();
-	const isLoggedIn = api.isLoggedIn();
-	const location = useLocation();
+  const api = useApi();
+  const isLoggedIn = api.isLoggedIn();
+  const location = useLocation();
+  const navigate = useNavigate();
 
-	// const handleauthrespn{
+  useEffect(() => {
+    if (!isLoggedIn) {
+      const destination = location.pathname + location.search;
+      navigate('/login', { state: { from: destination } });
+    }
+  }, [isLoggedIn, location, navigate]);
 
-	// 	//take url req to bck handleAuthorizationResponse
-	// 	//if 200 go to root /
-	// }
+  if (!isLoggedIn) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
 
-	if (!isLoggedIn) {
-		return <Navigate to="/login" state={{ from: location }} replace />;
-	}
-
-	return children;
+  return children;
 };
 
 export default PrivateRoute;

--- a/src/components/useStorage.ts
+++ b/src/components/useStorage.ts
@@ -15,7 +15,7 @@ function makeUseStorage<T>(
 	}
 
 	return (name: string, initialValue: T) => {
-		const [currentValue, setValue] = useState(
+		const getCurrentValue = useCallback(
 			() => {
 				const storedValueStr = storage.getItem(name);
 				try {
@@ -27,14 +27,17 @@ function makeUseStorage<T>(
 					storage.removeItem(name);
 				}
 				return initialValue;
-			}
+			},
+			[],
 		);
+
+		const [currentValue, setValue] = useState(getCurrentValue);
 
 		const updateValue = useCallback(
 			(action: SetStateAction<T>): void => {
 				const newValue =
 					action instanceof Function
-					? action(currentValue)
+					? action(getCurrentValue())
 					: action;
 				try {
 					storage.setItem(name, jsonStringifyTaggedBinary(newValue));
@@ -51,7 +54,7 @@ function makeUseStorage<T>(
 					})
 				);
 			},
-			[currentValue, name],
+			[],
 		);
 
 		useEffect(
@@ -77,7 +80,7 @@ function makeUseStorage<T>(
 					window.removeEventListener('storage', listener);
 				};
 			},
-			[name]
+			[]
 		);
 
 		useEffect(

--- a/src/pages/AccountSettings/AccountSettings.tsx
+++ b/src/pages/AccountSettings/AccountSettings.tsx
@@ -514,7 +514,11 @@ const Home = () => {
 				console.error('Failed to fetch data', error);
 			}
 		},
-		[api, setUserData],
+		[
+			api,
+			keystore, // To react if credentials are modified in a different tab
+			setUserData,
+		],
 	);
 
 	useEffect(

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { FaEye, FaExclamationTriangle, FaEyeSlash, FaInfoCircle, FaLock, FaUser } from 'react-icons/fa';
 import { GoPasskeyFill, GoTrash } from 'react-icons/go';
 import { AiOutlineUnlock } from 'react-icons/ai';
@@ -111,6 +111,9 @@ const WebauthnSignupLogin = ({
 	const [resolvePrfRetryPrompt, setResolvePrfRetryPrompt] = useState(null);
 	const [prfRetryAccepted, setPrfRetryAccepted] = useState(false);
 	const navigate = useNavigate();
+	const location = useLocation();
+	const from = location.state?.from || '/';
+
 	const { t } = useTranslation();
 	const keystore = useLocalStorageKeystore();
 	const [retrySignupFrom, setRetrySignupFrom] = useState(null);
@@ -139,7 +142,7 @@ const WebauthnSignupLogin = ({
 		async (cachedUser) => {
 			const result = await api.loginWebauthn(keystore, promptForPrfRetry, cachedUser);
 			if (result.ok) {
-				navigate('/');
+				navigate(from, { replace: true });
 
 			} else {
 				// Using a switch here so the t() argument can be a literal, to ease searching
@@ -179,7 +182,7 @@ const WebauthnSignupLogin = ({
 				retrySignupFrom,
 			);
 			if (result.ok) {
-				navigate('/');
+				navigate(from, { replace: true });
 
 			} else {
 				// Using a switch here so the t() argument can be a literal, to ease searching


### PR DESCRIPTION
This is part 2 of 3 in an effort to fix wwWallet/wallet-ecosystem#31; part 1 is #133.

Before, a new WebSocket was created on every render of `handleServerMessagesGuard`, and event listeners bound to all of them. This results in lots of sockets being opened - often about 8 on initial page load, and then another for each page navigation.

This changes the hook to keep the WebSocket instance in a React ref, so that the same socket instance is used consistently for the lifetime of the wrapped component. The startup procedure is also tweaked to unbind the startup message handlers and replace them with the long-term message handler.

This depends on the changes in #133 because the initialization logic now only runs once, and therefore needs to be able to react when the `appToken` state changes. This is much easier to do using the `useSessionStorage` hook than using cookies.