### PR TITLE
Move LocalStorageKeystore to SessionContext and remove useMemo

### DIFF
--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -1,7 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useApi } from '../api';
-import { useLocalStorageKeystore } from '../services/LocalStorageKeystore';
 import { fetchToken } from '../firebase';
 import Layout from './Layout';
 import Spinner from './Spinner'; // Import your spinner component
@@ -11,11 +10,10 @@ import SessionContext from '../context/SessionContext';
 
 const PrivateRoute = ({ children }) => {
 	const { isOnline } = useContext(OnlineStatusContext);
-	const { isLoggedIn, logout } = useContext(SessionContext);
+	const { isLoggedIn, keystore, logout } = useContext(SessionContext);
 	const api = useApi(isOnline);
 	const [isPermissionGranted, setIsPermissionGranted] = useState(null);
 	const [loading, setLoading] = useState(false);
-	const keystore = useLocalStorageKeystore();
 	const [tokenSentInSession, setTokenSentInSession,] = api.useClearOnClearSession(useSessionStorage('tokenSentInSession', null));
 	const [latestIsOnlineStatus, setLatestIsOnlineStatus,] = api.useClearOnClearSession(useSessionStorage('latestIsOnlineStatus', null));
 	const cachedUsers = keystore.getCachedUsers();

--- a/src/components/useCheckURL.ts
+++ b/src/components/useCheckURL.ts
@@ -1,6 +1,5 @@
 import { useEffect, useState, Dispatch, SetStateAction, useContext } from 'react';
 import { useApi } from '../api';
-import { useLocalStorageKeystore } from '../services/LocalStorageKeystore';
 import { useTranslation } from 'react-i18next';
 import SessionContext from '../context/SessionContext';
 
@@ -27,7 +26,7 @@ function useCheckURL(urlToCheck: string): {
 	typeMessagePopup: string;
 } {
 	const api = useApi();
-	const { isLoggedIn } = useContext(SessionContext);
+	const { isLoggedIn, keystore } = useContext(SessionContext);
 	const [showSelectCredentialsPopup, setShowSelectCredentialsPopup] = useState<boolean>(false);
 	const [showPinInputPopup, setShowPinInputPopup] = useState<boolean>(false);
 	const [selectionMap, setSelectionMap] = useState<string | null>(null);
@@ -36,7 +35,6 @@ function useCheckURL(urlToCheck: string): {
 	const [showMessagePopup, setMessagePopup] = useState<boolean>(false);
 	const [textMessagePopup, setTextMessagePopup] = useState<{ title: string, description: string }>({ title: "", description: "" });
 	const [typeMessagePopup, setTypeMessagePopup] = useState<string>("");
-	const keystore = useLocalStorageKeystore();
 	const { t } = useTranslation();
 
 	useEffect(() => {

--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -1,15 +1,19 @@
 import React, { createContext } from 'react';
 import { useApi } from '../api';
 import { useLocalStorageKeystore } from '../services/LocalStorageKeystore';
+import type { LocalStorageKeystore } from '../services/LocalStorageKeystore';
+
 
 type SessionContextValue = {
 	isLoggedIn: boolean,
+	keystore: LocalStorageKeystore,
 	logout: () => Promise<void>,
 };
 
 const SessionContext: React.Context<SessionContextValue> = createContext({
 	isLoggedIn: false,
-	logout: async () => { },
+	keystore: undefined,
+	logout: async () => {},
 });
 
 export const SessionContextProvider = ({ children }) => {
@@ -18,6 +22,7 @@ export const SessionContextProvider = ({ children }) => {
 
 	const value: SessionContextValue = {
 		isLoggedIn: api.isLoggedIn() && keystore.isOpen(),
+		keystore,
 		logout: async () => {
 
 			// Clear URL parameters

--- a/src/hoc/handleServerMessagesGuard.js
+++ b/src/hoc/handleServerMessagesGuard.js
@@ -2,11 +2,11 @@ import React, { useEffect, useRef, useState, useContext } from "react";
 
 import * as config from '../config';
 import { SignatureAction } from "../types/shared.types";
-import { useLocalStorageKeystore } from "../services/LocalStorageKeystore";
 import Spinner from '../components/Spinner';
 import { SigningRequestHandlerService } from '../services/SigningRequestHandlers';
 import { useApi } from "../api";
 import OnlineStatusContext from '../context/OnlineStatusContext';
+import SessionContext from "../context/SessionContext";
 
 
 export default function handleServerMessagesGuard(Component) {
@@ -17,9 +17,9 @@ export default function handleServerMessagesGuard(Component) {
 
 		const [handshakeEstablished, setHandshakeEstablished] = useState(false);
 		const socketRef = useRef(null);
-		const keystore = useLocalStorageKeystore();
 		const signingRequestHandlerService = SigningRequestHandlerService();
 		const { isOnline } = useContext(OnlineStatusContext);
+		const { keystore } = useContext(SessionContext);
 
 		useEffect(() => {
 			if (appToken) {

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -9,7 +9,6 @@ import { CSSTransition } from 'react-transition-group';
 import * as config from '../../config';
 import OnlineStatusContext from '../../context/OnlineStatusContext';
 import { useApi } from '../../api';
-import { useLocalStorageKeystore } from '../../services/LocalStorageKeystore';
 import logo from '../../assets/images/logo.png';
 import GetButton from '../../components/Buttons/GetButton';
 import { PiWifiHighBold, PiWifiSlashBold } from "react-icons/pi";
@@ -110,6 +109,7 @@ const WebauthnSignupLogin = ({
 	setIsSubmitting,
 }) => {
 	const { isOnline } = useContext(OnlineStatusContext);
+	const { keystore } = useContext(SessionContext);
 
 	const api = useApi(isOnline);
 	const [inProgress, setInProgress] = useState(false);
@@ -123,7 +123,6 @@ const WebauthnSignupLogin = ({
 	const from = location.state?.from || '/';
 
 	const { t } = useTranslation();
-	const keystore = useLocalStorageKeystore();
 	const [retrySignupFrom, setRetrySignupFrom] = useState(null);
 
 	const cachedUsers = keystore.getCachedUsers();
@@ -471,7 +470,7 @@ const WebauthnSignupLogin = ({
 
 const Login = () => {
 	const { isOnline } = useContext(OnlineStatusContext);
-	const { isLoggedIn } = useContext(SessionContext);
+	const { isLoggedIn, keystore } = useContext(SessionContext);
 	const api = useApi(isOnline);
 	const { t } = useTranslation();
 	const location = useLocation();
@@ -490,7 +489,6 @@ const Login = () => {
 	const nodeRef = useRef(null);
 
 	const navigate = useNavigate();
-	const keystore = useLocalStorageKeystore();
 
 	useEffect(() => {
 		if (isLoggedIn) {

--- a/src/pages/Login/LoginState.js
+++ b/src/pages/Login/LoginState.js
@@ -6,7 +6,6 @@ import { Trans, useTranslation } from 'react-i18next';
 import { CSSTransition } from 'react-transition-group';
 import OnlineStatusContext from '../../context/OnlineStatusContext';
 import { useApi } from '../../api';
-import { useLocalStorageKeystore } from '../../services/LocalStorageKeystore';
 import logo from '../../assets/images/logo.png';
 import GetButton from '../../components/Buttons/GetButton';
 import { PiWifiHighBold, PiWifiSlashBold } from "react-icons/pi";
@@ -17,13 +16,13 @@ const WebauthnLogin = ({
 	filteredUser,
 }) => {
 	const { isOnline } = useContext(OnlineStatusContext);
+	const { keystore } = useContext(SessionContext);
 	const api = useApi(isOnline);
 	const [error, setError] = useState('');
 	const navigate = useNavigate();
 	const location = useLocation();
 	const from = location.state?.from || '/';
 	const { t } = useTranslation();
-	const keystore = useLocalStorageKeystore();
 
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -104,12 +103,11 @@ const WebauthnLogin = ({
 
 const LoginState = () => {
 	const { isOnline } = useContext(OnlineStatusContext);
-	const { isLoggedIn } = useContext(SessionContext);
+	const { isLoggedIn, keystore } = useContext(SessionContext);
 	const { t } = useTranslation();
 	const location = useLocation();
 
 	const [isContentVisible, setIsContentVisible] = useState(false);
-	const keystore = useLocalStorageKeystore();
 	const cachedUsers = keystore.getCachedUsers();
 	const from = location.state?.from;
 

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -9,7 +9,6 @@ import { compareBy, toBase64Url } from '../../util';
 import { formatDate } from '../../functions/DateFormat';
 import type { WebauthnPrfEncryptionKeyInfo, WrappedKeyInfo } from '../../services/keystore';
 import { isPrfKeyV2, serializePrivateData } from '../../services/keystore';
-import { useLocalStorageKeystore } from '../../services/LocalStorageKeystore';
 import DeletePopup from '../../components/Popups/DeletePopup';
 import GetButton from '../../components/Buttons/GetButton';
 import OnlineStatusContext from '../../context/OnlineStatusContext';
@@ -91,6 +90,7 @@ const WebauthnRegistation = ({
 	wrappedMainKey?: WrappedKeyInfo,
 }) => {
 	const { isOnline } = useContext(OnlineStatusContext) as OnlineStatusContextType;
+	const { keystore } = useContext(SessionContext);
 	const api = useApi();
 	const [beginData, setBeginData] = useState(null);
 	const [pendingCredential, setPendingCredential] = useState(null);
@@ -100,7 +100,6 @@ const WebauthnRegistation = ({
 	const [resolvePrfRetryPrompt, setResolvePrfRetryPrompt] = useState<null | ((accept: boolean) => void)>(null);
 	const [prfRetryAccepted, setPrfRetryAccepted] = useState(false);
 	const { t } = useTranslation();
-	const keystore = useLocalStorageKeystore();
 	const unlocked = Boolean(unwrappingKey && wrappedMainKey);
 
 	const stateChooseNickname = Boolean(beginData) && !needPrfRetry;
@@ -325,12 +324,12 @@ const UnlockMainKey = ({
 	unlocked: boolean,
 }) => {
 	const { isOnline } = useContext(OnlineStatusContext) as OnlineStatusContextType;
+	const { keystore } = useContext(SessionContext);
 	const [inProgress, setInProgress] = useState(false);
 	const [resolvePasswordPromise, setResolvePasswordPromise] = useState<((password: string) => void) | null>(null);
 	const [isSubmittingPassword, setIsSubmittingPassword] = useState(false);
 	const [password, setPassword] = useState('');
 	const [error, setError] = useState('');
-	const keystore = useLocalStorageKeystore();
 	const { t } = useTranslation();
 	const isPromptingForPassword = Boolean(resolvePasswordPromise);
 
@@ -683,7 +682,7 @@ const WebauthnCredentialItem = ({
 
 const Settings = () => {
 	const { isOnline } = useContext(OnlineStatusContext) as OnlineStatusContextType;
-	const { logout } = useContext(SessionContext);
+	const { logout, keystore } = useContext(SessionContext);
 	const api = useApi(isOnline);
 	const [userData, setUserData] = useState<UserData>(null);
 	const { webauthnCredentialCredentialId: loggedInPasskeyCredentialId } = api.getSession();
@@ -691,7 +690,6 @@ const Settings = () => {
 	const [wrappedMainKey, setWrappedMainKey] = useState<WrappedKeyInfo | null>(null);
 	const unlocked = Boolean(unwrappingKey && wrappedMainKey);
 	const showDelete = userData?.webauthnCredentials?.length > 1;
-	const keystore = useLocalStorageKeystore();
 	const { t } = useTranslation();
 	const [isDeleteConfirmationOpen, setIsDeleteConfirmationOpen] = useState(false);
 	const [loading, setLoading] = useState(false);

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect } from "react";
 
 import * as config from "../config";
 import { useClearStorages, useLocalStorage, useSessionStorage } from "../components/useStorage";
@@ -145,268 +145,253 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 		[close, closeTabLocal, privateData, userHandleB64u, globalUserHandleB64u, setCachedUsers],
 	);
 
-	return useMemo(
-		() => {
-			const openPrivateData = async (): Promise<[PrivateData, CryptoKey]> => {
-				if (mainKey && privateData) {
-					return await keystore.openPrivateData(mainKey, privateData)
-				} else {
-					throw new Error("Private data not present in storage.");
+	const openPrivateData = async (): Promise<[PrivateData, CryptoKey]> => {
+		if (mainKey && privateData) {
+			return await keystore.openPrivateData(mainKey, privateData)
+		} else {
+			throw new Error("Private data not present in storage.");
+		}
+	};
+
+	const editPrivateData = async <T>(
+		action: (container: OpenedContainer) => Promise<[T, OpenedContainer]>,
+	): Promise<[T, AsymmetricEncryptedContainer, CommitCallback]> => {
+		if (mainKey && privateData) {
+			const [result, [newPrivateData, newMainKey]] = await action(
+				[
+					keystore.assertAsymmetricEncryptedContainer(privateData),
+					await keystore.importMainKey(mainKey),
+				],
+			);
+			return [
+				result,
+				newPrivateData,
+				async () => {
+					setPrivateData(newPrivateData);
+					setMainKey(await keystore.exportMainKey(newMainKey));
+				},
+			];
+		} else {
+			throw new Error("Private data not present in storage.");
+		}
+	};
+
+	const finishUnlock = async (
+		{ exportedMainKey, privateData }: UnlockSuccess,
+		user: CachedUser | UserData | null,
+	): Promise<void> => {
+		setMainKey(exportedMainKey);
+		setPrivateData(privateData);
+
+		if (user) {
+			const userHandleB64u = ("prfKeys" in user
+				? user.userHandleB64u
+				: toBase64Url(user.userHandle)
+			);
+			const newUser = ("prfKeys" in user
+				? user
+				: {
+					displayName: user.displayName,
+					userHandleB64u,
+					prfKeys: [], // Placeholder - will be updated by useEffect above
 				}
-			};
+			);
 
-			const editPrivateData = async <T>(
-				action: (container: OpenedContainer) => Promise<[T, OpenedContainer]>,
-			): Promise<[T, AsymmetricEncryptedContainer, CommitCallback]> => {
-				if (mainKey && privateData) {
-					const [result, [newPrivateData, newMainKey]] = await action(
-						[
-							keystore.assertAsymmetricEncryptedContainer(privateData),
-							await keystore.importMainKey(mainKey),
-						],
-					);
-					return [
-						result,
-						newPrivateData,
-						async () => {
-							setPrivateData(newPrivateData);
-							setMainKey(await keystore.exportMainKey(newMainKey));
-						},
-					];
-				} else {
-					throw new Error("Private data not present in storage.");
-				}
-			};
+			setUserHandleB64u(userHandleB64u);
+			setGlobalUserHandleB64u(userHandleB64u);
+			setCachedUsers((cachedUsers) => {
+				// Move most recently used user to front of list
+				const otherUsers = (cachedUsers || []).filter((cu) => cu.userHandleB64u !== newUser.userHandleB64u);
+				return [newUser, ...otherUsers];
+			});
+		}
+	};
 
-			const finishUnlock = async (
-				{ exportedMainKey, privateData }: UnlockSuccess,
-				user: CachedUser | UserData | null,
-			): Promise<void> => {
-				setMainKey(exportedMainKey);
-				setPrivateData(privateData);
+	const init = async (
+		mainKey: CryptoKey,
+		keyInfo: AsymmetricEncryptedContainerKeys,
+		user: UserData,
+	): Promise<EncryptedContainer> => {
+		const unlocked = await keystore.init(mainKey, keyInfo);
+		await finishUnlock(unlocked, user);
+		const { privateData } = unlocked;
+		return privateData;
+	};
 
-				if (user) {
-					const userHandleB64u = ("prfKeys" in user
-						? user.userHandleB64u
-						: toBase64Url(user.userHandle)
-					);
-					const newUser = ("prfKeys" in user
-						? user
-						: {
-							displayName: user.displayName,
-							userHandleB64u,
-							prfKeys: [], // Placeholder - will be updated by useEffect above
-						}
-					);
+	return {
+		isOpen: (): boolean => privateData !== null && mainKey !== null,
+		close,
 
-					setUserHandleB64u(userHandleB64u);
-					setGlobalUserHandleB64u(userHandleB64u);
-					setCachedUsers((cachedUsers) => {
-						// Move most recently used user to front of list
-						const otherUsers = (cachedUsers || []).filter((cu) => cu.userHandleB64u !== newUser.userHandleB64u);
-						return [newUser, ...otherUsers];
-					});
-				}
-			};
-
-			const init = async (
-				mainKey: CryptoKey,
-				keyInfo: AsymmetricEncryptedContainerKeys,
-				user: UserData,
-			): Promise<EncryptedContainer> => {
-				const unlocked = await keystore.init(mainKey, keyInfo);
-				await finishUnlock(unlocked, user);
-				const { privateData } = unlocked;
-				return privateData;
-			};
-
-			return {
-				isOpen: (): boolean => privateData !== null && mainKey !== null,
-				close,
-
-				initPassword: async (password: string): Promise<[EncryptedContainer, (userHandleB64u: string) => void]> => {
-					const { mainKey, keyInfo } = await keystore.initPassword(password);
-					return [await init(mainKey, keyInfo, null), setUserHandleB64u];
-				},
-
-				initPrf: async (
-					credential: PublicKeyCredential,
-					prfSalt: Uint8Array,
-					promptForPrfRetry: () => Promise<boolean | AbortSignal>,
-					user: UserData,
-				): Promise<EncryptedContainer> => {
-					const { mainKey, keyInfo } = await keystore.initPrf(credential, prfSalt, promptForPrfRetry);
-					const result = await init(mainKey, keyInfo, user);
-					return result;
-				},
-
-				addPrf: async (
-					credential: PublicKeyCredential,
-					[existingUnwrapKey, wrappedMainKey]: [CryptoKey, WrappedKeyInfo],
-					promptForPrfRetry: () => Promise<boolean | AbortSignal>,
-				): Promise<[EncryptedContainer, CommitCallback]> => {
-					const newPrivateData = await keystore.addPrf(privateData, credential, [existingUnwrapKey, wrappedMainKey], promptForPrfRetry);
-					return [
-						newPrivateData,
-						async () => {
-							setPrivateData(newPrivateData);
-						},
-					];
-				},
-
-				deletePrf: (credentialId: Uint8Array): [EncryptedContainer, CommitCallback] => {
-					const newPrivateData = keystore.deletePrf(privateData, credentialId);
-					return [
-						newPrivateData,
-						async () => {
-							setPrivateData(newPrivateData);
-						},
-					];
-				},
-
-				unlockPassword: async (
-					privateData: EncryptedContainer,
-					password: string,
-					user: UserData,
-				): Promise<[EncryptedContainer, CommitCallback] | null> => {
-					const [unlockResult, newPrivateData] = await keystore.unlockPassword(privateData, password);
-					await finishUnlock(unlockResult, user);
-					return (
-						newPrivateData
-							?
-							[newPrivateData,
-								async () => {
-									setPrivateData(newPrivateData);
-								},
-							]
-							: null
-					);
-				},
-
-				unlockPrf: async (
-					privateData: EncryptedContainer,
-					credential: PublicKeyCredential,
-					promptForPrfRetry: () => Promise<boolean | AbortSignal>,
-					user: CachedUser | UserData | null,
-				): Promise<[EncryptedContainer, CommitCallback] | null> => {
-					const [unlockPrfResult, newPrivateData] = await keystore.unlockPrf(privateData, credential, promptForPrfRetry);
-					await finishUnlock(unlockPrfResult, user);
-					return (
-						newPrivateData
-							?
-							[newPrivateData,
-								async () => {
-									setPrivateData(newPrivateData);
-								},
-							]
-							: null
-					);
-				},
-
-				getPrfKeyInfo: (id: BufferSource): WebauthnPrfEncryptionKeyInfo | undefined => {
-					return privateData?.prfKeys.find(({ credentialId }) => toBase64Url(credentialId) === toBase64Url(id));
-				},
-
-				getPasswordOrPrfKeyFromSession: async (
-					promptForPassword: () => Promise<string | null>,
-					promptForPrfRetry: () => Promise<boolean | AbortSignal>,
-				): Promise<[CryptoKey, WrappedKeyInfo]> => {
-					if (privateData && privateData?.prfKeys?.length > 0) {
-						const [prfKey, prfKeyInfo,] = await keystore.getPrfKey(privateData, null, promptForPrfRetry);
-						return [prfKey, keystore.isPrfKeyV2(prfKeyInfo) ? prfKeyInfo : prfKeyInfo.mainKey];
-
-					} else if (privateData && privateData?.passwordKey) {
-						const password = await promptForPassword();
-						if (password === null) {
-							throw new Error("Password prompt aborted");
-						} else {
-							try {
-								const [passwordKey, passwordKeyInfo] = await keystore.getPasswordKey(privateData, password);
-								return [passwordKey, keystore.isAsymmetricPasswordKeyInfo(passwordKeyInfo) ? passwordKeyInfo : passwordKeyInfo.mainKey];
-							} catch {
-								throw new Error("Failed to unlock key store", { cause: { errorId: "passwordUnlockFailed" } });
-							}
-						}
-
-					} else {
-						throw new Error("Session not initialized");
-					}
-				},
-
-				upgradePrfKey: async (
-					prfKeyInfo: WebauthnPrfEncryptionKeyInfo,
-					promptForPrfRetry: () => Promise<boolean | AbortSignal>,
-				): Promise<[EncryptedContainer, CommitCallback]> => {
-					if (keystore.isPrfKeyV2(prfKeyInfo)) {
-						throw new Error("Key is already upgraded");
-
-					} else if (privateData) {
-						const newPrivateData = await keystore.upgradePrfKey(privateData, null, prfKeyInfo, promptForPrfRetry);
-						return [
-							newPrivateData,
-							async () => {
-								setPrivateData(newPrivateData);
-							},
-						];
-
-					} else {
-						throw new Error("Session not initialized");
-					}
-				},
-
-				getCachedUsers: (): CachedUser[] => {
-					return [...(cachedUsers || [])];
-				},
-
-				forgetCachedUser: (user: CachedUser): void => {
-					setCachedUsers((cachedUsers) => cachedUsers.filter((cu) => cu.userHandleB64u !== user.userHandleB64u));
-				},
-
-				createIdToken: async (nonce: string, audience: string): Promise<[
-					{ id_token: string; },
-					AsymmetricEncryptedContainer,
-					CommitCallback,
-				]> => (
-					await editPrivateData(async (container) =>
-						await keystore.createIdToken(
-							container,
-							config.DID_KEY_VERSION,
-							nonce,
-							audience,
-						)
-					)
-				),
-
-				signJwtPresentation: async (nonce: string, audience: string, verifiableCredentials: any[]): Promise<{ vpjwt: string }> => (
-					await keystore.signJwtPresentation(await openPrivateData(), nonce, audience, verifiableCredentials)
-				),
-
-				generateOpenid4vciProof: async (nonce: string, audience: string): Promise<[
-					{ proof_jwt: string },
-					AsymmetricEncryptedContainer,
-					CommitCallback,
-				]> => (
-					await editPrivateData(async (container) =>
-						await keystore.generateOpenid4vciProof(
-							container,
-							config.DID_KEY_VERSION,
-							nonce,
-							audience,
-						),
-					)
-				),
-			};
+		initPassword: async (password: string): Promise<[EncryptedContainer, (userHandleB64u: string) => void]> => {
+			const { mainKey, keyInfo } = await keystore.initPassword(password);
+			return [await init(mainKey, keyInfo, null), setUserHandleB64u];
 		},
-		[
-			cachedUsers,
-			close,
-			mainKey,
-			privateData,
-			setCachedUsers,
-			setGlobalUserHandleB64u,
-			setMainKey,
-			setPrivateData,
-			setUserHandleB64u,
-		],
-	);
+
+		initPrf: async (
+			credential: PublicKeyCredential,
+			prfSalt: Uint8Array,
+			promptForPrfRetry: () => Promise<boolean | AbortSignal>,
+			user: UserData,
+		): Promise<EncryptedContainer> => {
+			const { mainKey, keyInfo } = await keystore.initPrf(credential, prfSalt, promptForPrfRetry);
+			const result = await init(mainKey, keyInfo, user);
+			return result;
+		},
+
+		addPrf: async (
+			credential: PublicKeyCredential,
+			[existingUnwrapKey, wrappedMainKey]: [CryptoKey, WrappedKeyInfo],
+			promptForPrfRetry: () => Promise<boolean | AbortSignal>,
+		): Promise<[EncryptedContainer, CommitCallback]> => {
+			const newPrivateData = await keystore.addPrf(privateData, credential, [existingUnwrapKey, wrappedMainKey], promptForPrfRetry);
+			return [
+				newPrivateData,
+				async () => {
+					setPrivateData(newPrivateData);
+				},
+			];
+		},
+
+		deletePrf: (credentialId: Uint8Array): [EncryptedContainer, CommitCallback] => {
+			const newPrivateData = keystore.deletePrf(privateData, credentialId);
+			return [
+				newPrivateData,
+				async () => {
+					setPrivateData(newPrivateData);
+				},
+			];
+		},
+
+		unlockPassword: async (
+			privateData: EncryptedContainer,
+			password: string,
+			user: UserData,
+		): Promise<[EncryptedContainer, CommitCallback] | null> => {
+			const [unlockResult, newPrivateData] = await keystore.unlockPassword(privateData, password);
+			await finishUnlock(unlockResult, user);
+			return (
+				newPrivateData
+					?
+					[newPrivateData,
+						async () => {
+							setPrivateData(newPrivateData);
+						},
+					]
+					: null
+			);
+		},
+
+		unlockPrf: async (
+			privateData: EncryptedContainer,
+			credential: PublicKeyCredential,
+			promptForPrfRetry: () => Promise<boolean | AbortSignal>,
+			user: CachedUser | UserData | null,
+		): Promise<[EncryptedContainer, CommitCallback] | null> => {
+			const [unlockPrfResult, newPrivateData] = await keystore.unlockPrf(privateData, credential, promptForPrfRetry);
+			await finishUnlock(unlockPrfResult, user);
+			return (
+				newPrivateData
+					?
+					[newPrivateData,
+						async () => {
+							setPrivateData(newPrivateData);
+						},
+					]
+					: null
+			);
+		},
+
+		getPrfKeyInfo: (id: BufferSource): WebauthnPrfEncryptionKeyInfo | undefined => {
+			return privateData?.prfKeys.find(({ credentialId }) => toBase64Url(credentialId) === toBase64Url(id));
+		},
+
+		getPasswordOrPrfKeyFromSession: async (
+			promptForPassword: () => Promise<string | null>,
+			promptForPrfRetry: () => Promise<boolean | AbortSignal>,
+		): Promise<[CryptoKey, WrappedKeyInfo]> => {
+			if (privateData && privateData?.prfKeys?.length > 0) {
+				const [prfKey, prfKeyInfo,] = await keystore.getPrfKey(privateData, null, promptForPrfRetry);
+				return [prfKey, keystore.isPrfKeyV2(prfKeyInfo) ? prfKeyInfo : prfKeyInfo.mainKey];
+
+			} else if (privateData && privateData?.passwordKey) {
+				const password = await promptForPassword();
+				if (password === null) {
+					throw new Error("Password prompt aborted");
+				} else {
+					try {
+						const [passwordKey, passwordKeyInfo] = await keystore.getPasswordKey(privateData, password);
+						return [passwordKey, keystore.isAsymmetricPasswordKeyInfo(passwordKeyInfo) ? passwordKeyInfo : passwordKeyInfo.mainKey];
+					} catch {
+						throw new Error("Failed to unlock key store", { cause: { errorId: "passwordUnlockFailed" } });
+					}
+				}
+
+			} else {
+				throw new Error("Session not initialized");
+			}
+		},
+
+		upgradePrfKey: async (
+			prfKeyInfo: WebauthnPrfEncryptionKeyInfo,
+			promptForPrfRetry: () => Promise<boolean | AbortSignal>,
+		): Promise<[EncryptedContainer, CommitCallback]> => {
+			if (keystore.isPrfKeyV2(prfKeyInfo)) {
+				throw new Error("Key is already upgraded");
+
+			} else if (privateData) {
+				const newPrivateData = await keystore.upgradePrfKey(privateData, null, prfKeyInfo, promptForPrfRetry);
+				return [
+					newPrivateData,
+					async () => {
+						setPrivateData(newPrivateData);
+					},
+				];
+
+			} else {
+				throw new Error("Session not initialized");
+			}
+		},
+
+		getCachedUsers: (): CachedUser[] => {
+			return [...(cachedUsers || [])];
+		},
+
+		forgetCachedUser: (user: CachedUser): void => {
+			setCachedUsers((cachedUsers) => cachedUsers.filter((cu) => cu.userHandleB64u !== user.userHandleB64u));
+		},
+
+		createIdToken: async (nonce: string, audience: string): Promise<[
+			{ id_token: string; },
+			AsymmetricEncryptedContainer,
+			CommitCallback,
+		]> => (
+			await editPrivateData(async (container) =>
+				await keystore.createIdToken(
+					container,
+					config.DID_KEY_VERSION,
+					nonce,
+					audience,
+				)
+			)
+		),
+
+		signJwtPresentation: async (nonce: string, audience: string, verifiableCredentials: any[]): Promise<{ vpjwt: string }> => (
+			await keystore.signJwtPresentation(await openPrivateData(), nonce, audience, verifiableCredentials)
+		),
+
+		generateOpenid4vciProof: async (nonce: string, audience: string): Promise<[
+			{ proof_jwt: string },
+			AsymmetricEncryptedContainer,
+			CommitCallback,
+		]> => (
+			await editPrivateData(async (container) =>
+				await keystore.generateOpenid4vciProof(
+					container,
+					config.DID_KEY_VERSION,
+					nonce,
+					audience,
+				),
+			)
+		),
+	};
 }


### PR DESCRIPTION
`LocalStorageKeystore` is essentially a singleton, so let's pull it up into `SessionContext` so that all uses of it can be references to a single shared instance. This also lets us get rid of `useMemo`, eliminating a possible source of subtle bugs caused by stale `useMemo` dependencies.