### PR TITLE
Move additional base64 encoding of WebAuthn responses to backend

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -2,7 +2,7 @@ import axios, { AxiosResponse } from 'axios';
 import { Err, Ok, Result } from 'ts-results';
 
 import * as config from '../config';
-import { jsonParseTaggedBinary, jsonStringifyTaggedBinary, toBase64Url } from '../util';
+import { fromBase64Url, jsonParseTaggedBinary, jsonStringifyTaggedBinary, toBase64Url } from '../util';
 import { makeAssertionPrfExtensionInputs, parsePrivateData, serializePrivateData } from '../services/keystore';
 import { CachedUser, LocalStorageKeystore } from '../services/LocalStorageKeystore';
 import { UserData, Verifier } from './types';
@@ -391,12 +391,12 @@ export function useApi(isOnline: boolean = true): BackendApi {
 										credential: {
 											type: credential.type,
 											id: credential.id,
-											rawId: credential.id, // SimpleWebauthn on server side expects this base64url encoded
+											rawId: credential.rawId,
 											response: {
-												authenticatorData: toBase64Url(response.authenticatorData),
-												clientDataJSON: toBase64Url(response.clientDataJSON),
-												signature: toBase64Url(response.signature),
-												userHandle: response.userHandle ? toBase64Url(response.userHandle) : cachedUser?.userHandleB64u,
+												authenticatorData: response.authenticatorData,
+												clientDataJSON: response.clientDataJSON,
+												signature: response.signature,
+												userHandle: response.userHandle ?? fromBase64Url(cachedUser?.userHandleB64u),
 											},
 											authenticatorAttachment: credential.authenticatorAttachment,
 											clientExtensionResults: credential.getClientExtensionResults(),
@@ -527,10 +527,10 @@ export function useApi(isOnline: boolean = true): BackendApi {
 									credential: {
 										type: credential.type,
 										id: credential.id,
-										rawId: credential.id, // SimpleWebauthn on server side expects this base64url encoded
+										rawId: credential.rawId,
 										response: {
-											attestationObject: toBase64Url(response.attestationObject),
-											clientDataJSON: toBase64Url(response.clientDataJSON),
+											attestationObject: response.attestationObject,
+											clientDataJSON: response.clientDataJSON,
 											transports: response.getTransports(),
 										},
 										authenticatorAttachment: credential.authenticatorAttachment,

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -171,10 +171,10 @@ const WebauthnRegistation = ({
 					credential: {
 						type: pendingCredential.type,
 						id: pendingCredential.id,
-						rawId: pendingCredential.id, // SimpleWebauthn on server side expects this base64url encoded
+						rawId: pendingCredential.rawId,
 						response: {
-							attestationObject: toBase64Url(pendingCredential.response.attestationObject),
-							clientDataJSON: toBase64Url(pendingCredential.response.clientDataJSON),
+							attestationObject: pendingCredential.response.attestationObject,
+							clientDataJSON: pendingCredential.response.clientDataJSON,
 							transports: pendingCredential.response.getTransports(),
 						},
 						authenticatorAttachment: pendingCredential.authenticatorAttachment,


### PR DESCRIPTION
I changed my mind about how to deal with issue in #291. :slightly_smiling_face:

We already have JSON body parsers configured to automatically wrap and unwrap binary data, so we don't need this encoding for the frontend's sake. That the backend uses SimpleWebauthn which expects inputs base64url encoded is an implementation detail that should not leak into the API exposed to the frontend.

This is mutually dependent on:
- https://github.com/wwWallet/wallet-backend-server/pull/61