### PR TITLE
Extract function onCancelEditing used for both click and ESC

### DIFF
--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -505,14 +505,21 @@ const WebauthnCredentialItem = ({
 		}
 	};
 
+	const onCancelEditing = useCallback(
+		() => {
+			setNickname(credential.nickname || '');
+			setEditing(false);
+		},
+		[credential.nickname],
+	);
+
 	const onKeyUp = useCallback(
 		(event: KeyboardEvent<HTMLInputElement>) => {
 			if (event.key === "Escape") {
-				setNickname(credential.nickname || '');
-				setEditing(false);
+				onCancelEditing();
 			}
 		},
-		[credential.nickname],
+		[onCancelEditing],
 	);
 
 	const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -611,7 +618,7 @@ const WebauthnCredentialItem = ({
 						<div className='flex gap-2'>
 							<GetButton
 								content={t('common.cancel')}
-								onClick={() => setEditing(false)}
+								onClick={onCancelEditing}
 								variant="cancel"
 								disabled={submitting}
 								ariaLabel={t('pageSettings.passkeyItem.cancelChangesAriaLabel', { passkeyLabel: currentLabel })}


### PR DESCRIPTION
Before this, pressing ESC would cancel editing and reset the nickname input to the current nickname, while clicking the "cancel" button would only cancel editing but not reset the input.