### PR TITLE
Show byte length counter and disable submit button when max length exceeded

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -65,7 +65,7 @@
 		"signUpSubmit": "Sign Up",
 		"signupPasskey": "Sign up with passkey",
 		"specialCharacter": "At least one special character",
-		"reachedLengthLimit": "You have reached the Name length limit",
+		"reachedLengthLimit": "Length limit exceeded",
 		"strength": "Strength",
 		"submitting": "Submitting...",
 		"tryAgain": "Try again",

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -279,7 +279,9 @@ const WebauthnSignupLogin = ({
 	};
 
 	const nameByteLength = calculateByteSize(name);
-	const nameByteLimitReached = nameByteLength > 64;
+	const nameByteLimit = 64;
+	const nameByteLimitReached = nameByteLength > nameByteLimit;
+	const nameByteLimitApproaching = nameByteLength >= nameByteLimit / 2;
 
 	return (
 		<form onSubmit={onSubmit}>
@@ -380,7 +382,10 @@ const WebauthnSignupLogin = ({
 										>
 											{t('loginSignup.reachedLengthLimit')}
 										</div>
-										<div className="text-right">
+										<div
+											className={`text-right ${nameByteLimitApproaching ? 'opacity-100' : 'opacity-0 select-none'} transition-opacity`}
+											aria-hidden={!nameByteLimitApproaching}
+										>
 											{nameByteLength} / 64
 										</div>
 									</div>

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -373,11 +373,14 @@ const WebauthnSignupLogin = ({
 										value={name}
 										required
 									/>
-									<div className="flex flex-row flex-nowrap">
-										<div className="text-sm italic mt-1 text-red-500 flex-grow">
-											{nameByteLimitReached ? t('loginSignup.reachedLengthLimit') : ''}
+									<div className={`flex flex-row flex-nowrap text-gray-500 text-sm italic mt-1 ${nameByteLimitReached ? 'text-red-500' : ''} transition-colors` }>
+										<div
+											className={`text-red-500 flex-grow ${nameByteLimitReached ? 'opacity-100' : 'opacity-0 select-none'} transition-opacity`}
+											aria-hidden={!nameByteLimitReached}
+										>
+											{t('loginSignup.reachedLengthLimit')}
 										</div>
-										<div className={`text-gray-500 text-sm italic mt-1 text-right ${nameByteLimitReached ? 'text-red-500' : ''}`}>
+										<div className="text-right">
 											{nameByteLength} / 64
 										</div>
 									</div>

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -119,7 +119,6 @@ const WebauthnSignupLogin = ({
 	const [retrySignupFrom, setRetrySignupFrom] = useState(null);
 
 	const cachedUsers = keystore.getCachedUsers();
-	const [nameByteLimitReached, setNameByteLimitReached] = useState(false);
 
 	useEffect(
 		() => {
@@ -279,6 +278,9 @@ const WebauthnSignupLogin = ({
 		return encoded.length;
 	};
 
+	const nameByteLength = calculateByteSize(name);
+	const nameByteLimitReached = nameByteLength > 64;
+
 	return (
 		<form onSubmit={onSubmit}>
 			{inProgress || retrySignupFrom
@@ -365,23 +367,20 @@ const WebauthnSignupLogin = ({
 									<FormInputField
 										ariaLabel="Passkey name"
 										name="name"
-										onChange={(event) => {
-											const newValue = event.target.value;
-											const byteSize = calculateByteSize(newValue);
-
-											if (byteSize <= 64) {
-													setName(newValue);
-													setNameByteLimitReached(false);
-											} else {
-													setNameByteLimitReached(true);
-											}
-									}}   								
+										onChange={(event) => setName(event.target.value)}
 										placeholder={t('loginSignup.enterPasskeyName')}
 										type="text"
 										value={name}
 										required
 									/>
-									{nameByteLimitReached && <div className="text-gray-500 text-sm italic mt-1">{t('loginSignup.reachedLengthLimit')}</div>}
+									<div className="flex flex-row flex-nowrap">
+										<div className="text-sm italic mt-1 text-red-500 flex-grow">
+											{nameByteLimitReached ? t('loginSignup.reachedLengthLimit') : ''}
+										</div>
+										<div className={`text-gray-500 text-sm italic mt-1 text-right ${nameByteLimitReached ? 'text-red-500' : ''}`}>
+											{nameByteLength} / 64
+										</div>
+									</div>
 								</FormInputRow>
 							</>)}
 
@@ -421,7 +420,7 @@ const WebauthnSignupLogin = ({
 						<button
 							className="w-full text-white bg-custom-blue hover:bg-custom-blue-hover dark:text-gray-900 dark:hover:bg-gray-300 dark:bg-custom-light-blue focus:ring-4 focus:outline-none focus:ring-gray-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center flex flex-row flex-nowrap items-center justify-center"
 							type="submit"
-							disabled={isSubmitting}
+							disabled={isSubmitting || nameByteLimitReached}
 						>
 							<GoPasskeyFill className="inline text-xl mr-2" />
 							{isSubmitting

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -418,7 +418,7 @@ const WebauthnSignupLogin = ({
 						{isLogin && cachedUsers?.length > 0 && <SeparatorLine className="my-4"/>}
 
 						<button
-							className="w-full text-white bg-custom-blue hover:bg-custom-blue-hover dark:text-gray-900 dark:hover:bg-gray-300 dark:bg-custom-light-blue focus:ring-4 focus:outline-none focus:ring-gray-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center flex flex-row flex-nowrap items-center justify-center"
+							className={`w-full text-white bg-custom-blue hover:bg-custom-blue-hover dark:text-gray-900 dark:hover:bg-gray-300 dark:bg-custom-light-blue focus:ring-4 focus:outline-none focus:ring-gray-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center flex flex-row flex-nowrap items-center justify-center ${nameByteLimitReached && 'cursor-not-allowed bg-gray-300 hover:bg-gray-300'}`} 
 							type="submit"
 							disabled={isSubmitting || nameByteLimitReached}
 						>


### PR DESCRIPTION
(This would merge into PR #170, not directly into master)

I think something like this would make for a better user experience around the max length limitation:

- Display an interactive byte length counter,
- Allow the name input to be longer than the limit, but disable the submit button while the length is exceeded (I haven't changed the button styles to match, as I'm not sure what styles we want)
- Show the "length exceeded" message while the length is exceeded

This enables users to figure out on their own that some (most non-ASCII) characters take more than one unit of "length" and by exactly how much they exceed the limit, reducing the guesswork in how much they need to shorten the value.

A possible additional improvement could be to only show the byte counter if the current length is approaching the limit - for example you could show it only if the current length exceeds 32 or something like that.