### PR TITLE
Flip parameter order of generateOpenid4vciProof to match sibling functions

### DIFF
--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -319,7 +319,7 @@ export interface LocalStorageKeystore {
 
 	createIdToken(nonce: string, audience: string): Promise<{ id_token: string; }>,
 	signJwtPresentation(nonce: string, audience: string, verifiableCredentials: any[]): Promise<{ vpjwt: string }>,
-	generateOpenid4vciProof(audience: string, nonce: string): Promise<{ proof_jwt: string }>,
+	generateOpenid4vciProof(nonce: string, audience: string): Promise<{ proof_jwt: string }>,
 }
 
 export function useLocalStorageKeystore(): LocalStorageKeystore {
@@ -812,7 +812,7 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 					return { vpjwt: jws };
 				},
 
-				generateOpenid4vciProof: async (audience: string, nonce: string): Promise<{ proof_jwt: string }> => {
+				generateOpenid4vciProof: async (nonce: string, audience: string): Promise<{ proof_jwt: string }> => {
 					const [{ alg, did, wrappedPrivateKey }, sessionKey] = await openPrivateData();
 					const privateKey = await unwrapPrivateKey(wrappedPrivateKey, sessionKey);
 					const header = {

--- a/src/services/SigningRequestHandlers.ts
+++ b/src/services/SigningRequestHandlers.ts
@@ -38,7 +38,7 @@ export function SigningRequestHandlerService(): SigningRequestHandlers {
 		},
 
 		handleGenerateOpenid4vciProofSigningRequest: async (socket, keystore, { message_id, audience, nonce }) => {
-			const { proof_jwt } = await keystore.generateOpenid4vciProof(audience, nonce)
+			const { proof_jwt } = await keystore.generateOpenid4vciProof(nonce, audience)
 			console.log("proof jwt = ", proof_jwt);
 			const outgoingMessage: ClientSocketMessage = {
 				message_id: message_id,

--- a/src/types/shared.types.ts
+++ b/src/types/shared.types.ts
@@ -5,7 +5,7 @@ export enum SignatureAction {
 }
 
 export type WalletKeystoreRequest = (
-	{ action: SignatureAction.generateOpenid4vciProof, audience: string, nonce: string }
+	{ action: SignatureAction.generateOpenid4vciProof, nonce: string, audience: string }
 	| { action: SignatureAction.createIdToken, nonce: string, audience: string }
 	| { action: SignatureAction.signJwtPresentation, nonce: string, audience: string, verifiableCredentials: any[] }
 );


### PR DESCRIPTION
Both `createIdToken` and `signJwtPresentation` have the parameter order `nonce, audience`, but `generateOpenid4vciProof` has parameter order `audience, nonce`. Both parameters have the same type, so the type system wouldn't catch a mistake passing arguments in reverse order. This change flips the parameter order to be the same between all three functions, lowering the risk of such a mistake.