### PR TITLE
Change format of privateData from string to Uint8Array

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -2,7 +2,7 @@ import axios, { AxiosResponse } from 'axios';
 import { Err, Ok, Result } from 'ts-results';
 
 import { jsonParseTaggedBinary, jsonStringifyTaggedBinary, toBase64Url } from '../util';
-import { makeAssertionPrfExtensionInputs } from '../services/keystore';
+import { makeAssertionPrfExtensionInputs, parsePrivateData, serializePrivateData } from '../services/keystore';
 import { CachedUser, LocalStorageKeystore } from '../services/LocalStorageKeystore';
 import { UserData, Verifier } from './types';
 import { useEffect, useMemo } from 'react';
@@ -168,7 +168,7 @@ export function useApi(): BackendApi {
 				try {
 					const response = await post('/user/login', { username, password });
 					const userData = response.data as UserData;
-					const privateData = jsonParseTaggedBinary(userData.privateData);
+					const privateData = await parsePrivateData(userData.privateData);
 					try {
 						await keystore.unlockPassword(privateData, password);
 						setSession(response, null, 'login', false);
@@ -195,7 +195,7 @@ export function useApi(): BackendApi {
 							password,
 							displayName: username,
 							keys: publicData,
-							privateData: jsonStringifyTaggedBinary(privateData),
+							privateData: serializePrivateData(privateData),
 						});
 						setSession(response, null, 'signup', true);
 						return Ok.EMPTY;
@@ -302,7 +302,7 @@ export function useApi(): BackendApi {
 
 							try {
 								const userData = finishResp.data as UserData;
-								const privateData = jsonParseTaggedBinary(userData.privateData);
+								const privateData = await parsePrivateData(userData.privateData);
 								await keystore.unlockPrf(
 									privateData,
 									credential,
@@ -384,7 +384,7 @@ export function useApi(): BackendApi {
 									challengeId: beginData.challengeId,
 									displayName: name,
 									keys: publicData,
-									privateData: jsonStringifyTaggedBinary(privateData),
+									privateData: serializePrivateData(privateData),
 									credential: {
 										type: credential.type,
 										id: credential.id,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -13,7 +13,7 @@ export type UserData = {
 	publicKey: JsonWebKey;
 	webauthnUserHandle: string;
 	webauthnCredentials: WebauthnCredential[];
-	privateData: string;
+	privateData: Uint8Array;
 }
 
 export type WebauthnCredential = {

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -5,9 +5,10 @@ import { BsLock, BsPlusCircle, BsUnlock } from 'react-icons/bs';
 
 import { useApi } from '../../api';
 import { UserData, WebauthnCredential } from '../../api/types';
-import { compareBy, jsonStringifyTaggedBinary, toBase64Url } from '../../util';
+import { compareBy, toBase64Url } from '../../util';
 import { formatDate } from '../../functions/DateFormat';
 import type { WrappedKeyInfo } from '../../services/keystore';
+import { serializePrivateData } from '../../services/keystore';
 import { useLocalStorageKeystore } from '../../services/LocalStorageKeystore';
 import DeletePopup from '../../components/Popups/DeletePopup';
 import { useNavigate } from 'react-router-dom';
@@ -151,7 +152,7 @@ const WebauthnRegistation = ({
 						authenticatorAttachment: pendingCredential.authenticatorAttachment,
 						clientExtensionResults: pendingCredential.getClientExtensionResults(),
 					},
-					privateData: jsonStringifyTaggedBinary(newPrivateData),
+					privateData: serializePrivateData(newPrivateData),
 				});
 				onSuccess();
 				setNickname("");
@@ -608,7 +609,7 @@ const Settings = () => {
 	const deleteWebauthnCredential = async (credential: WebauthnCredential) => {
 		const [newPrivateData, keystoreCommit] = keystore.deletePrf(credential.credentialId);
 		const deleteResp = await api.post(`/user/session/webauthn/credential/${credential.id}/delete`, {
-			privateData: jsonStringifyTaggedBinary(newPrivateData),
+			privateData: serializePrivateData(newPrivateData),
 		});
 		if (deleteResp.status === 204) {
 			await keystoreCommit();

--- a/src/services/keystore.ts
+++ b/src/services/keystore.ts
@@ -73,6 +73,14 @@ type WrappedPrivateKey = {
 }
 
 
+export async function parsePrivateData(privateData: BufferSource): Promise<EncryptedContainer> {
+	return jsonParseTaggedBinary(new TextDecoder().decode(privateData));
+}
+
+export function serializePrivateData(privateData: EncryptedContainer): Uint8Array {
+	return new TextEncoder().encode(jsonStringifyTaggedBinary(privateData));
+}
+
 async function createMainKey(wrappingKey: CryptoKey): Promise<WrappedKeyInfo> {
 	const mainKey = await crypto.subtle.generateKey(
 		{ name: "AES-GCM", length: 256 },


### PR DESCRIPTION
Preliminary step towards resolving the "phase 0" laid out in https://github.com/wwWallet/wallet-ecosystem/issues/62.

The internal format of the opaque `privateData` should be up to the frontend alone, so there's no need for the server backend to care about any format conversions, other than making sure the binary data is unchanged. This simplifies things by reducing the number of format conversions that need to be made.

This is mutually dependent on this PR in wallet-backend-server:
- https://github.com/wwWallet/wallet-backend-server/pull/54