### PR TITLE
Handle State and Error Parameters in URL for Error Messaging

### DIFF
--- a/src/components/useCheckURL.ts
+++ b/src/components/useCheckURL.ts
@@ -93,6 +93,19 @@ function useCheckURL(urlToCheck: string): {
 			})();
 		}
 
+		if (urlToCheck && isLoggedIn) {
+			const urlParams = new URLSearchParams(window.location.search);
+			const state = urlParams.get('state');
+			const error = urlParams.get('error');
+			const errorDescription = urlParams.get('error_description');
+
+			if (state && error) {
+				setTextMessagePopup({ title: error, description: errorDescription });
+				setTypeMessagePopup('error');
+				setMessagePopup(true);
+			}
+		}
+
 	}, [api, keystore, t, urlToCheck, isLoggedIn]);
 
 	useEffect(() => {


### PR DESCRIPTION
This PR enhances the `useCheckURL` hook by adding handling for `state` and `error` parameters in the URL. When these parameters are present, the hook will now display an appropriate error message.

example url: 
`localhost:3000/?error_description=Identification failed&error=access_denied&state=eyJ1c2VySG...............`