### PR TITLE
Use separate Docker steps to install dependencies and build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM node:16-bullseye-slim AS builder
 
 WORKDIR /home/node/app
-COPY . .
 
+# Install dependencies first so rebuild of these layers is only needed when dependencies change
+COPY package.json yarn.lock .
 RUN --mount=type=secret,id=npmrc,required=true,target=./.npmrc,uid=1000 \
-	yarn cache clean -f && yarn install && yarn build
+	yarn cache clean -f && yarn install
+
+COPY . .
+RUN yarn build
 
 
 FROM nginx:alpine as deploy


### PR DESCRIPTION
This makes repeated rebuilds much faster as long as dependencies don't change.