### PR TITLE
Don't remove old localStorage items anymore

### DIFF
--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -83,12 +83,6 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 	const [privateDataJwe, setPrivateDataJwe, clearPrivateDataJwe] = useSessionStorage<string | null>("privateDataJwe", null);
 	const clearSessionStorage = useClearStorages(clearUserHandleB64u, clearSessionKey, clearPrivateDataJwe);
 
-	useEffect(() => {
-		// Moved from local storage to session storage
-		window?.localStorage?.removeItem("userHandle");
-		window?.localStorage?.removeItem("webauthnRpId");
-	}, []);
-
 	const idb = useIndexedDb("wallet-frontend", 2, useCallback((db, prevVersion, newVersion) => {
 		if (prevVersion < 1) {
 			const objectStore = db.createObjectStore("keys", { keyPath: "id" });


### PR DESCRIPTION
This interferes with the `globalUserHandleB64u` state which also uses the `"userHandle"` key in local storage. The RP ID is not privacy sensitive, so we don't really need to clear it either.