### PR TITLE
Added Android Scenarios to PRF Compatibility Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,13 @@ The PRF (Pseudo Random Function) extension in WebAuthn enables the evaluation of
 | MacOS            | Android 				      | Hybrid     		| ✔                  |
 | MacOS            | iOS 				          | Hybrid     		| ❌                  |
 | Android          | Android 					    | Internal      | ✔                  |
-| Android          | FIDO Security Key 	  | USB           | ✔                  |
+| Android          | FIDO Security Key 	  | USB           | ✔ <sup>[1]</sup>    |
 | Android          | Android          	  | Hybrid        | ❌                  |
+| Android          | FIDO Security Key    | NFC           | ❌                  |
 | iOS              | iOS 					        | Internal      | ❌                  |
 | iOS              | FIDO Security Key 	  | NFC           | ❌                  |
 
+<sup>[1]</sup> **Note on Android with FIDO Security Keys over USB:** It's essential to have **Google Play Services (GPS) version 24.08.12 or later**.
 
 ***Note:** In this table, we use the term "FIDO Security Key" to refer to compatible security keys. It's important to understand that any security key should work with the hmac-secret extension, provided it supports this feature.
 For a detailed list of security key models that support hmac-secret, you can refer to the [FIDO MDS Explorer](https://opotonniee.github.io/fido-mds-explorer/), where hmac-secret support is listed under metadataStatement > authenticatorGetInfo > extensions.*

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The PRF (Pseudo Random Function) extension in WebAuthn enables the evaluation of
 | MacOS            | Android 				      | Hybrid     		| ✔                  |
 | MacOS            | iOS 				          | Hybrid     		| ❌                  |
 | Android          | Android 					    | Internal      | ✔                  |
+| Android          | FIDO Security Key 	  | USB           | ✔                  |
 | iOS              | iOS 					        | Internal      | ❌                  |
 | iOS              | FIDO Security Key 	  | NFC           | ❌                  |
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The PRF (Pseudo Random Function) extension in WebAuthn enables the evaluation of
 | MacOS            | iOS 				          | Hybrid     		| ❌                  |
 | Android          | Android 					    | Internal      | ✔                  |
 | Android          | FIDO Security Key 	  | USB           | ✔                  |
+| Android          | Android          	  | Hybrid        | ❌                  |
 | iOS              | iOS 					        | Internal      | ❌                  |
 | iOS              | FIDO Security Key 	  | NFC           | ❌                  |
 


### PR DESCRIPTION
Enhanced the prf compatibility table with two new entries for Android: FIDO Security Key with USB (compatible) and Android in Hybrid mode (not compatible yet).

In reference to issue #81