### PR TITLE
Make license field in package.json agree with LICENSE file

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,5 @@
   },
   "main": "index.js",
   "repository": "https://github.com/wwwallet/wallet-frontend",
-  "author": "",
   "license": "BSD-2-Clause"
 }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     ]
   },
   "main": "index.js",
-  "repository": "https://github.com/gunet/wallet-frontend",
-  "author": "gregory1996 <grigoriskatrakazas@gmail.com>",
+  "repository": "https://github.com/wwwallet/wallet-frontend",
+  "author": "",
   "license": "BSD-2-Clause"
 }

--- a/package.json
+++ b/package.json
@@ -78,5 +78,5 @@
   "main": "index.js",
   "repository": "https://github.com/gunet/wallet-frontend",
   "author": "gregory1996 <grigoriskatrakazas@gmail.com>",
-  "license": "MIT"
+  "license": "BSD-2-Clause"
 }


### PR DESCRIPTION
`package.json` says MIT, but `LICENSE` says BSD :slightly_smiling_face: