### PR TITLE
Fix validateDOMNesting and findDOMNode warnings in Login component

### DIFF
--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { FaExclamationTriangle, FaEye, FaEyeSlash, FaInfoCircle, FaLock, FaUser } from 'react-icons/fa';
 import { GoPasskeyFill, GoTrash } from 'react-icons/go';
@@ -35,12 +35,12 @@ const FormInputRow = ({
 );
 
 const PasswordCriterionMessage = ({ text, ok }) => (
-	<p className={ok ? "text-green-500" : "text-red-500"}>
-		<span className="text-sm">
+	<div className={ok ? "text-green-500" : "text-red-500"}>
+		<p className="text-sm">
 			<AiOutlineUnlock className="inline-block mr-2" />
 			{text}
-		</span>
-	</p>
+		</p>
+	</div>
 );
 
 const FormInputField = ({
@@ -485,6 +485,7 @@ const Login = () => {
 	const [isLogin, setIsLogin] = useState(true);
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [isContentVisible, setIsContentVisible] = useState(false);
+	const nodeRef = useRef(null);
 
 	const navigate = useNavigate();
 	const keystore = useLocalStorageKeystore();
@@ -592,9 +593,9 @@ const Login = () => {
 	return (
 		<section className="bg-gray-100 dark:bg-gray-900 h-full">
 
-			<CSSTransition in={isContentVisible} timeout={400} classNames="content-fade-in">
+			<CSSTransition in={isContentVisible} timeout={400} classNames="content-fade-in" nodeRef={nodeRef}>
 				<>
-					<div className='h-max min-h-screen'>
+					<div ref={nodeRef} className='h-max min-h-screen'>
 						<div className="flex flex-col items-center justify-center px-6 py-8 mx-auto min-h-[95vh]">
 							<a href="/" className="flex justify-center mb-6 text-2xl font-semibold text-gray-900 dark:text-white">
 								<img className="w-40" src={logo} alt="logo" />
@@ -616,7 +617,7 @@ const Login = () => {
 						</div> */}
 								<CheckBrowserSupport.Ctx>
 									<CheckBrowserSupport.If test={(ctx) => !ctx.showWarningPortal}>
-										<p className="text-sm font-light text-gray-500 dark:text-gray-200 italic mb-2">
+										<div className="text-sm font-light text-gray-500 dark:text-gray-200 italic mb-2">
 											<CheckBrowserSupport.If test={(ctx) => ctx.browserSupported}>
 												<FaInfoCircle className="text-md inline-block text-gray-500 mr-2" />
 												<Trans
@@ -659,7 +660,7 @@ const Login = () => {
 													}}
 												/>
 											</CheckBrowserSupport.If>
-										</p>
+										</div>
 									</CheckBrowserSupport.If>
 								</CheckBrowserSupport.Ctx>
 								<div className="relative p-6 space-y-4 md:space-y-6 sm:p-8 bg-white rounded-lg shadow dark:bg-gray-800">


### PR DESCRIPTION
This PR addresses two warnings in the Login component:


1. **validateDOMNesting Warning**:
   - Replaced a `<p>` element with a `<div>` to fix invalid DOM nesting.
```
Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
at div at If (http://localhost:3000/static/js/src_pages_Login_Login_js.chunk.js:98:3)
```

2. **findDOMNode Deprecation Warning**:
   - Added a `ref` to the `CSSTransition` component to remove deprecated `findDOMNode` usage.

```
react-dom.development.js:74 Warning: findDOMNode is deprecated and will be removed in the next major release. Instead, add a ref directly to the element you want to reference. Learn more about using refs safely here: https://reactjs.org/link/strict-mode-find-node
at Transition (http://localhost:3000/static/js/vendors-node_modules_react-transition-group_esm_CSSTransition_js.chunk.js:602:30)
at CSSTransition (http://localhost:3000/static/js/vendors-node_modules_react-transition-group_esm_CSSTransition_js.chunk.js:203:35)
at section
at Login (http://localhost:3000/static/js/src_pages_Login_Login_js.chunk.js:1160:56)
```

### Changes Made
- Updated `CheckBrowserSupport` component to use `<div>` instead of `<p>`.
- Defined and used a `nodeRef` with `useRef` for `CSSTransition`.