### PR TITLE
Add session timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The project uses environment variables to manage different configurations. A `.e
 	 - REACT_APP_FIREBASE_APP_ID: Your Firebase App ID.
 	 - REACT_APP_FIREBASE_MEASUREMENT_ID: Your Firebase Measurement ID.
 	 - REACT_APP_DISPLAY_CONSOLE: Handle console logs (`true` or `false`). If left empty, it will be handled as `true`.
+	 - REACT_APP_INACTIVE_LOGOUT_SECONDS: Session will time out after approximately this time in seconds since the last user activity (default is 15 minutes).
 	 - REACT_APP_WEBAUTHN_RPID: WebAuthn relying party ID (when running locally, set to `localhost`). This must match the `config.webauthn.rp.id` setting in `wallet-backend-server`.
 
 4. Install dependencies:

--- a/src/components/useOnUserInactivity.ts
+++ b/src/components/useOnUserInactivity.ts
@@ -13,6 +13,13 @@ export function useOnUserInactivity(action: () => void, timeoutMillis: number) {
 
 	useEffect(
 		() => {
+			// I would have liked to use the User Activation API
+			// (https://developer.mozilla.org/en-US/docs/Web/API/UserActivation/isActive)
+			// for this, but it doesn't appear to provide an event source and the
+			// transient activation duration is on the order of a few seconds, so
+			// you'd have to poll `navigator.userActivation.isActive` in a fairly
+			// tight loop in order to actually hit the transient activation window.
+
 			const debouncedReset = debounce(resetTimeout, timeoutMillis / 4);
 			const eventTypes = ["keydown", "pointermove", "pointerdown"];
 			for (const eventType of eventTypes) {

--- a/src/components/useOnUserInactivity.ts
+++ b/src/components/useOnUserInactivity.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+import { useResettableTimeout } from './useResettableTimeout';
+import { debounce } from '../util';
+
+
+/**
+ * Schedules execution of a one-time `callback` after `timeoutMillis` milliseconds.
+ * The timer resets whenever the user interacts with the application,
+ * but at most once every `timeoutMillis / 4` milliseconds.
+ */
+export function useOnUserInactivity(action: () => void, timeoutMillis: number) {
+	const resetTimeout = useResettableTimeout(action, timeoutMillis);
+
+	useEffect(
+		() => {
+			const debouncedReset = debounce(resetTimeout, timeoutMillis / 4);
+			const eventTypes = ["keydown", "pointermove", "pointerdown"];
+			for (const eventType of eventTypes) {
+				window.document.addEventListener(eventType, debouncedReset, { passive: true });
+			}
+			return () => {
+				for (const eventType of eventTypes) {
+					window.document.removeEventListener(eventType, debouncedReset);
+				}
+			}
+		},
+		[resetTimeout, timeoutMillis],
+	);
+}

--- a/src/components/useOnUserInactivity.ts
+++ b/src/components/useOnUserInactivity.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useResettableTimeout } from './useResettableTimeout';
-import { debounce } from '../util';
+import { throttle } from '../util';
 
 
 /**
@@ -20,14 +20,14 @@ export function useOnUserInactivity(action: () => void, timeoutMillis: number) {
 			// you'd have to poll `navigator.userActivation.isActive` in a fairly
 			// tight loop in order to actually hit the transient activation window.
 
-			const debouncedReset = debounce(resetTimeout, timeoutMillis / 4);
+			const throttledReset = throttle(resetTimeout, timeoutMillis / 4);
 			const eventTypes = ["keydown", "pointermove", "pointerdown"];
 			for (const eventType of eventTypes) {
-				window.document.addEventListener(eventType, debouncedReset, { passive: true });
+				window.document.addEventListener(eventType, throttledReset, { passive: true });
 			}
 			return () => {
 				for (const eventType of eventTypes) {
-					window.document.removeEventListener(eventType, debouncedReset);
+					window.document.removeEventListener(eventType, throttledReset);
 				}
 			}
 		},

--- a/src/components/useResettableTimeout.ts
+++ b/src/components/useResettableTimeout.ts
@@ -1,0 +1,27 @@
+import { useCallback, useEffect, useState } from 'react';
+
+
+export type ResetHandle = () => void;
+
+/**
+ * Schedules execution of a one-time `callback` after `delayMillis` milliseconds.
+ * Returns a callback that will reset the timer.
+ */
+export function useResettableTimeout(action: () => void, delayMillis: number): ResetHandle {
+	const getTime = useCallback(() => new Date().getTime(), []);
+	const [startTime, setStartTime] = useState(getTime);
+
+	useEffect(
+		() => {
+			const timeElapsed = getTime() - startTime;
+			const clearTimeoutHandle = setTimeout(action, delayMillis - timeElapsed);
+			return () => { clearTimeout(clearTimeoutHandle); };
+		},
+		[action, delayMillis, getTime, startTime],
+	);
+
+	return useCallback(
+		() => { setStartTime(getTime); },
+		[getTime, setStartTime],
+	);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ export const FIREBASE = {
 	storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
 };
 export const FIREBASE_VAPIDKEY = process.env.REACT_APP_FIREBASE_VAPIDKEY;
+export const INACTIVE_LOGOUT_MILLIS = (process.env.REACT_APP_INACTIVE_LOGOUT_SECONDS ? parseInt(process.env.REACT_APP_INACTIVE_LOGOUT_SECONDS, 10) : 60 * 15) * 1000
 export const LOGIN_WITH_PASSWORD: boolean = process.env.REACT_APP_LOGIN_WITH_PASSWORD === 'true';
 export const WEBAUTHN_RPID = process.env.REACT_APP_WEBAUTHN_RPID ?? "localhost";
 export const WS_URL = process.env.REACT_APP_WS_URL;

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -4,6 +4,7 @@ import * as config from "../config";
 import { useClearStorages, useLocalStorage, useSessionStorage } from "../components/useStorage";
 import { toBase64Url } from "../util";
 import { useIndexedDb } from "../components/useIndexedDb";
+import { useOnUserInactivity } from "../components/useOnUserInactivity";
 
 import * as keystore from "./keystore";
 import type { AsymmetricEncryptedContainerKeys, EncryptedContainer, PrivateData, PublicData, UnlockSuccess, WebauthnPrfEncryptionKeyInfo, WebauthnPrfSaltInfo, WrappedKeyInfo } from "./keystore";
@@ -114,6 +115,8 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 		},
 		[closeTabLocal, idb, clearGlobalUserHandleB64u, clearPrivateDataCache],
 	);
+
+	useOnUserInactivity(close, config.INACTIVE_LOGOUT_MILLIS);
 
 	useEffect(
 		() => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -76,3 +76,18 @@ export function compareBy<T, U>(f: (v: T) => U): (a: T, b: T) => number {
 		}
 	};
 }
+
+/**
+ * Wrap `action` so that it will not execute again for `timeoutMillis` milliseconds after each execution.
+ */
+export function debounce(action: () => void, timeoutMillis: number): () => void {
+	let ready = true;
+	const setReady = () => { ready = true; };
+	return () => {
+		if (ready) {
+			ready = false;
+			action();
+			setTimeout(setReady, timeoutMillis);
+		}
+	};
+};

--- a/src/util.ts
+++ b/src/util.ts
@@ -80,7 +80,7 @@ export function compareBy<T, U>(f: (v: T) => U): (a: T, b: T) => number {
 /**
  * Wrap `action` so that it will not execute again for `timeoutMillis` milliseconds after each execution.
  */
-export function debounce(action: () => void, timeoutMillis: number): () => void {
+export function throttle(action: () => void, timeoutMillis: number): () => void {
 	let ready = true;
 	const setReady = () => { ready = true; };
 	return () => {


### PR DESCRIPTION
We use `sessionStorage` for the session key [in the hopes of bounding the lifetime of the decrypted wallet contents](https://wwwallet.github.io/wallet-docs/docs/wallet/encryption-architecture/v1#session-storage), as `sessionStorage` is cleared when the browser tab is closed. We chose this passive approach for fail-safety, so that we don't rely on active application code to perform the cleanup - which risks that the cleanup might be skipped in case the session ends unexpectedly, like if the browser crashes or in case of power loss.

However, a session may continue indefinitely, so there is no guarantee that the `sessionStorage` will ever be cleared. But none of this prevents us from using active safety as well: either the session ends within some given time, in which case the browser clears the `sessionStorage` and thus the decrypted wallet contents; or the session does _not_ end within that time, in which case the application is still running and can trigger the cleanup programmatically.

This sets a configurable session timeout with a default of 15 minutes. When the timeout triggers, the key store is closed and the user needs to log in again in order to access the wallet contents. The timer resets whenever the user interacts with the application.