### PR TITLE
Correct Console Log Location Override

### DIFF
--- a/src/ConsoleBehavior.js
+++ b/src/ConsoleBehavior.js
@@ -16,17 +16,30 @@ function isMethodAllowed(method) {
 }
 
 function ConsoleBehavior() {
-	const originalConsole = { ...console };
+  const originalConsole = { ...console };
 
-	Object.keys(console).forEach(method => {
-		if (typeof console[method] === 'function') {
-			console[method] = (...args) => {
-				if (isMethodAllowed(method)) {
-					originalConsole[method](...args);
-				}
-			};
-		}
-	});
+  const originalPrepareStackTrace = Error.prepareStackTrace;
+
+  Object.keys(console).forEach(method => {
+    if (typeof console[method] === 'function') {
+      console[method] = (...args) => {
+        if (isMethodAllowed(method)) {
+          Error.prepareStackTrace = (_, stack) => stack;
+          const stack = new Error().stack;
+          Error.prepareStackTrace = originalPrepareStackTrace;
+
+          const callSite = stack[1];
+          if (callSite) {
+            const fileName = callSite.getFileName();
+            const lineNumber = callSite.getLineNumber();
+            args.push(`(at ${fileName}:${lineNumber})`);
+          }
+
+          originalConsole[method].apply(console, args);
+        }
+      };
+    }
+  });
 }
 
 export default ConsoleBehavior;


### PR DESCRIPTION
Solve #181 where overridden console methods incorrectly display the overriding file's location instead of the original log call location.