### PR TITLE
Upgrade to ES2022 and use throw new Error instead of Promise.reject

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -545,9 +545,9 @@ export function useApi(isOnline: boolean = true): BackendApi {
 							}
 
 						} catch (e) {
-							if (e?.errorId === "prf_retry_failed") {
+							if (e?.cause?.errorId === "prf_retry_failed") {
 								return Err({ errorId: 'prfRetryFailed', retryFrom: { credential, beginData } });
-							} else if (e?.errorId === "prf_not_supported") {
+							} else if (e?.cause?.errorId === "prf_not_supported") {
 								return Err('passkeySignupPrfNotSupported');
 							} else {
 								return Err('passkeySignupKeystoreFailed');

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -353,7 +353,7 @@ const UnlockMainKey = ({
 				onUnlock(unwrappingKey, wrappedMainKey);
 			} catch (e) {
 				// Using a switch here so the t() argument can be a literal, to ease searching
-				switch (e.errorId) {
+				switch (e?.cause?.errorId) {
 					case 'passkeyInvalid':
 						setError(t('passkeyInvalid'));
 						break;

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -315,7 +315,7 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 								const [passwordKey, passwordKeyInfo] = await keystore.getPasswordKey(privateDataCache, password);
 								return [passwordKey, keystore.isAsymmetricPasswordKeyInfo(passwordKeyInfo) ? passwordKeyInfo : passwordKeyInfo.mainKey];
 							} catch {
-								return Promise.reject({ errorId: "passwordUnlockFailed" });
+								throw new Error("Failed to unlock key store", { cause: { errorId: "passwordUnlockFailed" } });
 							}
 						}
 

--- a/src/services/keystore.ts
+++ b/src/services/keystore.ts
@@ -616,18 +616,18 @@ async function getPrfOutput(
 				return await getPrfOutput(retryCred, prfInputs, async () => false);
 			} catch (err) {
 				if (err instanceof DOMException && err.name === "NotAllowedError") {
-					return Promise.reject({ errorId: "prf_retry_failed", credential });
+					throw new Error("Failed to evaluate PRF", { cause: { errorId: "prf_retry_failed", credential, err } });
 				} else {
-					return Promise.reject({ errorId: "failed" });
+					throw new Error("Failed to evaluate PRF", { cause: err });
 				}
 			}
 
 		} else {
-			return Promise.reject({ errorId: "canceled" });
+			throw new Error("Canceled by user", { cause: { errorId: "canceled" } });
 		}
 
 	} else {
-		return Promise.reject({ errorId: "prf_not_supported" });
+		throw new Error("Browser or authenticator does not support PRF", { cause: { errorId: "prf_not_supported" } });
 	}
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,8 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": [ "es2016", "dom"],                           /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": [ "es2022", "dom"],                           /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     "jsx": "preserve",                                   /* Specify what JSX code is generated. */
     "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */


### PR DESCRIPTION
This was originally motivated by one of the lints fixed in #278:

```
src/services/keystore.ts
  Line 619:6:  Expected an error object to be thrown  no-throw-literal
  Line 621:6:  Expected an error object to be thrown  no-throw-literal
  Line 626:4:  Expected an error object to be thrown  no-throw-literal
  Line 630:3:  Expected an error object to be thrown  no-throw-literal
```

I resolved this at the time by using `Promise.reject` instead of `throw`, because TypeScript is currently configured to output ES2016 code which does not have the [`cause` argument](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error#cause) in the `Error` constructor. But as explained in the [ESLint docs for no-throw-literal](https://eslint.org/docs/latest/rules/no-throw-literal):

>It is considered good practice to only throw the `Error` object itself or an object using the `Error` object as base objects for user-defined exceptions. The fundamental benefit of `Error` objects is that they automatically keep track of where they were built and originated.
