### PR TITLE
Fix issues with X-Private-Data-ETag header

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -94,27 +94,6 @@ export function useApi(isOnline: boolean = true): BackendApi {
 	 */
 	const [privateDataEtag, setPrivateDataEtag] = useLocalStorage<string | null>("privateDataEtag", null);
 
-	function updatePrivateDataEtag(resp: AxiosResponse): AxiosResponse {
-		if (resp.headers['x-private-data-etag']) {
-			setPrivateDataEtag(resp.headers['x-private-data-etag']);
-		}
-		return resp;
-	}
-
-	function buildGetHeaders(headers: { appToken?: string }): { [header: string]: string } {
-		const authz = headers?.appToken || appToken;
-		return {
-			...(authz ? { Authorization: `Bearer ${authz}` } : {}),
-		};
-	}
-
-	function buildMutationHeaders(headers: { appToken?: string }): { [header: string]: string } {
-		return {
-			...buildGetHeaders(headers),
-			...(privateDataEtag ? { 'X-Private-Data-If-Match': privateDataEtag } : {}),
-		};
-	}
-
 	return useMemo(
 		() => {
 			function getAppToken(): string | null {
@@ -127,6 +106,28 @@ export function useApi(isOnline: boolean = true): BackendApi {
 				} else {
 					return data;
 				}
+			}
+
+			function updatePrivateDataEtag(resp: AxiosResponse): AxiosResponse {
+				const newValue = resp.headers['x-private-data-etag']
+				if (newValue) {
+					setPrivateDataEtag(newValue);
+				}
+				return resp;
+			}
+
+			function buildGetHeaders(headers: { appToken?: string }): { [header: string]: string } {
+				const authz = headers?.appToken || appToken;
+				return {
+					...(authz ? { Authorization: `Bearer ${authz}` } : {}),
+				};
+			}
+
+			function buildMutationHeaders(headers: { appToken?: string }): { [header: string]: string } {
+				return {
+					...buildGetHeaders(headers),
+					...(privateDataEtag ? { 'X-Private-Data-If-Match': privateDataEtag } : {}),
+				};
 			}
 
 			async function getWithLocalDbKey(path: string, dbKey: string, options?: { appToken?: string }): Promise<AxiosResponse> {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -74,6 +74,7 @@ export interface BackendApi {
 		promptForPrfRetry: () => Promise<boolean | AbortSignal>,
 		retryFrom?: SignupWebauthnRetryParams,
 	): Promise<Result<void, SignupWebauthnError>>,
+	updatePrivateDataEtag(resp: AxiosResponse): AxiosResponse,
 
 	addEventListener(type: ApiEventType, listener: EventListener, options?: boolean | AddEventListenerOptions): void,
 	removeEventListener(type: ApiEventType, listener: EventListener, options?: boolean | EventListenerOptions): void,
@@ -245,11 +246,11 @@ export function useApi(isOnline: boolean = true): BackendApi {
 						if (updatePrivateData) {
 							const [newPrivateData, keystoreCommit] = updatePrivateData;
 							try {
-								const updateResp = await post(
+								const updateResp = updatePrivateDataEtag(await post(
 									'/user/session/update-private-data',
 									serializePrivateData(newPrivateData),
 									{ appToken: response.data.appToken },
-								);
+								));
 								if (updateResp.status === 204) {
 									await keystoreCommit();
 								} else {
@@ -606,6 +607,7 @@ export function useApi(isOnline: boolean = true): BackendApi {
 
 				loginWebauthn,
 				signupWebauthn,
+				updatePrivateDataEtag,
 
 				addEventListener,
 				removeEventListener,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -618,10 +618,12 @@ export function useApi(isOnline: boolean = true): BackendApi {
 		[
 			appToken,
 			clearSessionStorage,
+			isOnline,
+			privateDataEtag,
 			sessionState,
 			setAppToken,
+			setPrivateDataEtag,
 			setSessionState,
-			isOnline
 		],
 	);
 }

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -167,7 +167,7 @@ const WebauthnRegistation = ({
 				);
 
 				setIsSubmitting(true);
-				await api.post('/user/session/webauthn/register-finish', {
+				api.updatePrivateDataEtag(await api.post('/user/session/webauthn/register-finish', {
 					challengeId: beginData.challengeId,
 					nickname,
 					credential: {
@@ -183,7 +183,7 @@ const WebauthnRegistation = ({
 						clientExtensionResults: pendingCredential.getClientExtensionResults(),
 					},
 					privateData: serializePrivateData(newPrivateData),
-				});
+				}));
 				onSuccess();
 				setNickname("");
 				await keystoreCommit();
@@ -742,9 +742,9 @@ const Settings = () => {
 	const deleteWebauthnCredential = async (credential: WebauthnCredential) => {
 		const [newPrivateData, keystoreCommit] = keystore.deletePrf(credential.credentialId);
 		try {
-			const deleteResp = await api.post(`/user/session/webauthn/credential/${credential.id}/delete`, {
+			const deleteResp = api.updatePrivateDataEtag(await api.post(`/user/session/webauthn/credential/${credential.id}/delete`, {
 				privateData: serializePrivateData(newPrivateData),
-			});
+			}));
 			if (deleteResp.status === 204) {
 				await keystoreCommit();
 			} else {
@@ -792,7 +792,9 @@ const Settings = () => {
 				},
 			);
 			setUpgradePrfState(null);
-			const updateResp = await api.post('/user/session/update-private-data', serializePrivateData(newPrivateData));
+			const updateResp = api.updatePrivateDataEtag(
+				await api.post('/user/session/update-private-data', serializePrivateData(newPrivateData)),
+			);
 			if (updateResp.status === 204) {
 				await keystoreCommit();
 			} else {


### PR DESCRIPTION
Apparently I didn't properly test #263 - attempting to register and/or delete multiple credentials in sequence would fail, because both the frontend and the backend failed to keep track of the correct ETag state.

Related:
- https://github.com/wwWallet/wallet-backend-server/pull/60