### PR TITLE
Hide byte counter row along with byte counter

### DIFF
--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -375,7 +375,7 @@ const WebauthnSignupLogin = ({
 										value={name}
 										required
 									/>
-									<div className={`flex flex-row flex-nowrap text-gray-500 text-sm italic mt-1 ${nameByteLimitReached ? 'text-red-500' : ''} transition-colors` }>
+									<div className={`flex flex-row flex-nowrap text-gray-500 text-sm italic ${nameByteLimitReached ? 'text-red-500' : ''} ${nameByteLimitApproaching ? 'h-4 mt-1' : 'h-0 mt-0'} transition-all` }>
 										<div
 											className={`text-red-500 flex-grow ${nameByteLimitReached ? 'opacity-100' : 'opacity-0 select-none'} transition-opacity`}
 											aria-hidden={!nameByteLimitReached}


### PR DESCRIPTION
(This would merge into PR #170, not directly into master)

Optional add-on to PR #171: collapse the byte counter/error message row while the byte counter is hidden. This saves some unused vertical whitespace, but also makes the UI move depending on input state, so I'm not sure this is a good idea. So feel free to accept or reject this, I don't mind dropping this if we don't want the UI moving like this.