### PR TITLE
Support parallel sessions in multiple tabs

### DIFF
--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -1,25 +1,26 @@
-import React from 'react';
-import { Navigate, useLocation } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import { Navigate, useLocation, useNavigate } from 'react-router-dom';
 
 import { useApi } from '../api';
 
-
 const PrivateRoute = ({ children }) => {
-	const api = useApi();
-	const isLoggedIn = api.isLoggedIn();
-	const location = useLocation();
+  const api = useApi();
+  const isLoggedIn = api.isLoggedIn();
+  const location = useLocation();
+  const navigate = useNavigate();
 
-	// const handleauthrespn{
+  useEffect(() => {
+    if (!isLoggedIn) {
+      const destination = location.pathname + location.search;
+      navigate('/login', { state: { from: destination } });
+    }
+  }, [isLoggedIn, location, navigate]);
 
-	// 	//take url req to bck handleAuthorizationResponse
-	// 	//if 200 go to root /
-	// }
+  if (!isLoggedIn) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
 
-	if (!isLoggedIn) {
-		return <Navigate to="/login" state={{ from: location }} replace />;
-	}
-
-	return children;
+  return children;
 };
 
 export default PrivateRoute;

--- a/src/components/useStorage.ts
+++ b/src/components/useStorage.ts
@@ -15,7 +15,7 @@ function makeUseStorage<T>(
 	}
 
 	return (name: string, initialValue: T) => {
-		const [currentValue, setValue] = useState(
+		const getCurrentValue = useCallback(
 			() => {
 				const storedValueStr = storage.getItem(name);
 				try {
@@ -27,14 +27,17 @@ function makeUseStorage<T>(
 					storage.removeItem(name);
 				}
 				return initialValue;
-			}
+			},
+			[],
 		);
+
+		const [currentValue, setValue] = useState(getCurrentValue);
 
 		const updateValue = useCallback(
 			(action: SetStateAction<T>): void => {
 				const newValue =
 					action instanceof Function
-					? action(currentValue)
+					? action(getCurrentValue())
 					: action;
 				try {
 					storage.setItem(name, jsonStringifyTaggedBinary(newValue));
@@ -51,7 +54,7 @@ function makeUseStorage<T>(
 					})
 				);
 			},
-			[currentValue, name],
+			[],
 		);
 
 		useEffect(
@@ -77,7 +80,7 @@ function makeUseStorage<T>(
 					window.removeEventListener('storage', listener);
 				};
 			},
-			[name]
+			[]
 		);
 
 		useEffect(

--- a/src/pages/AccountSettings/AccountSettings.tsx
+++ b/src/pages/AccountSettings/AccountSettings.tsx
@@ -514,7 +514,11 @@ const Home = () => {
 				console.error('Failed to fetch data', error);
 			}
 		},
-		[api, setUserData],
+		[
+			api,
+			keystore, // To react if credentials are modified in a different tab
+			setUserData,
+		],
 	);
 
 	useEffect(

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { FaEye, FaExclamationTriangle, FaEyeSlash, FaInfoCircle, FaLock, FaUser } from 'react-icons/fa';
 import { GoPasskeyFill, GoTrash } from 'react-icons/go';
 import { AiOutlineUnlock } from 'react-icons/ai';
@@ -111,6 +111,9 @@ const WebauthnSignupLogin = ({
 	const [resolvePrfRetryPrompt, setResolvePrfRetryPrompt] = useState(null);
 	const [prfRetryAccepted, setPrfRetryAccepted] = useState(false);
 	const navigate = useNavigate();
+	const location = useLocation();
+	const from = location.state?.from || '/';
+
 	const { t } = useTranslation();
 	const keystore = useLocalStorageKeystore();
 	const [retrySignupFrom, setRetrySignupFrom] = useState(null);
@@ -139,7 +142,7 @@ const WebauthnSignupLogin = ({
 		async (cachedUser) => {
 			const result = await api.loginWebauthn(keystore, promptForPrfRetry, cachedUser);
 			if (result.ok) {
-				navigate('/');
+				navigate(from, { replace: true });
 
 			} else {
 				// Using a switch here so the t() argument can be a literal, to ease searching
@@ -179,7 +182,7 @@ const WebauthnSignupLogin = ({
 				retrySignupFrom,
 			);
 			if (result.ok) {
-				navigate('/');
+				navigate(from, { replace: true });
 
 			} else {
 				// Using a switch here so the t() argument can be a literal, to ease searching

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -345,7 +345,7 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 				}));
 			}
 		},
-		[privateDataCache, userHandleB64u],
+		[privateDataCache, userHandleB64u, setCachedUsers],
 	);
 
 	return useMemo(
@@ -751,6 +751,7 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 			setInnerSessionKey,
 			setPrivateDataCache,
 			setPrivateDataJwe,
+			setUserHandleB64u,
 			setWebauthnRpId,
 			webauthnRpId,
 		],

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -313,11 +313,19 @@ export interface LocalStorageKeystore {
 
 export function useLocalStorageKeystore(): LocalStorageKeystore {
 	const [cachedUsers, setCachedUsers] = useLocalStorage<CachedUser[]>("cachedUsers", []);
-	const [userHandleB64u, setUserHandleB64u] = useLocalStorage<string | null>("userHandle", null);
-	const [webauthnRpId, setWebauthnRpId] = useLocalStorage<string | null>("webauthnRpId", null);
 	const [privateDataCache, setPrivateDataCache] = useLocalStorage<EncryptedContainer | null>("privateData", null);
+
+	const [userHandleB64u, setUserHandleB64u] = useSessionStorage<string | null>("userHandle", null);
+	const [webauthnRpId, setWebauthnRpId] = useSessionStorage<string | null>("webauthnRpId", null);
 	const [sessionKey, setSessionKey] = useSessionStorage<BufferSource | null>("sessionKey", null);
 	const [privateDataJwe, setPrivateDataJwe] = useSessionStorage<string | null>("privateDataJwe", null);
+
+	useEffect(() => {
+		// Moved from local storage to session storage
+		window?.localStorage?.removeItem("userHandle");
+		window?.localStorage?.removeItem("webauthnRpId");
+	}, []);
+
 	const clearSessionStorage = useClearSessionStorage();
 
 	const idb = useIndexedDb("wallet-frontend", 2, useCallback((db, prevVersion, newVersion) => {
@@ -546,8 +554,6 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 				close: async (): Promise<void> => {
 					await idb.destroy();
 					setPrivateDataCache(null);
-					setWebauthnRpId(null);
-					setUserHandleB64u(null);
 					clearSessionStorage();
 				},
 

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -338,6 +338,15 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 		}
 	}, []));
 
+	const close = useCallback(
+		async (): Promise<void> => {
+			await idb.destroy();
+			setPrivateDataCache(null);
+			clearSessionStorage();
+		},
+		[idb, setPrivateDataCache, clearSessionStorage],
+	);
+
 	useEffect(
 		() => {
 			if (privateDataCache && userHandleB64u) {
@@ -354,9 +363,11 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 						return cu;
 					}
 				}));
+			} else if (!privateDataCache) {
+				close();
 			}
 		},
-		[privateDataCache, userHandleB64u, setCachedUsers],
+		[close, privateDataCache, userHandleB64u, setCachedUsers],
 	);
 
 	return useMemo(
@@ -551,11 +562,7 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 			};
 
 			return {
-				close: async (): Promise<void> => {
-					await idb.destroy();
-					setPrivateDataCache(null);
-					clearSessionStorage();
-				},
+				close,
 
 				initPassword: async (password: string): Promise<{ publicData: PublicData, privateData: EncryptedContainer }> => {
 					console.log("initPassword");
@@ -721,8 +728,7 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 		},
 		[
 			cachedUsers,
-			clearSessionStorage,
-			idb,
+			close,
 			privateDataCache,
 			privateDataJwe,
 			sessionKey,

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -6,7 +6,7 @@ import { SignVerifiablePresentationJWT } from "@wwwallet/ssi-sdk";
 import { util } from '@cef-ebsi/key-did-resolver';
 
 import { verifiablePresentationSchemaURL } from "../constants";
-import { useClearLocalStorage, useClearSessionStorage, useLocalStorage, useSessionStorage } from "../components/useStorage";
+import { useClearSessionStorage, useLocalStorage, useSessionStorage } from "../components/useStorage";
 import { jsonParseTaggedBinary, jsonStringifyTaggedBinary, toBase64Url } from "../util";
 import { useIndexedDb } from "../components/useIndexedDb";
 
@@ -318,7 +318,6 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 	const [privateDataCache, setPrivateDataCache] = useLocalStorage<EncryptedContainer | null>("privateData", null);
 	const [innerSessionKey, setInnerSessionKey] = useSessionStorage<BufferSource | null>("sessionKey", null);
 	const [privateDataJwe, setPrivateDataJwe] = useSessionStorage<string | null>("privateDataJwe", null);
-	const clearLocalStorage = useClearLocalStorage();
 	const clearSessionStorage = useClearSessionStorage();
 
 	const idb = useIndexedDb("wallet-frontend", 1, useCallback((db, prevVersion, newVersion) => {
@@ -743,7 +742,6 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 		},
 		[
 			cachedUsers,
-			clearLocalStorage,
 			clearSessionStorage,
 			idb,
 			innerSessionKey,


### PR DESCRIPTION
This is part 3 of 3 in an effort to fix wwWallet/wallet-ecosystem#31. Parts 1 and 2 are in #133 and #134.

Most notably, this deletes the `outerSessionKey` and just stores the `innerSessionKey` (now renamed to just `sessionKey`) in cleartext in session storage.

Since the outer session key is stored in IndexedDB under a constant name that is shared between all tabs, concurrent tabs overwrite the existing outer session key when the user re-authenticates in the new tab. This causes all attempts to access encrypted data to fail because the inner session key can no longer be unwrapped.

As noted in the [self-critique][1] of the encryption architecture, the outer session key doesn't really add much. Any malicious code with access to the session storage probably also has access to the IndexedDB, and thus also to the outer session key. We don't really gain anything by having the outer session key unextractable.

In addition to that, this also sets up some state transmission so that logging out in any tab logs out in every tab, logging in in any tab logs out of tabs logged in to a different account, and adding/deleting WebAuthn credentials in any tab causes the changes to also be visible in other tabs with `<AccountSettings>` open.

[1]: https://wwwallet.github.io/wallet-docs/docs/wallet/encryption-architecture/#unextractable-cryptokeys
