### PR TITLE
Fix Navigation Item Activation on Wallet Redirect

### DIFF
--- a/src/components/BottomNav.js
+++ b/src/components/BottomNav.js
@@ -10,7 +10,7 @@ const BottomNav = ({ isOpen, toggle }) => {
 	const { t } = useTranslation();
 
 	const navItems = [
-		{ icon: <FaWallet size={26} />, path: '/', label: `${t("common.navItemCredentials")}` },
+		{ icon: <FaWallet size={26} />, path: '/', alias: '/cb', label: `${t("common.navItemCredentials")}` },
 		{ icon: <IoIosTime size={26} />, path: '/history', label: `${t("common.navItemHistory")}` },
 		{ icon: <IoIosAddCircle size={26} />, path: '/add', label: `${t("common.navItemAddCredentialsSimple")}` },
 		{ icon: <IoIosSend size={26} />, path: '/send', label: `${t("common.navItemSendCredentialsSimple")}` },
@@ -26,12 +26,16 @@ const BottomNav = ({ isOpen, toggle }) => {
 		}
 	};
 
+	const isActive = (item) => {
+		return location.pathname === item.path || location.pathname === item.alias;
+	};
+
 	return (
 		<div className={`fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 flex justify-around p-4 z-40 max480:flex hidden shadow-2xl rounded-t-lg`}>
 			{navItems.map(item => (
 				<button
 					key={item.path}
-					className={`cursor-pointer flex flex-col items-center w-[20%] ${(location.pathname === item.path && !isOpen) ? 'text-primary dark:text-white' : 'text-gray-400 dark:text-gray-400'} transition-colors duration-200`}
+					className={`cursor-pointer flex flex-col items-center w-[20%] ${isActive(item) && !isOpen ? 'text-primary dark:text-white' : 'text-gray-400 dark:text-gray-400'} transition-colors duration-200`}
 					onClick={() => handleNavigate(item.path)}
 					title={item.label}
 				>
@@ -41,7 +45,7 @@ const BottomNav = ({ isOpen, toggle }) => {
 			))}
 			<button
 				key={t("common.navItemProfile")}
-				className={`cursor-pointer flex flex-col items-center w-[20%] ${(isOpen) ? 'text-primary dark:text-white' : 'text-gray-400 dark:text-gray-400'} transition-colors duration-200`}
+				className={`cursor-pointer flex flex-col items-center w-[20%] ${isOpen ? 'text-primary dark:text-white' : 'text-gray-400 dark:text-gray-400'} transition-colors duration-200`}
 				onClick={toggle}
 				title={t("common.navItemProfile")}
 			>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -14,11 +14,13 @@ const NavItem = ({
 	handleNavigate,
 	location,
 	path,
+	alias,
 }) => {
+	const isActive = location.pathname === path || location.pathname === alias;
 	return (
 		<button
 			onClick={() => handleNavigate(path)}
-			className={`cursor-pointer flex items-center space-x-2 mb-4 p-2 rounded-r-xl w-full ${location.pathname === path ? 'bg-white text-primary' : 'nav-item-animate-hover'}`}
+			className={`cursor-pointer flex items-center space-x-2 mb-4 p-2 rounded-r-xl w-full ${isActive ? 'bg-white text-primary' : 'nav-item-animate-hover'}`}
 		>
 			{children}
 		</button>
@@ -110,7 +112,7 @@ const Sidebar = ({ isOpen, toggle }) => {
 
 						{/* Nav Menu */}
 						<div className='max480:hidden'>
-							<NavItem path="/" location={location} handleNavigate={handleNavigate}>
+							<NavItem path="/" alias="/cb" location={location} handleNavigate={handleNavigate}>
 								<FaWallet size={30} />
 								<span>{t("common.navItemCredentials")}</span>
 							</NavItem>


### PR DESCRIPTION
This pull request resolves an issue where the bottom/sidebar navigation item fails to activate upon redirecting to the wallet page with `/cb`. The changes ensure that the navigation state correctly updates to reflect the active page.
