### PR TITLE
Passing user data on password unlocking (alternative 2)

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -280,7 +280,7 @@ export function useApi(isOnline: boolean = true): BackendApi {
 			async function signup(username: string, password: string, keystore: LocalStorageKeystore): Promise<Result<void, any>> {
 
 				try {
-					const { publicData, privateData } = await keystore.initPassword(password);
+					const { publicData, privateData, setUserHandleB64u } = await keystore.initPassword(password);
 
 					try {
 						const response = updatePrivateDataEtag(await post('/user/register', {
@@ -290,6 +290,7 @@ export function useApi(isOnline: boolean = true): BackendApi {
 							keys: publicData,
 							privateData: serializePrivateData(privateData),
 						}));
+						setUserHandleB64u(toBase64Url(new TextEncoder().encode(response.data.webauthnUserHandle)));
 						await setSession(response, null, 'signup', true);
 						return Ok.EMPTY;
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -242,7 +242,7 @@ export function useApi(isOnline: boolean = true): BackendApi {
 					const userData = response.data as UserData;
 					const privateData = await parsePrivateData(userData.privateData);
 					try {
-						const updatePrivateData = await keystore.unlockPassword(privateData, password);
+						const updatePrivateData = await keystore.unlockPassword(privateData, password, { displayName: userData.displayName, userHandle: new TextEncoder().encode(userData.webauthnUserHandle) });
 						if (updatePrivateData) {
 							const [newPrivateData, keystoreCommit] = updatePrivateData;
 							try {

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -403,7 +403,7 @@ const WebauthnSignupLogin = ({
 
 						{isLogin && (
 							<ul className="overflow-y-auto max-h-24 p-2 custom-scrollbar">
-								{cachedUsers.map((cachedUser) => (
+								{cachedUsers.filter(cachedUser => cachedUser?.prfKeys?.length > 0).map((cachedUser) => (
 									<li
 										key={cachedUser.userHandleB64u}
 										className="w-full flex flex-row flex-nowrap mb-2"

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -51,6 +51,7 @@ export interface LocalStorageKeystore {
 	unlockPassword(
 		privateData: EncryptedContainer,
 		password: string,
+		user: UserData,
 	): Promise<[EncryptedContainer, CommitCallback] | null>,
 	unlockPrf(
 		privateData: EncryptedContainer,
@@ -259,9 +260,10 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 				unlockPassword: async (
 					privateData: EncryptedContainer,
 					password: string,
+					user: UserData,
 				): Promise<[EncryptedContainer, CommitCallback] | null> => {
 					const [unlockResult, newPrivateData] = await keystore.unlockPassword(privateData, password);
-					await finishUnlock(unlockResult, null);
+					await finishUnlock(unlockResult, user);
 					return (
 						newPrivateData
 							?

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -35,6 +35,7 @@ export interface LocalStorageKeystore {
 	initPassword(password: string): Promise<{
 		publicData: PublicData,
 		privateData: EncryptedContainer,
+		setUserHandleB64u: (userHandleB64u: string) => void,
 	}>,
 	initPrf(
 		credential: PublicKeyCredential,
@@ -217,9 +218,10 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 				initPassword: async (password: string): Promise<{
 					publicData: PublicData,
 					privateData: EncryptedContainer,
+					setUserHandleB64u: (userHandleB64u: string) => void,
 				}> => {
 					const { mainKey, keyInfo } = await keystore.initPassword(password);
-					return await init(mainKey, keyInfo, null);
+					return { ...await init(mainKey, keyInfo, null), setUserHandleB64u };
 				},
 
 				initPrf: async (


### PR DESCRIPTION
@kkmanos This is what I meant in https://github.com/wwWallet/wallet-frontend/pull/296#issuecomment-2271320238.

I went with `initPassword` returning a `setUserHandleB64u` callback function instead of exposing it on the `LocalStorageKeystore` API, since it should only be relevant in this particular case.