### PR TITLE
Update Online Status Check to Use Navigator Connection Downlink

### DIFF
--- a/src/context/OnlineStatusContext.js
+++ b/src/context/OnlineStatusContext.js
@@ -3,10 +3,10 @@ import React, { useEffect, createContext, useState } from 'react';
 const OnlineStatusContext = createContext();
 
 export const OnlineStatusProvider = ({ children }) => {
-	const [isOnline, setIsOnline] = useState(() => navigator.onLine && navigator.connection?.type !== "unknown");
+	const [isOnline, setIsOnline] = useState(() => navigator.onLine && (navigator.connection?.downlink ?? 0) !== 0);
 
 	const updateOnlineStatus = () => {
-		setIsOnline(navigator.onLine && navigator.connection?.type !== "unknown");
+		setIsOnline(navigator.onLine && (navigator.connection?.downlink ?? 0) !== 0);
 	};
 
 	useEffect(() => {


### PR DESCRIPTION
This PR updates the online status check mechanism in the OnlineStatusProvider component. Previously, the online status was determined using `navigator.onLine` and `navigator.connection?.type !== "unknown"`. This has been changed to use `navigator.onLine` and `navigator.connection?.downlink !== 0` to provide a more accurate determination of the online status.
