### PR TITLE
Fix API path of update-private-data endpoint

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -247,7 +247,7 @@ export function useApi(isOnline: boolean = true): BackendApi {
 							const [newPrivateData, keystoreCommit] = updatePrivateData;
 							try {
 								const updateResp = updatePrivateDataEtag(await post(
-									'/user/session/update-private-data',
+									'/user/session/private-data',
 									serializePrivateData(newPrivateData),
 									{ appToken: response.data.appToken },
 								));
@@ -438,7 +438,7 @@ export function useApi(isOnline: boolean = true): BackendApi {
 									const [newPrivateData, keystoreCommit] = updatePrivateData;
 									try {
 										const updateResp = await post(
-											'/user/session/update-private-data',
+											'/user/session/private-data',
 											serializePrivateData(newPrivateData),
 											{ appToken: finishResp.data.appToken },
 										);

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -792,7 +792,7 @@ const Settings = () => {
 			);
 			setUpgradePrfState(null);
 			const updateResp = api.updatePrivateDataEtag(
-				await api.post('/user/session/update-private-data', serializePrivateData(newPrivateData)),
+				await api.post('/user/session/private-data', serializePrivateData(newPrivateData)),
 			);
 			if (updateResp.status === 204) {
 				await keystoreCommit();


### PR DESCRIPTION
The API path was [changed in wallet-backend-server commit `7f55c8e2`](https://github.com/wwWallet/wallet-backend-server/pull/57/commits/7f55c8e243fbeb0a9083ff7004d8015349bf6a95#diff-f9032a71f6b60851d31e2f2e430220746a5d15841dc8177684e8d254024bd542L480-R515), but not updated here in the frontend.