### PR TITLE
Fix console warnings for react-modal and title attribute

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect, useContext, useRef } from 'react';
 import Sidebar from './Sidebar';
 import { AiOutlineMenu } from "react-icons/ai";
 import { FaExclamationTriangle, FaTimes } from 'react-icons/fa';
@@ -25,6 +25,7 @@ const Layout = ({ children, isPermissionGranted, tokenSentInSession }) => {
 	const [isMessageGrantedVisible, setIsMessageGrantedVisible,] = api.useClearOnClearSession(useSessionStorage('isMessageGrantedVisible', false));
 	const [isMessageOfflineVisible, setIsMessageOfflineVisible,] = api.useClearOnClearSession(useSessionStorage('isMessageOfflineVisible', false));
 	const { t } = useTranslation();
+	const nodeRef = useRef(null);
 
 	const handleNavigate = (path) => {
 		if (location.pathname === path) {
@@ -168,8 +169,11 @@ const Layout = ({ children, isPermissionGranted, tokenSentInSession }) => {
 						classNames="content-fade-in"
 						appear
 						key={location.pathname}
+						nodeRef={nodeRef}
 					>
-						{children}
+						<div ref={nodeRef}>
+							{children}
+						</div>
 					</CSSTransition>
 				</div>
 			</div>

--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,12 @@ import { OnlineStatusProvider } from './context/OnlineStatusContext';
 import { initializeDataSource } from './indexedDB';
 import * as offlineSW from './offlineRegistrationSW';
 import * as firebaseSW from './firebase';
+import Modal from 'react-modal';
 import './index.css';
 
 ConsoleBehavior();
+
+Modal.setAppElement('#root');
 
 const RootComponent = () => {
 	useEffect(() => {

--- a/src/pages/AddCredentials/AddCredentials.js
+++ b/src/pages/AddCredentials/AddCredentials.js
@@ -158,7 +158,7 @@ const Issuers = () => {
 								style={{ wordBreak: 'break-all' }}
 								onClick={() => handleIssuerClick(issuer.did)}
 								disabled={!isOnline}
-								title={!isOnline && t('common.offlineTitle')}
+								title={!isOnline ? t('common.offlineTitle') : ''}
 							>
 								<div dangerouslySetInnerHTML={{ __html: highlightBestSequence(issuer.friendlyName, searchQuery) }} />
 							</button>

--- a/src/pages/SendCredentials/SendCredentials.js
+++ b/src/pages/SendCredentials/SendCredentials.js
@@ -144,7 +144,7 @@ const Verifiers = () => {
 								style={{ wordBreak: 'break-all' }}
 								onClick={() => handleVerifierClick(verifier.did)}
 								disabled={!isOnline}
-								title={!isOnline && t('common.offlineTitle')}
+								title={!isOnline ? t('common.offlineTitle') : ''}
 							>
 								<div dangerouslySetInnerHTML={{ __html: highlightBestSequence(verifier.name, searchQuery) }} />
 							</button>


### PR DESCRIPTION
### Description
This PR addresses three console warnings that were present in the application:

1. **react-modal: App element is not defined**: 
   - Added `Modal.setAppElement('#root')` to `index.js` to properly hide the main content from screen readers when modals are open, ensuring accessibility.

2. **Received `false` for a non-boolean attribute `title`**: 
   - Updated the `title` attribute in the `AddCredentials` and `SendCredentials components to conditionally render a string or empty string.

3. **findDOMNode is deprecated and will be removed in the next major release**: 
   - Refactored the `CSSTransition` component in the `Layout` component to use a `ref` instead of `findDOMNode`.

