### PR TITLE
Improve translation keys in PR #161

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -137,14 +137,14 @@
 			"unnamedPasskey": "Unnamed passkey"
 		},
 		"manageOtherPasskey": {
-			"authOneMore": "To finish setting up, please authenticate with it once more.",
+			"authOnceMore": "To finish setting up, please authenticate with it once more.",
 			"giveNickname": "Give this credential a nickname:",
-			"manageSuccess": "Success!",
+			"messageSuccess": "Success!",
 			"messageDone": "Almost done!",
 			"messageInteract": "Please interact with your authenticator...",
 			"messageInteractNewPasskey": "Please authenticate with the new passkey...",
 			"passkeyCreated": "Your passkey has been created.",
-			"title": "Manage other Passkey"
+			"title": "Manage other Passkeys"
 		}
 	},
 	"qrCodeScanner": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -121,6 +121,8 @@
 		"lockPasskeyManagement": "Lock passkey management",
 		"passkeyItem": {
 			"canEncrypt": "Can Encrypt",
+			"canEncryptNo": "No",
+			"canEncryptYes": "Yes",
 			"cancelChangesAriaLabel": "Cancel changes to passkey {{passkeyLabel}}",
 			"created": "Created",
 			"deleteAriaLabel": "Delete passkey {{passkeyLabel}}",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -26,13 +26,10 @@
 		}
 	},
 	"loginSignup": {
-		"addPasskey": "Add passkey",
 		"alreadyHaveAccountQuestion": "Already have an account? ",
-		"cancelPasskeyChangesAriaLabel": "Cancel changes to passkey {{passkeyLabel}}",
 		"capitalLetter": "At least one capital letter",
 		"choosePasskeyUsername": "What should we call you?",
 		"confirmPasswordLabel": "Confirm Password",
-		"deletePasskeyAriaLabel": "Delete passkey {{passkeyLabel}}",
 		"enterPasskeyName": "Choose a name for yourself",
 		"enterPassword": "Enter your password",
 		"enterUsername": "Enter your username",
@@ -42,7 +39,6 @@
 		"infoAboutTimeAndLocation": "Make sure that your date/time settings and timezone are correctly set and accurate.",
 		"learnMoreAboutPrfCompatibility": "Learn about <docLinkPrf>PRF Compatibility regarding browser/OS support.</docLinkPrf>",
 		"learnMoreAboutPrfCompatibilityLaunchpadAndScenarios": "Learn about <docLinkPrf>PRF Compatibility regarding browser/OS support</docLinkPrf> and discover wwWallet via our <docLinkLaunchpad>Launchpad</docLinkLaunchpad> and <docLinkScenarios>Sample Scenarios</docLinkScenarios> ",
-		"lockPasskeyManagement": "Lock passkey management",
 		"login": "Login",
 		"loginAsUser": "Log in as {{name}}",
 		"loginLocalKeystoreFailed": "Failed to initialize wallet key store, please try again.",
@@ -55,8 +51,6 @@
 		"passkeyInvalid": "Unknown passkey, possibly deleted by user.",
 		"passkeyLoginFailedServerError": "Failed to initiate passkey login, please try again later.",
 		"passkeyLoginFailedTryAgain": "Passkey login failed, please try again.",
-		"passkeyNicknameInput": "New nickname",
-		"passkeyNicknameInputAriaLabel": "Enter new nickname for passkey {{passkeyLabel}}",
 		"passkeySignupFailedServerError": "Failed to initiate passkey creation, please try again later.",
 		"passkeySignupFailedTryAgain": "Passkey creation failed, please try again.",
 		"passkeySignupFinishFailedServerError": "Failed to finalize passkey creation, please try again later.",
@@ -65,10 +59,6 @@
 		"passwordLabel": "Password",
 		"passwordLength": "Minimum length: 8 characters",
 		"passwordsNotMatchError": "Passwords do not match",
-		"renamePasskey": "Rename",
-		"renamePasskeyAriaLabel": "Rename passkey {{passkeyLabel}}",
-		"save": "Save",
-		"savePasskeyChangesAriaLabel": "Save changes to passkey {{passkeyLabel}}",
 		"signUp": "Sign Up",
 		"signUpPasskey": "Sign up with passkey",
 		"signUpSubmit": "Sign Up",
@@ -77,7 +67,6 @@
 		"strength": "Strength",
 		"submitting": "Submitting...",
 		"tryAgain": "Try again",
-		"unlockPasskeyManagement": "Unlock passkey management",
 		"usernameExistsError": "Failed to create user account, username already exists",
 		"usernameLabel": "Username",
 		"weakPasswordError": "Weak password",
@@ -127,7 +116,11 @@
 		"searchPlaceholder": "Search verifiers..."
 	},
 	"pageSettings": {
+		"addPasskey": "Add passkey",
+		"cancelPasskeyChangesAriaLabel": "Cancel changes to passkey {{passkeyLabel}}",
+		"deletePasskeyAriaLabel": "Delete passkey {{passkeyLabel}}",
 		"description": "View account information and manage passkeys",
+		"lockPasskeyManagement": "Lock passkey management",
 		"loggedPasskey": {
 			"canEncrypt": "Can Encrypt",
 			"created": "Created",
@@ -145,7 +138,13 @@
 			"messageInteractNewPasskey": "Please authenticate with the new passkey...",
 			"passkeyCreated": "Your passkey has been created.",
 			"title": "Manage other Passkeys"
-		}
+		},
+		"passkeyNicknameInput": "New nickname",
+		"passkeyNicknameInputAriaLabel": "Enter new nickname for passkey {{passkeyLabel}}",
+		"renamePasskey": "Rename",
+		"renamePasskeyAriaLabel": "Rename passkey {{passkeyLabel}}",
+		"savePasskeyChangesAriaLabel": "Save changes to passkey {{passkeyLabel}}",
+		"unlockPasskeyManagement": "Unlock passkey management"
 	},
 	"qrCodeScanner": {
 		"description": "Target the QR Code, and you will redirect to proceed with the process",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -117,33 +117,35 @@
 	},
 	"pageSettings": {
 		"addPasskey": "Add passkey",
-		"cancelPasskeyChangesAriaLabel": "Cancel changes to passkey {{passkeyLabel}}",
-		"deletePasskeyAriaLabel": "Delete passkey {{passkeyLabel}}",
 		"description": "View account information and manage passkeys",
 		"lockPasskeyManagement": "Lock passkey management",
-		"loggedPasskey": {
+		"passkeyItem": {
 			"canEncrypt": "Can Encrypt",
+			"cancelChangesAriaLabel": "Cancel changes to passkey {{passkeyLabel}}",
 			"created": "Created",
+			"deleteAriaLabel": "Delete passkey {{passkeyLabel}}",
 			"lastUsed": "Last Used",
 			"nickname": "Nickname",
-			"title": "Logged in Passkey",
-			"unnamedPasskey": "Unnamed passkey"
+			"nicknameInput": "New nickname",
+			"nicknameInputAriaLabel": "Enter new nickname for passkey {{passkeyLabel}}",
+			"rename": "Rename",
+			"renameAriaLabel": "Rename passkey {{passkeyLabel}}",
+			"saveChangesAriaLabel": "Save changes to passkey {{passkeyLabel}}",
+			"unnamed": "Unnamed passkey"
 		},
-		"manageOtherPasskey": {
+		"registerPasskey": {
 			"authOnceMore": "To finish setting up, please authenticate with it once more.",
 			"giveNickname": "Give this credential a nickname:",
 			"messageSuccess": "Success!",
 			"messageDone": "Almost done!",
 			"messageInteract": "Please interact with your authenticator...",
 			"messageInteractNewPasskey": "Please authenticate with the new passkey...",
-			"passkeyCreated": "Your passkey has been created.",
-			"title": "Manage other Passkeys"
+			"passkeyCreated": "Your passkey has been created."
 		},
-		"passkeyNicknameInput": "New nickname",
-		"passkeyNicknameInputAriaLabel": "Enter new nickname for passkey {{passkeyLabel}}",
-		"renamePasskey": "Rename",
-		"renamePasskeyAriaLabel": "Rename passkey {{passkeyLabel}}",
-		"savePasskeyChangesAriaLabel": "Save changes to passkey {{passkeyLabel}}",
+		"title": {
+			"loggedInPasskey": "Logged in Passkey",
+			"manageOtherPasskeys": "Manage other Passkeys"
+		},
 		"unlockPasskeyManagement": "Unlock passkey management"
 	},
 	"qrCodeScanner": {

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -194,8 +194,8 @@ const WebauthnRegistation = ({
 					{pendingCredential
 						? (
 							<>
-								<h3 className="text-2xl mt-4 mb-2 font-bold text-custom-blue">{t('pageSettings.manageOtherPasskey.messageSuccess')}</h3>
-								<p className="mb-2">{t('pageSettings.manageOtherPasskey.giveNickname')}</p>
+								<h3 className="text-2xl mt-4 mb-2 font-bold text-custom-blue">{t('pageSettings.registerPasskey.messageSuccess')}</h3>
+								<p className="mb-2">{t('pageSettings.registerPasskey.giveNickname')}</p>
 								<input
 									type="text"
 									className="shadow appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
@@ -210,7 +210,7 @@ const WebauthnRegistation = ({
 						)
 						: (
 							<>
-								<p>{t('pageSettings.manageOtherPasskey.messageInteract')}</p>
+								<p>{t('pageSettings.registerPasskey.messageInteract')}</p>
 							</>
 						)
 					}
@@ -243,9 +243,9 @@ const WebauthnRegistation = ({
 				open={needPrfRetry && !prfRetryAccepted}
 				onCancel={() => resolvePrfRetryPrompt(false)}
 			>
-				<h3 className="text-2xl mt-4 mb-2 font-bold text-custom-blue">{t('pageSettings.manageOtherPasskey.messageDone')}</h3>
-				<p>{t('pageSettings.manageOtherPasskey.passkeyCreated')}</p>
-				<p>{t('pageSettings.manageOtherPasskey.authOnceMore')}</p>
+				<h3 className="text-2xl mt-4 mb-2 font-bold text-custom-blue">{t('pageSettings.registerPasskey.messageDone')}</h3>
+				<p>{t('pageSettings.registerPasskey.passkeyCreated')}</p>
+				<p>{t('pageSettings.registerPasskey.authOnceMore')}</p>
 
 				<button
 					type="button"
@@ -268,7 +268,7 @@ const WebauthnRegistation = ({
 				open={prfRetryAccepted}
 				onCancel={onCancel}
 			>
-				<p>{t('pageSettings.manageOtherPasskey.messageInteractNewPasskey')}</p>
+				<p>{t('pageSettings.registerPasskey.messageInteractNewPasskey')}</p>
 
 				<button
 					type="button"
@@ -371,7 +371,7 @@ const WebauthnCredentialItem = ({
 	const [nickname, setNickname] = useState(credential.nickname || '');
 	const [editing, setEditing] = useState(false);
 	const { t } = useTranslation();
-	const currentLabel = credential.nickname || `${t('pageSettings.loggedPasskey.unnamedPasskey')} ${credential.id.substring(0, 8)}`;
+	const currentLabel = credential.nickname || `${t('pageSettings.passkeyItem.unnamed')} ${credential.id.substring(0, 8)}`;
 	const [submitting, setSubmitting] = useState(false);
 
 	const onKeyUp = useCallback(
@@ -408,15 +408,15 @@ const WebauthnCredentialItem = ({
 						<>
 							<div className="flex items-center">
 								<p className="font-semibold">
-									{t('pageSettings.loggedPasskey.nickname')}:&nbsp;
+									{t('pageSettings.passkeyItem.nickname')}:&nbsp;
 								</p>
 								<input
 									className="shadow appearance-none border rounded-md w-36 p-2 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
 									type="text"
-									placeholder={t('pageSettings.passkeyNicknameInput')}
+									placeholder={t('pageSettings.passkeyItem.nicknameInput')}
 									value={nickname}
 									onChange={(event) => setNickname(event.target.value)}
-									aria-label={t('pageSettings.passkeyNicknameInputAriaLabel', { passkeyLabel: currentLabel })}
+									aria-label={t('pageSettings.passkeyItem.nicknameInputAriaLabel', { passkeyLabel: currentLabel })}
 									onKeyUp={onKeyUp}
 									disabled={submitting}
 								/>
@@ -427,7 +427,7 @@ const WebauthnCredentialItem = ({
 						<div className="flex items-center">
 							<p>
 								<span className="font-semibold">
-									{t('pageSettings.loggedPasskey.nickname')}:&nbsp;
+									{t('pageSettings.passkeyItem.nickname')}:&nbsp;
 								</span>
 								<span className="font-bold text-custom-blue">
 									{currentLabel}
@@ -438,18 +438,18 @@ const WebauthnCredentialItem = ({
 				}
 				<p>
 					<span className="font-semibold">
-						{t('pageSettings.loggedPasskey.created')}:&nbsp;
+						{t('pageSettings.passkeyItem.created')}:&nbsp;
 					</span>
 					{formatDate(credential.createTime)}
 				</p>
 				<p>
 					<span className="font-semibold">
-						{t('pageSettings.loggedPasskey.lastUsed')}:&nbsp;
+						{t('pageSettings.passkeyItem.lastUsed')}:&nbsp;
 					</span>
 					{formatDate(credential.lastUseTime)}</p>
 				<p>
 					<span className="font-semibold">
-						{t('pageSettings.loggedPasskey.canEncrypt')}:&nbsp;
+						{t('pageSettings.passkeyItem.canEncrypt')}:&nbsp;
 					</span>
 					{credential.prfCapable ? "Yes" : "No"}</p>
 			</div>
@@ -463,7 +463,7 @@ const WebauthnCredentialItem = ({
 								type="button"
 								disabled={submitting}
 								onClick={() => setEditing(false)}
-								aria-label={t('pageSettings.cancelPasskeyChangesAriaLabel', { passkeyLabel: currentLabel })}
+								aria-label={t('pageSettings.passkeyItem.cancelChangesAriaLabel', { passkeyLabel: currentLabel })}
 							>
 								{t('common.cancel')}
 							</button>
@@ -471,7 +471,7 @@ const WebauthnCredentialItem = ({
 								className="text-white bg-blue-600 hover:bg-blue-700 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-4 py-2 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
 								type="submit"
 								disabled={submitting}
-								aria-label={t('pageSettings.savePasskeyChangesAriaLabel', { passkeyLabel: currentLabel })}
+								aria-label={t('pageSettings.passkeyItem.saveChangesAriaLabel', { passkeyLabel: currentLabel })}
 							>
 								{t('common.save')}
 							</button>
@@ -483,9 +483,9 @@ const WebauthnCredentialItem = ({
 								className="flex flex-row flex-nowrap items-center text-white bg-blue-600 hover:bg-blue-700 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-4 py-2 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
 								type="button"
 								onClick={() => setEditing(true)}
-								aria-label={t('pageSettings.renamePasskeyAriaLabel', { passkeyLabel: currentLabel })}
+								aria-label={t('pageSettings.passkeyItem.renameAriaLabel', { passkeyLabel: currentLabel })}
 							>
-								<FaEdit size={16} className="mr-2" /> {t('pageSettings.renamePasskey')}
+								<FaEdit size={16} className="mr-2" /> {t('pageSettings.passkeyItem.rename')}
 							</button>
 						</>
 					)
@@ -496,7 +496,7 @@ const WebauthnCredentialItem = ({
 						className="text-white bg-red-700 text-sm hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-red-700 dark:hover:bg-red-800 dark:focus:ring-red-800 ml-2 px-4 py-2"
 						type="button"
 						onClick={onDelete}
-						aria-label={t('pageSettings.deletePasskeyAriaLabel', { passkeyLabel: currentLabel })}
+						aria-label={t('pageSettings.passkeyItem.deleteAriaLabel', { passkeyLabel: currentLabel })}
 					>
 						<FaTrash size={16} />
 					</button>
@@ -582,7 +582,7 @@ const Settings = () => {
 						<p className="italic pd-2 text-gray-700">{t('pageSettings.description')}</p>
 
 						<div className="mt-2 mb-2 py-2">
-							<h1 className="text-lg mt-2 mb-2 font-bold text-custom-blue">{t('pageSettings.loggedPasskey.title')}</h1>
+							<h1 className="text-lg mt-2 mb-2 font-bold text-custom-blue">{t('pageSettings.title.loggedInPasskey')}</h1>
 							<hr className="mb-2 border-t border-gray-300" />
 							{loggedInPasskey && (
 								<WebauthnCredentialItem
@@ -594,7 +594,7 @@ const Settings = () => {
 						</div>
 						<div className="mt-2 mb-2 py-2">
 							<div className="flex justify-between items-center">
-								<h1 className="text-lg mt-2 mb-2 font-bold text-custom-blue">{t('pageSettings.manageOtherPasskey.title')}</h1>
+								<h1 className="text-lg mt-2 mb-2 font-bold text-custom-blue">{t('pageSettings.title.manageOtherPasskeys')}</h1>
 								<div className='flex'>
 									<WebauthnUnlock
 										unlocked={unlocked}

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -180,7 +180,7 @@ const WebauthnRegistation = ({
 					) : (
 						<>
 							<BsPlusCircle size={20} className="text-white mr-2 sm:inline" />
-							{t('loginSignup.addPasskey')}
+							{t('pageSettings.addPasskey')}
 						</>
 					)}
 				</div>
@@ -340,7 +340,7 @@ const WebauthnUnlock = ({
 				{unlocked
 					? <>
 						<BsUnlock size={20} className="text-white mr-2 sm:inline" />
-						{t('loginSignup.lockPasskeyManagement')}
+						{t('pageSettings.lockPasskeyManagement')}
 					</>
 					: <>
 						{(window.innerWidth < 768) ? (
@@ -348,7 +348,7 @@ const WebauthnUnlock = ({
 						) : (
 							<>
 								<BsLock size={20} className="text-white mr-2 sm:inline" />
-								{t('loginSignup.unlockPasskeyManagement')}
+								{t('pageSettings.unlockPasskeyManagement')}
 							</>
 						)}
 
@@ -413,10 +413,10 @@ const WebauthnCredentialItem = ({
 								<input
 									className="shadow appearance-none border rounded-md w-36 p-2 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
 									type="text"
-									placeholder={t('loginSignup.passkeyNicknameInput')}
+									placeholder={t('pageSettings.passkeyNicknameInput')}
 									value={nickname}
 									onChange={(event) => setNickname(event.target.value)}
-									aria-label={t('loginSignup.passkeyNicknameInputAriaLabel', { passkeyLabel: currentLabel })}
+									aria-label={t('pageSettings.passkeyNicknameInputAriaLabel', { passkeyLabel: currentLabel })}
 									onKeyUp={onKeyUp}
 									disabled={submitting}
 								/>
@@ -463,7 +463,7 @@ const WebauthnCredentialItem = ({
 								type="button"
 								disabled={submitting}
 								onClick={() => setEditing(false)}
-								aria-label={t('loginSignup.cancelPasskeyChangesAriaLabel', { passkeyLabel: currentLabel })}
+								aria-label={t('pageSettings.cancelPasskeyChangesAriaLabel', { passkeyLabel: currentLabel })}
 							>
 								{t('common.cancel')}
 							</button>
@@ -471,9 +471,9 @@ const WebauthnCredentialItem = ({
 								className="text-white bg-blue-600 hover:bg-blue-700 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-4 py-2 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
 								type="submit"
 								disabled={submitting}
-								aria-label={t('loginSignup.savePasskeyChangesAriaLabel', { passkeyLabel: currentLabel })}
+								aria-label={t('pageSettings.savePasskeyChangesAriaLabel', { passkeyLabel: currentLabel })}
 							>
-								{t('loginSignup.save')}
+								{t('common.save')}
 							</button>
 						</>
 					)
@@ -483,9 +483,9 @@ const WebauthnCredentialItem = ({
 								className="flex flex-row flex-nowrap items-center text-white bg-blue-600 hover:bg-blue-700 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-4 py-2 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
 								type="button"
 								onClick={() => setEditing(true)}
-								aria-label={t('loginSignup.renamePasskeyAriaLabel', { passkeyLabel: currentLabel })}
+								aria-label={t('pageSettings.renamePasskeyAriaLabel', { passkeyLabel: currentLabel })}
 							>
-								<FaEdit size={16} className="mr-2" /> {t('loginSignup.renamePasskey')}
+								<FaEdit size={16} className="mr-2" /> {t('pageSettings.renamePasskey')}
 							</button>
 						</>
 					)
@@ -496,7 +496,7 @@ const WebauthnCredentialItem = ({
 						className="text-white bg-red-700 text-sm hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-red-700 dark:hover:bg-red-800 dark:focus:ring-red-800 ml-2 px-4 py-2"
 						type="button"
 						onClick={onDelete}
-						aria-label={t('loginSignup.deletePasskeyAriaLabel', { passkeyLabel: currentLabel })}
+						aria-label={t('pageSettings.deletePasskeyAriaLabel', { passkeyLabel: currentLabel })}
 					>
 						<FaTrash size={16} />
 					</button>

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -451,7 +451,7 @@ const WebauthnCredentialItem = ({
 					<span className="font-semibold">
 						{t('pageSettings.passkeyItem.canEncrypt')}:&nbsp;
 					</span>
-					{credential.prfCapable ? "Yes" : "No"}</p>
+					{credential.prfCapable ? t('pageSettings.passkeyItem.canEncryptYes') : t('pageSettings.passkeyItem.canEncryptNo')}</p>
 			</div>
 
 			<div className="items-start	 flex inline-flex">

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -210,7 +210,7 @@ const WebauthnRegistation = ({
 						)
 						: (
 							<>
-								<p>{t('pageSettings.manageOtherPasskey.messageiInteract')}</p>
+								<p>{t('pageSettings.manageOtherPasskey.messageInteract')}</p>
 							</>
 						)
 					}
@@ -245,7 +245,7 @@ const WebauthnRegistation = ({
 			>
 				<h3 className="text-2xl mt-4 mb-2 font-bold text-custom-blue">{t('pageSettings.manageOtherPasskey.messageDone')}</h3>
 				<p>{t('pageSettings.manageOtherPasskey.passkeyCreated')}</p>
-				<p>{t('pageSettings.manageOtherPasskey.authOneMore')}</p>
+				<p>{t('pageSettings.manageOtherPasskey.authOnceMore')}</p>
 
 				<button
 					type="button"
@@ -268,7 +268,7 @@ const WebauthnRegistation = ({
 				open={prfRetryAccepted}
 				onCancel={onCancel}
 			>
-				<p>{t('pageSettings.manageOtherPasskey.messageiInteractNewPasskey')}</p>
+				<p>{t('pageSettings.manageOtherPasskey.messageInteractNewPasskey')}</p>
 
 				<button
 					type="button"


### PR DESCRIPTION
(This PR would merge into PR #161, not into master)

A couple of fixes and (in my opinion) improvements to PR #161:

- The first two commits (https://github.com/wwWallet/wallet-frontend/compare/feat/settings-page...af7350cd01552a79e95fb611d8f7954a51cb7aa0) fix a few typos and move some other translation keys into the new section.
- Commit https://github.com/wwWallet/wallet-frontend/commit/761a76abf1756ccc0c7dfb6b1c1b4154abcaaeec restructures the translation keys to (in my opinion) better represent how they are used.
- Commit https://github.com/wwWallet/wallet-frontend/commit/a86460806873993695836db1a33475c2a5531d8f just extracts a few more translation strings.