### PR TITLE
Clear individual session/local storage items instead of clearing all

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -86,7 +86,7 @@ function App() {
 				<HandlerNotification>
 					<Routes>
 						<Route path="/login" element={<Login />} />
-						<Route path="/account" element={<AccountSettings />} />
+						<Route path="/account" element={<PrivateRoute><AccountSettings /></PrivateRoute>} />
 						<Route path="/" element={<PrivateRoute><Home /></PrivateRoute>} />
 						<Route path="/credential/:id" element={<PrivateRoute><CredentialDetail /></PrivateRoute>} />
 						<Route path="/history" element={<PrivateRoute><History /></PrivateRoute>} />

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,7 +6,7 @@ import { jsonParseTaggedBinary, jsonStringifyTaggedBinary, toBase64Url } from '.
 import { CachedUser, LocalStorageKeystore, makePrfExtensionInputs } from '../services/LocalStorageKeystore';
 import { UserData, Verifier } from './types';
 import { useMemo } from 'react';
-import { useClearSessionStorage, useSessionStorage } from '../components/useStorage';
+import { useClearStorages, useSessionStorage } from '../components/useStorage';
 
 
 const walletBackendUrl = process.env.REACT_APP_WALLET_BACKEND_URL;
@@ -61,9 +61,9 @@ export interface BackendApi {
 }
 
 export function useApi(): BackendApi {
-	const clearSessionStorage = useClearSessionStorage();
-	const [appToken, setAppToken,] = useSessionStorage<string | null>("appToken", null);
-	const [sessionState, setSessionState,] = useSessionStorage<SessionState | null>("sessionState", null);
+	const [appToken, setAppToken, clearAppToken] = useSessionStorage<string | null>("appToken", null);
+	const [sessionState, setSessionState, clearSessionState] = useSessionStorage<SessionState | null>("sessionState", null);
+	const clearSessionStorage = useClearStorages(clearAppToken, clearSessionState);
 
 	return useMemo(
 		() => {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -62,8 +62,8 @@ export interface BackendApi {
 
 export function useApi(): BackendApi {
 	const clearSessionStorage = useClearSessionStorage();
-	const [appToken, setAppToken] = useSessionStorage<string | null>("appToken", null);
-	const [sessionState, setSessionState] = useSessionStorage<SessionState | null>("sessionState", null);
+	const [appToken, setAppToken,] = useSessionStorage<string | null>("appToken", null);
+	const [sessionState, setSessionState,] = useSessionStorage<SessionState | null>("sessionState", null);
 
 	return useMemo(
 		() => {

--- a/src/components/BrowserSupport.tsx
+++ b/src/components/BrowserSupport.tsx
@@ -27,7 +27,7 @@ const BrowserSupportedContext = createContext<ContextValue>({
 });
 
 export function Ctx({ children }: { children: ReactNode }) {
-	const [bypass, setBypass] = useSessionStorage('browser_warning_ack', false);
+	const [bypass, setBypass,] = useSessionStorage('browser_warning_ack', false);
 
 	const userAgent = new UAParser(window.navigator.userAgent).getResult();
 

--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -2,10 +2,12 @@ import React, { useEffect } from 'react';
 import { Navigate, useLocation, useNavigate } from 'react-router-dom';
 
 import { useApi } from '../api';
+import { useLocalStorageKeystore } from '../services/LocalStorageKeystore';
 
 const PrivateRoute = ({ children }) => {
   const api = useApi();
-  const isLoggedIn = api.isLoggedIn();
+  const keystore = useLocalStorageKeystore();
+  const isLoggedIn = api.isLoggedIn() && keystore.isOpen();
   const location = useLocation();
   const navigate = useNavigate();
 

--- a/src/components/useStorage.ts
+++ b/src/components/useStorage.ts
@@ -122,42 +122,8 @@ function makeUseStorage<T>(
 			[],
 		);
 
-		useEffect(
-			() => {
-				// Listen to synthetic events sent by the useClearLocalStorage and
-				// useClearSessionStorage hooks. Storage.clear() does not send "storage"
-				// events in the same Document.
-				const listener = (event: CustomEvent<ClearEvent>) => {
-					if (event.detail.storageArea === storage) {
-						setValue(initialValue);
-					}
-				};
-				window.addEventListener('useStorage.clear', listener);
-				return () => {
-					window.removeEventListener('useStorage.clear', listener);
-				};
-			},
-			[],
-		);
-
 		return [currentValue, updateValue, clearValue];
 	};
-}
-
-function makeUseClearStorage(storage: Storage, description: string): () => ClearHandle {
-	if (!storage) {
-		throw new Error(`${description} is not available.`);
-	}
-
-	return () => useCallback(
-		() => {
-			storage.clear();
-			window.dispatchEvent(new CustomEvent<ClearEvent>('useStorage.clear', {
-				detail: { storageArea: storage },
-			}));
-		},
-		[],
-	);
 }
 
 export const useLocalStorage: <T>(name: string, initialValue: T) => UseStorageHandle<T> =
@@ -165,9 +131,6 @@ export const useLocalStorage: <T>(name: string, initialValue: T) => UseStorageHa
 
 export const useSessionStorage: <T>(name: string, initialValue: T) => UseStorageHandle<T> =
 	makeUseStorage(window.sessionStorage, "Session storage");
-
-export const useClearLocalStorage: () => ClearHandle = makeUseClearStorage(window.localStorage, "Local storage");
-export const useClearSessionStorage: () => ClearHandle = makeUseClearStorage(window.sessionStorage, "Session storage");
 
 export const useClearStorages: (...clearHandles: ClearHandle[]) => ClearHandle =
 	(...clearHandles: ClearHandle[]) => useCallback(

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -6,7 +6,7 @@ import { SignVerifiablePresentationJWT } from "@wwwallet/ssi-sdk";
 import { util } from '@cef-ebsi/key-did-resolver';
 
 import { verifiablePresentationSchemaURL } from "../constants";
-import { useClearSessionStorage, useLocalStorage, useSessionStorage } from "../components/useStorage";
+import { useClearStorages, useLocalStorage, useSessionStorage } from "../components/useStorage";
 import { jsonParseTaggedBinary, jsonStringifyTaggedBinary, toBase64Url } from "../util";
 import { useIndexedDb } from "../components/useIndexedDb";
 
@@ -313,21 +313,20 @@ export interface LocalStorageKeystore {
 
 export function useLocalStorageKeystore(): LocalStorageKeystore {
 	const [cachedUsers, setCachedUsers,] = useLocalStorage<CachedUser[]>("cachedUsers", []);
-	const [privateDataCache, setPrivateDataCache,] = useLocalStorage<EncryptedContainer | null>("privateData", null);
-	const [globalUserHandleB64u, setGlobalUserHandleB64u,] = useLocalStorage<string | null>("userHandle", null);
+	const [privateDataCache, setPrivateDataCache, clearPrivateDataCache] = useLocalStorage<EncryptedContainer | null>("privateData", null);
+	const [globalUserHandleB64u, setGlobalUserHandleB64u, clearGlobalUserHandleB64u] = useLocalStorage<string | null>("userHandle", null);
 
-	const [userHandleB64u, setUserHandleB64u,] = useSessionStorage<string | null>("userHandle", null);
-	const [webauthnRpId, setWebauthnRpId,] = useSessionStorage<string | null>("webauthnRpId", null);
-	const [sessionKey, setSessionKey,] = useSessionStorage<BufferSource | null>("sessionKey", null);
-	const [privateDataJwe, setPrivateDataJwe,] = useSessionStorage<string | null>("privateDataJwe", null);
+	const [userHandleB64u, setUserHandleB64u, clearUserHandleB64u] = useSessionStorage<string | null>("userHandle", null);
+	const [webauthnRpId, setWebauthnRpId, clearWebauthnRpId] = useSessionStorage<string | null>("webauthnRpId", null);
+	const [sessionKey, setSessionKey, clearSessionKey] = useSessionStorage<BufferSource | null>("sessionKey", null);
+	const [privateDataJwe, setPrivateDataJwe, clearPrivateDataJwe] = useSessionStorage<string | null>("privateDataJwe", null);
+	const clearSessionStorage = useClearStorages(clearUserHandleB64u, clearWebauthnRpId, clearSessionKey, clearPrivateDataJwe);
 
 	useEffect(() => {
 		// Moved from local storage to session storage
 		window?.localStorage?.removeItem("userHandle");
 		window?.localStorage?.removeItem("webauthnRpId");
 	}, []);
-
-	const clearSessionStorage = useClearSessionStorage();
 
 	const idb = useIndexedDb("wallet-frontend", 2, useCallback((db, prevVersion, newVersion) => {
 		if (prevVersion < 1) {
@@ -349,11 +348,11 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 	const close = useCallback(
 		async (): Promise<void> => {
 			await idb.destroy();
-			setPrivateDataCache(null);
-			setGlobalUserHandleB64u(null);
+			clearPrivateDataCache();
+			clearGlobalUserHandleB64u();
 			closeTabLocal();
 		},
-		[closeTabLocal, idb, setGlobalUserHandleB64u, setPrivateDataCache],
+		[closeTabLocal, idb, clearGlobalUserHandleB64u, clearPrivateDataCache],
 	);
 
 	useEffect(

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -312,14 +312,14 @@ export interface LocalStorageKeystore {
 }
 
 export function useLocalStorageKeystore(): LocalStorageKeystore {
-	const [cachedUsers, setCachedUsers] = useLocalStorage<CachedUser[]>("cachedUsers", []);
-	const [privateDataCache, setPrivateDataCache] = useLocalStorage<EncryptedContainer | null>("privateData", null);
-	const [globalUserHandleB64u, setGlobalUserHandleB64u] = useLocalStorage<string | null>("userHandle", null);
+	const [cachedUsers, setCachedUsers,] = useLocalStorage<CachedUser[]>("cachedUsers", []);
+	const [privateDataCache, setPrivateDataCache,] = useLocalStorage<EncryptedContainer | null>("privateData", null);
+	const [globalUserHandleB64u, setGlobalUserHandleB64u,] = useLocalStorage<string | null>("userHandle", null);
 
-	const [userHandleB64u, setUserHandleB64u] = useSessionStorage<string | null>("userHandle", null);
-	const [webauthnRpId, setWebauthnRpId] = useSessionStorage<string | null>("webauthnRpId", null);
-	const [sessionKey, setSessionKey] = useSessionStorage<BufferSource | null>("sessionKey", null);
-	const [privateDataJwe, setPrivateDataJwe] = useSessionStorage<string | null>("privateDataJwe", null);
+	const [userHandleB64u, setUserHandleB64u,] = useSessionStorage<string | null>("userHandle", null);
+	const [webauthnRpId, setWebauthnRpId,] = useSessionStorage<string | null>("webauthnRpId", null);
+	const [sessionKey, setSessionKey,] = useSessionStorage<BufferSource | null>("sessionKey", null);
+	const [privateDataJwe, setPrivateDataJwe,] = useSessionStorage<string | null>("privateDataJwe", null);
 
 	useEffect(() => {
 		// Moved from local storage to session storage

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -276,6 +276,7 @@ async function getPrfOutput(
 
 export type CommitCallback = () => Promise<void>;
 export interface LocalStorageKeystore {
+	isOpen(): boolean,
 	close(): Promise<void>,
 
 	initPassword(password: string): Promise<{ publicData: PublicData, privateData: EncryptedContainer }>,
@@ -582,6 +583,9 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 			};
 
 			return {
+				isOpen: () => {
+					return privateDataJwe !== null && sessionKey !== null;
+				},
 				close,
 
 				initPassword: async (password: string): Promise<{ publicData: PublicData, privateData: EncryptedContainer }> => {


### PR DESCRIPTION
The `useClearSessionStorage` and `useClearLocalStorage` hooks weren't a very good idea, because unrelated components might use these storages and inadvertently clear each others' storage. For example this made the `<BrowserSupport.WarningPortal>` component not work correctly, because the logout event handler in `LocalStorageKeystore` would clear session storage immediately after `<BrowserSupport.WarningPortal>` set its override flag.

This refactors the `useState` hooks to instead also return a clear function, which can be called with no arguments to reset the state of the hook and remove the storage entry. There's also a `useClearStorages()` hook which composes several such clear functions into one, so that all of a component's state can be cleared easily without accidentally clearing other components' state as well.

One potential issue with this is that the `appToken` and `sessionState` storage items are no longer reset when the user logs out in a different tab, because `LocalStorageKeystore` no longer resets them.