### PR TITLE
Add framework for subscribing to events from useApi()

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -4,8 +4,8 @@ import { Err, Ok, Result } from 'ts-results';
 import { jsonParseTaggedBinary, jsonStringifyTaggedBinary, toBase64Url } from '../util';
 import { CachedUser, LocalStorageKeystore, makePrfExtensionInputs } from '../services/LocalStorageKeystore';
 import { UserData, Verifier } from './types';
-import { useMemo } from 'react';
-import { useClearStorages, useSessionStorage } from '../components/useStorage';
+import { useEffect, useMemo } from 'react';
+import { UseStorageHandle, useClearStorages, useSessionStorage } from '../components/useStorage';
 
 
 const walletBackendUrl = process.env.REACT_APP_WALLET_BACKEND_URL;
@@ -26,6 +26,13 @@ type SignupWebauthnError = (
 	| { errorId: 'prfRetryFailed', retryFrom: SignupWebauthnRetryParams }
 );
 type SignupWebauthnRetryParams = { beginData: any, credential: PublicKeyCredential };
+
+
+export type ClearSessionEvent = {};
+export const CLEAR_SESSION_EVENT = 'clearSession';
+export type ApiEventType = typeof CLEAR_SESSION_EVENT;
+const events: EventTarget = new EventTarget();
+
 
 export interface BackendApi {
 	del(path: string): Promise<AxiosResponse>,
@@ -57,15 +64,17 @@ export interface BackendApi {
 		promptForPrfRetry: () => Promise<boolean>,
 		retryFrom?: SignupWebauthnRetryParams,
 	): Promise<Result<void, SignupWebauthnError>>,
+
+	addEventListener(type: ApiEventType, listener: EventListener, options?: boolean | AddEventListenerOptions): void,
+	removeEventListener(type: ApiEventType, listener: EventListener, options?: boolean | EventListenerOptions): void,
+	/** Register a storage hook handle to be cleared when `useApi().clearSession()` is invoked. */
+	useClearOnClearSession<T>(storageHandle: UseStorageHandle<T>): UseStorageHandle<T>,
 }
 
 export function useApi(): BackendApi {
 	const [appToken, setAppToken, clearAppToken] = useSessionStorage<string | null>("appToken", null);
 	const [sessionState, setSessionState, clearSessionState] = useSessionStorage<SessionState | null>("sessionState", null);
-	const [, , clearTokenSentInSession] = useSessionStorage<boolean | null>("tokenSentInSession", null);
-	const [, , clearIsMessageNoGrantedVisible] = useSessionStorage<boolean | null>("isMessageNoGrantedVisible", null);
-	const [, , clearIsMessageGrantedVisible] = useSessionStorage<boolean | null>("isMessageGrantedVisible", null);
-	const clearSessionStorage = useClearStorages(clearAppToken, clearSessionState, clearTokenSentInSession, clearIsMessageNoGrantedVisible, clearIsMessageGrantedVisible);
+	const clearSessionStorage = useClearStorages(clearAppToken, clearSessionState);
 
 	return useMemo(
 		() => {
@@ -130,6 +139,7 @@ export function useApi(): BackendApi {
 
 			function clearSession(): void {
 				clearSessionStorage();
+				events.dispatchEvent(new CustomEvent<ClearSessionEvent>(CLEAR_SESSION_EVENT));
 			}
 
 			function setSession(response: AxiosResponse, credential: PublicKeyCredential | null): void {
@@ -401,6 +411,29 @@ export function useApi(): BackendApi {
 				}
 			}
 
+			function addEventListener(type: ApiEventType, listener: EventListener, options?: boolean | AddEventListenerOptions): void {
+				events.addEventListener(type, listener, options);
+			}
+
+			function removeEventListener(type: ApiEventType, listener: EventListener, options?: boolean | EventListenerOptions): void {
+				events.removeEventListener(type, listener, options);
+			}
+
+			function useClearOnClearSession<T>(storageHandle: UseStorageHandle<T>): UseStorageHandle<T> {
+				const [, , clearHandle] = storageHandle;
+				useEffect(
+					() => {
+						const listener = () => { clearHandle(); };
+						addEventListener(CLEAR_SESSION_EVENT, listener);
+						return () => {
+							removeEventListener(CLEAR_SESSION_EVENT, listener);
+						};
+					},
+					[clearHandle]
+				);
+				return storageHandle;
+			}
+
 			return {
 				del,
 				get,
@@ -419,6 +452,10 @@ export function useApi(): BackendApi {
 
 				loginWebauthn,
 				signupWebauthn,
+
+				addEventListener,
+				removeEventListener,
+				useClearOnClearSession,
 			}
 		},
 		[

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -16,8 +16,8 @@ const Layout = ({ children, isPermissionGranted, tokenSentInSession }) => {
 	const [isOpen, setIsOpen] = useState(false);
 	const toggleSidebar = () => setIsOpen(!isOpen);
 	const api = useApi();
-	const [isMessageNoGrantedVisible, setIsMessageNoGrantedVisible, ] = api.useClearOnClearSession(useSessionStorage('isMessageNoGrantedVisible', null));
-	const [isMessageGrantedVisible, setIsMessageGrantedVisible, ] = api.useClearOnClearSession(useSessionStorage('isMessageGrantedVisible', null));
+	const [isMessageNoGrantedVisible, setIsMessageNoGrantedVisible,] = api.useClearOnClearSession(useSessionStorage('isMessageNoGrantedVisible', null));
+	const [isMessageGrantedVisible, setIsMessageGrantedVisible,] = api.useClearOnClearSession(useSessionStorage('isMessageGrantedVisible', null));
 	const { t } = useTranslation();
 
 	const handleNavigate = (path) => {

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -8,7 +8,6 @@ import { CSSTransition } from 'react-transition-group';
 import { useSessionStorage } from '../components/useStorage';
 import { Trans, useTranslation } from 'react-i18next';
 import { useApi } from '../api';
-import { Trans, useTranslation } from 'react-i18next';
 
 const Layout = ({ children, isPermissionGranted, tokenSentInSession }) => {
 	const location = useLocation();

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -7,6 +7,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { CSSTransition } from 'react-transition-group';
 import { useSessionStorage } from '../components/useStorage';
 import { useTranslation } from 'react-i18next';
+import { useApi } from '../api';
 
 const Layout = ({ children, isPermissionGranted, tokenSentInSession }) => {
 	const location = useLocation();
@@ -14,8 +15,9 @@ const Layout = ({ children, isPermissionGranted, tokenSentInSession }) => {
 	const [isContentVisible, setIsContentVisible] = useState(false);
 	const [isOpen, setIsOpen] = useState(false);
 	const toggleSidebar = () => setIsOpen(!isOpen);
-	const [isMessageNoGrantedVisible, setIsMessageNoGrantedVisible] = useSessionStorage('isMessageNoGrantedVisible', null);
-	const [isMessageGrantedVisible, setIsMessageGrantedVisible] = useSessionStorage('isMessageGrantedVisible', null);
+	const api = useApi();
+	const [isMessageNoGrantedVisible, setIsMessageNoGrantedVisible, ] = api.useClearOnClearSession(useSessionStorage('isMessageNoGrantedVisible', null));
+	const [isMessageGrantedVisible, setIsMessageGrantedVisible, ] = api.useClearOnClearSession(useSessionStorage('isMessageGrantedVisible', null));
 	const { t } = useTranslation();
 
 	const handleNavigate = (path) => {

--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -13,7 +13,7 @@ const PrivateRoute = ({ children }) => {
 	const [loading, setLoading] = useState(false);
 	const keystore = useLocalStorageKeystore();
 	const isLoggedIn = api.isLoggedIn() && keystore.isOpen();
-	const [tokenSentInSession, setTokenSentInSession,] = useSessionStorage('tokenSentInSession', null);
+	const [tokenSentInSession, setTokenSentInSession,] = api.useClearOnClearSession(useSessionStorage('tokenSentInSession', null));
 
 	const location = useLocation();
 	const navigate = useNavigate();

--- a/src/components/useStorage.ts
+++ b/src/components/useStorage.ts
@@ -2,7 +2,7 @@ import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'reac
 import { jsonParseTaggedBinary, jsonStringifyTaggedBinary } from '../util';
 
 type ClearHandle = () => void;
-type UseStorageHandle<T> = [T, Dispatch<SetStateAction<T>>, ClearHandle];
+export type UseStorageHandle<T> = [T, Dispatch<SetStateAction<T>>, ClearHandle];
 type UseStorageEvent = { storageArea: Storage };
 type ClearEvent = UseStorageEvent;
 type SetValueEvent<T> = UseStorageEvent & { name: string, value: T };


### PR DESCRIPTION
(This would merge into PR #196, not directly to master.)

One potential issue I saw in PR #196 is that right now the three storage items (`tokenSentInSession`, `isMessageNoGrantedVisible`, `isMessageGrantedVisible`) are "owned" in two places - `tokenSentInSession` is "owned" in both `useApi()` and `PrivateRoute`, and the other two are "owned" in both `useApi()` and `Layout`. This could be a bit brittle - for example, if you change the storage key in one place but not the other, they will go out of sync. There's also a fair risk of introducing bugs with one component overwriting the other's state since there's also no explicit link between the two places.

So I was considering if there's a good way to move the ownership to one place to avoid that. I could see a few options:

- Move the `useSessionStorage` calls into `useApi()` and expose accessor methods. This is fairly straightforward but bloats the `useApi()` interface a bit. Also, `useApi()` is not really the proper home for these properties since `useApi()` doesn't _do_ anything with them, it would just hold them. It makes more sense for them to be owned by `PrivateRoute` and `Layout` since that's where they are used.
- So maybe instead it could make sense to add some kind of way to subscribe to events from `useApi()`, so that the appropriate component can own the storage items but have them cleared on logout.

This PR does the second of these: add an `EventTarget` in `useApi()` that dependent components can subscribe to. I also added the convenience hook `useClearOnClearSession` which takes a `UseStorageHandle` from `useSessionStorage()` or `useLocalStorage()` and automatically subscribes it to be cleared on logout, so dependent components can subscribe to have a storage state hook cleared by simply wrapping the hook call like so: `api.useClearOnClearSession(useSessionStorage("foo", "default-value"))`. This way the solution feels fairly lightweight to me.

Thoughts?
