### PR TITLE
login-state refactorizations from review

### DIFF
--- a/src/pages/Login/LoginState.js
+++ b/src/pages/Login/LoginState.js
@@ -70,33 +70,31 @@ const WebauthnLogin = ({
 	return (
 		<>
 			<ul className=" p-2">
-				{filteredUser && (
-					<div className='flex flex-row gap-4 justify-center mr-2'>
-						<GetButton
-							content={
-								<>
-									{t('common.cancel')}
-								</>
-							}
-							onClick={() => navigate('/')}
-							variant="cancel"
-							disabled={isSubmitting}
-							additionalClassName='w-full'
-						/>
-						<GetButton
-							content={
-								<>
-									<GoPasskeyFill className="inline text-xl mr-2" />
-									{isSubmitting ? t('loginSignup.submitting') : t('common.continue')}
-								</>
-							}
-							onClick={() => onLoginCachedUser(filteredUser)}
-							variant="primary"
-							disabled={isSubmitting}
-							additionalClassName='w-full'
-						/>
-					</div>
-				)}
+				<div className='flex flex-row gap-4 justify-center mr-2'>
+					<GetButton
+						content={
+							<>
+								{t('common.cancel')}
+							</>
+						}
+						onClick={() => navigate('/')}
+						variant="cancel"
+						disabled={isSubmitting}
+						additionalClassName='w-full'
+					/>
+					<GetButton
+						content={
+							<>
+								<GoPasskeyFill className="inline text-xl mr-2" />
+								{isSubmitting ? t('loginSignup.submitting') : t('common.continue')}
+							</>
+						}
+						onClick={() => onLoginCachedUser(filteredUser)}
+						variant="primary"
+						disabled={isSubmitting}
+						additionalClassName='w-full'
+					/>
+				</div>
 			</ul>
 			{error && <div className="text-red-500 pt-4">{error}</div>}
 		</>

--- a/src/pages/Login/LoginState.js
+++ b/src/pages/Login/LoginState.js
@@ -13,20 +13,18 @@ import { PiWifiHighBold, PiWifiSlashBold } from "react-icons/pi";
 
 
 const WebauthnLogin = ({
-	isSubmitting,
-	setIsSubmitting,
 	filteredUser,
 }) => {
 	const { isOnline } = useContext(OnlineStatusContext);
-
 	const api = useApi(isOnline);
 	const [error, setError] = useState('');
 	const navigate = useNavigate();
 	const location = useLocation();
 	const from = location.state?.from || '/';
-
 	const { t } = useTranslation();
 	const keystore = useLocalStorageKeystore();
+
+	const [isSubmitting, setIsSubmitting] = useState(false);
 
 	const onLogin = useCallback(
 		async (cachedUser) => {
@@ -111,7 +109,6 @@ const LoginState = () => {
 	const { t } = useTranslation();
 	const location = useLocation();
 
-	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [isContentVisible, setIsContentVisible] = useState(false);
 	const [filteredUser, setFilteredUser] = useState(null);
 	const navigate = useNavigate();
@@ -193,8 +190,6 @@ const LoginState = () => {
 									</p>
 
 									<WebauthnLogin
-										isSubmitting={isSubmitting}
-										setIsSubmitting={setIsSubmitting}
 										filteredUser={filteredUser}
 									/>
 

--- a/src/pages/Login/LoginState.js
+++ b/src/pages/Login/LoginState.js
@@ -12,8 +12,7 @@ import GetButton from '../../components/Buttons/GetButton';
 import { PiWifiHighBold, PiWifiSlashBold } from "react-icons/pi";
 
 
-const WebauthnSignupLogin = ({
-	isLogin,
+const WebauthnLogin = ({
 	isSubmitting,
 	setIsSubmitting,
 	filteredUser,
@@ -28,12 +27,6 @@ const WebauthnSignupLogin = ({
 
 	const { t } = useTranslation();
 	const keystore = useLocalStorageKeystore();
-	useEffect(
-		() => {
-			setError("");
-		},
-		[isLogin],
-	);
 
 	const onLogin = useCallback(
 		async (cachedUser) => {
@@ -199,8 +192,7 @@ const LoginState = () => {
 										/>
 									</p>
 
-									<WebauthnSignupLogin
-										isLogin={true}
+									<WebauthnLogin
 										isSubmitting={isSubmitting}
 										setIsSubmitting={setIsSubmitting}
 										filteredUser={filteredUser}

--- a/src/pages/Login/LoginState.js
+++ b/src/pages/Login/LoginState.js
@@ -117,7 +117,7 @@ const LoginState = () => {
 	const from = location.state?.from;
 
 	useEffect(() => {
-		const queryParams = new URLSearchParams(from.search);
+		const queryParams = new URLSearchParams(from?.search ?? location.search);
 		const state = queryParams.get('state');
 
 		if (state) {
@@ -130,7 +130,7 @@ const LoginState = () => {
 				console.error('Error decoding state:', error);
 			}
 		}
-	}, [cachedUsers, from.search]);
+	}, [cachedUsers, from?.search, location.search]);
 
 	useEffect(() => {
 		if (api.isLoggedIn()) {

--- a/src/pages/Login/LoginState.js
+++ b/src/pages/Login/LoginState.js
@@ -129,6 +129,8 @@ const LoginState = () => {
 			} catch (error) {
 				console.error('Error decoding state:', error);
 			}
+		} else {
+			navigate('/login');
 		}
 	}, [cachedUsers, from?.search, location.search]);
 

--- a/src/pages/Login/LoginState.js
+++ b/src/pages/Login/LoginState.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation, Navigate } from 'react-router-dom';
 import { FaInfoCircle } from 'react-icons/fa';
 import { GoPasskeyFill } from 'react-icons/go';
 import { Trans, useTranslation } from 'react-i18next';
@@ -110,39 +110,36 @@ const LoginState = () => {
 	const location = useLocation();
 
 	const [isContentVisible, setIsContentVisible] = useState(false);
-	const [filteredUser, setFilteredUser] = useState(null);
-	const navigate = useNavigate();
 	const keystore = useLocalStorageKeystore();
 	const cachedUsers = keystore.getCachedUsers();
 	const from = location.state?.from;
 
-	useEffect(() => {
+	const getCachedUser = () => {
 		const queryParams = new URLSearchParams(from?.search ?? location.search);
 		const state = queryParams.get('state');
-
 		if (state) {
 			try {
-				console.log('state', state)
+				console.log('state', state);
 				const decodedState = atob(state);
 				const stateObj = JSON.parse(decodedState);
-				setFilteredUser(cachedUsers.find(user => user.userHandleB64u === stateObj.userHandleB64u));
+				return cachedUsers.find(user => user.userHandleB64u === stateObj.userHandleB64u);
 			} catch (error) {
 				console.error('Error decoding state:', error);
 			}
-		} else {
-			navigate('/login');
 		}
-	}, [cachedUsers, from?.search, location.search]);
-
-	useEffect(() => {
-		if (api.isLoggedIn()) {
-			navigate('/');
-		}
-	}, [api, navigate]);
+		return null;
+	};
+	const filteredUser = getCachedUser();
 
 	useEffect(() => {
 		setIsContentVisible(true);
 	}, []);
+
+	if (!filteredUser) {
+		return <Navigate to="/login" replace />;
+	} else if (api.isLoggedIn()) {
+		return <Navigate to="/" replace />;
+	}
 
 	return (
 		<section className="bg-gray-100 dark:bg-gray-900 h-full">
@@ -166,11 +163,9 @@ const LoginState = () => {
 
 							<div className="relative w-full md:mt-0 sm:max-w-md xl:p-0">
 								<div className="relative p-6 space-y-4 md:space-y-6 sm:p-8 bg-white rounded-lg shadow dark:bg-gray-800">
-									{filteredUser && (
-										<h1 className="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl text-center dark:text-white">
-											{t('loginState.title')} {filteredUser.displayName}
-										</h1>
-									)}
+									<h1 className="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl text-center dark:text-white">
+										{t('loginState.title')} {filteredUser.displayName}
+									</h1>
 									<div className='absolute text-gray-500 dark:text-white dark top-0 left-5'>
 										{isOnline ? (
 											<PiWifiHighBold size={25} title={t('common.online')} />


### PR DESCRIPTION
Since this page handles only login, not signup, some of the state can be pushed down from the `<LoginState>` component to (renamed) `<WebauthnLogin>`. This also simplifies some of the logic so that the component never renders if `filteredUser` is not found, and fixes a [crash on navigating directly to `/login-state`](https://github.com/wwWallet/wallet-frontend/pull/282#discussion_r1698391555).