### PR TITLE
Fix errors and lint in History.js

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -56,7 +56,7 @@ export interface BackendApi {
 	login(username: string, password: string, keystore: LocalStorageKeystore): Promise<Result<void, any>>,
 	signup(username: string, password: string, keystore: LocalStorageKeystore): Promise<Result<void, any>>,
 	getAllVerifiers(): Promise<Verifier[]>,
-	getAllPresentations(): Promise<AxiosResponse>,
+	getAllPresentations(): Promise<{ vp_list: any[] }>,
 	initiatePresentationExchange(verifier_id: number, scope_name: string): Promise<{ redirect_to?: string }>,
 
 	loginWebauthn(
@@ -343,7 +343,7 @@ export function useApi(isOnline: boolean = true): BackendApi {
 				}
 			}
 
-			async function getAllPresentations(): Promise<AxiosResponse> {
+			async function getAllPresentations(): Promise<{ vp_list: any[] }> {
 				try {
 					const result = await get('/storage/vp');
 					return result.data; // Return the Axios response.

--- a/src/pages/History/History.js
+++ b/src/pages/History/History.js
@@ -120,13 +120,13 @@ const History = () => {
 					overlayClassName="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
 				>
 					{/* Popup content */}
-					<div class="flex items-start justify-between mb-2 dark:border-gray-600">
+					<div className="flex items-start justify-between mb-2 dark:border-gray-600">
 						<h2 className="right text-lg font-bold text-primary dark:text-white">
 							{t('pageHistory.popupTitle')}
 						</h2>
-						<button type="button" class="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ml-auto inline-flex justify-center items-center dark:hover:bg-gray-600 dark:hover:text-white" onClick={() => { setImageModalOpen(false); setCurrentSlide(1); }}>
-							<svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
-								<path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6" />
+						<button type="button" className="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ml-auto inline-flex justify-center items-center dark:hover:bg-gray-600 dark:hover:text-white" onClick={() => { setImageModalOpen(false); setCurrentSlide(1); }}>
+							<svg className="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
+								<path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6" />
 							</svg>
 						</button>
 					</div>

--- a/src/pages/History/History.js
+++ b/src/pages/History/History.js
@@ -138,8 +138,7 @@ const History = () => {
 							{matchingCredentials.map((vcEntity, index) => (
 								<>
 									<React.Fragment key={vcEntity.id}>
-										{(currentSlide === index + 1 ? 'button' : 'div')
-											.split()
+										{[currentSlide === index + 1 ? 'button' : 'div']
 											.map(Tag => (
 												<>
 													<div

--- a/src/pages/History/History.js
+++ b/src/pages/History/History.js
@@ -141,7 +141,6 @@ const History = () => {
 									<React.Fragment key={vcEntity}>
 										<div
 											className="relative rounded-xl xl:w-full md:w-full sm:w-full overflow-hidden transition-shadow shadow-md hover:shadow-lg w-full mb-2"
-											aria-label={`${vcEntity.friendlyName}`}
 										>
 											<CredentialImage credential={vcEntity} className={"w-full h-full object-cover rounded-xl"} />
 										</div>

--- a/src/pages/History/History.js
+++ b/src/pages/History/History.js
@@ -135,50 +135,48 @@ const History = () => {
 					{/* Display presented credentials */}
 					<div className=" py-2">
 						<Slider ref={sliderRef} {...settings}>
-							{matchingCredentials.map((vcEntity, index) => (
-								<React.Fragment key={vcEntity.id}>
-									{[currentSlide === index + 1 ? 'button' : 'div']
-										.map(Tag => (
-											<>
-												<div
-													className="relative rounded-xl xl:w-full md:w-full sm:w-full overflow-hidden transition-shadow shadow-md hover:shadow-lg w-full mb-2"
-													aria-label={`${vcEntity.friendlyName}`}
-												>
-													<CredentialImage credential={vcEntity} className={"w-full h-full object-cover rounded-xl"} />
-												</div>
-												<div className="flex items-center justify-end">
-													<span className="mr-4 dark:text-white">{currentSlide} of {matchingCredentials.length}</span>
-													<Tag
-														onClick={() => sliderRef.current.slickPrev()}
-														aria-label={currentSlide === 1 ? t('pageCredentials.slideButtonAriaLabelDisable', { direction: t('pageCredentials.slidePrevious') }) : t('pageCredentials.slideButtonAriaLabelEnable', { direction: t('pageCredentials.slidePrevious') })}
-														title={currentSlide === 1 ? t('pageCredentials.slideButtonTitleDisable', { direction: t('pageCredentials.slidePrevious') }) : t('pageCredentials.slideButtonTitleEnable', { direction: t('pageCredentials.slidePrevious') })}
-														disabled={currentSlide === 1}
-														className={`${currentSlide === 1 ? 'opacity-50 cursor-not-allowed dark:text-gray-400' : 'text-primary dark:text-white hover:text-primary-hover dark:hover:text-gray-300'}`}
-													>
-														<BiLeftArrow size={22} />
-													</Tag>
-													<Tag
-														onClick={() => sliderRef.current.slickNext()}
-														aria-label={currentSlide === matchingCredentials.length ? t('pageCredentials.slideButtonAriaLabelDisable', { direction: t('pageCredentials.slideNext') }) : t('pageCredentials.slideButtonAriaLabelEnable', { direction: t('pageCredentials.slideNext') })}
-														title={currentSlide === matchingCredentials.length ? t('pageCredentials.slideButtonTitleDisable', { direction: t('pageCredentials.slideNext') }) : t('pageCredentials.slideButtonTitleEnable', { direction: t('pageCredentials.slideNext') })}
-														disabled={currentSlide === matchingCredentials.length}
-														className={`${currentSlide === matchingCredentials.length ? 'opacity-50 cursor-not-allowed dark:text-gray-400' : 'text-primary dark:text-white hover:text-primary-hover dark:hover:text-primary-light-hover dark:hover:text-gray-300'}`}
-													>
-														<BiRightArrow size={22} />
-													</Tag>
-												</div>
-											</>
-										))}
-
-									<div className='h-[30vh]'>
-
-										<div className={`transition-all ease-in-out duration-500 ${(currentSlide === index + 1) ? 'max-h-[30vh] overflow-y-auto rounded-md custom-scrollbar my-2 bg-gray-800" opacity-100' : 'max-h-0 opacity-0'}`}>
-											<CredentialInfo credential={vcEntity} />
+							{matchingCredentials.map((vcEntity, index) => {
+								const Tag = currentSlide === index + 1 ? 'button' : 'div';
+								return (
+									<React.Fragment key={vcEntity.id}>
+										<div
+											className="relative rounded-xl xl:w-full md:w-full sm:w-full overflow-hidden transition-shadow shadow-md hover:shadow-lg w-full mb-2"
+											aria-label={`${vcEntity.friendlyName}`}
+										>
+											<CredentialImage credential={vcEntity} className={"w-full h-full object-cover rounded-xl"} />
 										</div>
-									</div>
+										<div className="flex items-center justify-end">
+											<span className="mr-4 dark:text-white">{currentSlide} of {matchingCredentials.length}</span>
+											<Tag
+												onClick={() => sliderRef.current.slickPrev()}
+												aria-label={currentSlide === 1 ? t('pageCredentials.slideButtonAriaLabelDisable', { direction: t('pageCredentials.slidePrevious') }) : t('pageCredentials.slideButtonAriaLabelEnable', { direction: t('pageCredentials.slidePrevious') })}
+												title={currentSlide === 1 ? t('pageCredentials.slideButtonTitleDisable', { direction: t('pageCredentials.slidePrevious') }) : t('pageCredentials.slideButtonTitleEnable', { direction: t('pageCredentials.slidePrevious') })}
+												disabled={currentSlide === 1}
+												className={`${currentSlide === 1 ? 'opacity-50 cursor-not-allowed dark:text-gray-400' : 'text-primary dark:text-white hover:text-primary-hover dark:hover:text-gray-300'}`}
+											>
+												<BiLeftArrow size={22} />
+											</Tag>
+											<Tag
+												onClick={() => sliderRef.current.slickNext()}
+												aria-label={currentSlide === matchingCredentials.length ? t('pageCredentials.slideButtonAriaLabelDisable', { direction: t('pageCredentials.slideNext') }) : t('pageCredentials.slideButtonAriaLabelEnable', { direction: t('pageCredentials.slideNext') })}
+												title={currentSlide === matchingCredentials.length ? t('pageCredentials.slideButtonTitleDisable', { direction: t('pageCredentials.slideNext') }) : t('pageCredentials.slideButtonTitleEnable', { direction: t('pageCredentials.slideNext') })}
+												disabled={currentSlide === matchingCredentials.length}
+												className={`${currentSlide === matchingCredentials.length ? 'opacity-50 cursor-not-allowed dark:text-gray-400' : 'text-primary dark:text-white hover:text-primary-hover dark:hover:text-primary-light-hover dark:hover:text-gray-300'}`}
+											>
+												<BiRightArrow size={22} />
+											</Tag>
+										</div>
 
-								</React.Fragment>
-							))}
+										<div className='h-[30vh]'>
+
+											<div className={`transition-all ease-in-out duration-500 ${(currentSlide === index + 1) ? 'max-h-[30vh] overflow-y-auto rounded-md custom-scrollbar my-2 bg-gray-800" opacity-100' : 'max-h-0 opacity-0'}`}>
+												<CredentialInfo credential={vcEntity} />
+											</div>
+										</div>
+
+									</React.Fragment>
+								);
+							})}
 						</Slider>
 					</div>
 				</Modal>

--- a/src/pages/History/History.js
+++ b/src/pages/History/History.js
@@ -136,42 +136,40 @@ const History = () => {
 					<div className=" py-2">
 						<Slider ref={sliderRef} {...settings}>
 							{matchingCredentials.map((vcEntity, index) => (
-								<>
-									<React.Fragment key={vcEntity.id}>
-										{[currentSlide === index + 1 ? 'button' : 'div']
-											.map(Tag => (
-												<>
-													<div
-														className="relative rounded-xl xl:w-full md:w-full sm:w-full overflow-hidden transition-shadow shadow-md hover:shadow-lg w-full mb-2"
-														aria-label={`${vcEntity.friendlyName}`}
+								<React.Fragment key={vcEntity.id}>
+									{[currentSlide === index + 1 ? 'button' : 'div']
+										.map(Tag => (
+											<>
+												<div
+													className="relative rounded-xl xl:w-full md:w-full sm:w-full overflow-hidden transition-shadow shadow-md hover:shadow-lg w-full mb-2"
+													aria-label={`${vcEntity.friendlyName}`}
+												>
+													<CredentialImage credential={vcEntity} className={"w-full h-full object-cover rounded-xl"} />
+												</div>
+												<div className="flex items-center justify-end">
+													<span className="mr-4 dark:text-white">{currentSlide} of {matchingCredentials.length}</span>
+													<Tag
+														onClick={() => sliderRef.current.slickPrev()}
+														aria-label={currentSlide === 1 ? t('pageCredentials.slideButtonAriaLabelDisable', { direction: t('pageCredentials.slidePrevious') }) : t('pageCredentials.slideButtonAriaLabelEnable', { direction: t('pageCredentials.slidePrevious') })}
+														title={currentSlide === 1 ? t('pageCredentials.slideButtonTitleDisable', { direction: t('pageCredentials.slidePrevious') }) : t('pageCredentials.slideButtonTitleEnable', { direction: t('pageCredentials.slidePrevious') })}
+														disabled={currentSlide === 1}
+														className={`${currentSlide === 1 ? 'opacity-50 cursor-not-allowed dark:text-gray-400' : 'text-primary dark:text-white hover:text-primary-hover dark:hover:text-gray-300'}`}
 													>
-														<CredentialImage credential={vcEntity} className={"w-full h-full object-cover rounded-xl"} />
-													</div>
-													<div className="flex items-center justify-end">
-														<span className="mr-4 dark:text-white">{currentSlide} of {matchingCredentials.length}</span>
-														<Tag
-															onClick={() => sliderRef.current.slickPrev()}
-															aria-label={currentSlide === 1 ? t('pageCredentials.slideButtonAriaLabelDisable', { direction: t('pageCredentials.slidePrevious') }) : t('pageCredentials.slideButtonAriaLabelEnable', { direction: t('pageCredentials.slidePrevious') })}
-															title={currentSlide === 1 ? t('pageCredentials.slideButtonTitleDisable', { direction: t('pageCredentials.slidePrevious') }) : t('pageCredentials.slideButtonTitleEnable', { direction: t('pageCredentials.slidePrevious') })}
-															disabled={currentSlide === 1}
-															className={`${currentSlide === 1 ? 'opacity-50 cursor-not-allowed dark:text-gray-400' : 'text-primary dark:text-white hover:text-primary-hover dark:hover:text-gray-300'}`}
-														>
-															<BiLeftArrow size={22} />
-														</Tag>
-														<Tag
-															onClick={() => sliderRef.current.slickNext()}
-															aria-label={currentSlide === matchingCredentials.length ? t('pageCredentials.slideButtonAriaLabelDisable', { direction: t('pageCredentials.slideNext') }) : t('pageCredentials.slideButtonAriaLabelEnable', { direction: t('pageCredentials.slideNext') })}
-															title={currentSlide === matchingCredentials.length ? t('pageCredentials.slideButtonTitleDisable', { direction: t('pageCredentials.slideNext') }) : t('pageCredentials.slideButtonTitleEnable', { direction: t('pageCredentials.slideNext') })}
-															disabled={currentSlide === matchingCredentials.length}
-															className={`${currentSlide === matchingCredentials.length ? 'opacity-50 cursor-not-allowed dark:text-gray-400' : 'text-primary dark:text-white hover:text-primary-hover dark:hover:text-primary-light-hover dark:hover:text-gray-300'}`}
-														>
-															<BiRightArrow size={22} />
-														</Tag>
-													</div>
-												</>
-											))}
+														<BiLeftArrow size={22} />
+													</Tag>
+													<Tag
+														onClick={() => sliderRef.current.slickNext()}
+														aria-label={currentSlide === matchingCredentials.length ? t('pageCredentials.slideButtonAriaLabelDisable', { direction: t('pageCredentials.slideNext') }) : t('pageCredentials.slideButtonAriaLabelEnable', { direction: t('pageCredentials.slideNext') })}
+														title={currentSlide === matchingCredentials.length ? t('pageCredentials.slideButtonTitleDisable', { direction: t('pageCredentials.slideNext') }) : t('pageCredentials.slideButtonTitleEnable', { direction: t('pageCredentials.slideNext') })}
+														disabled={currentSlide === matchingCredentials.length}
+														className={`${currentSlide === matchingCredentials.length ? 'opacity-50 cursor-not-allowed dark:text-gray-400' : 'text-primary dark:text-white hover:text-primary-hover dark:hover:text-primary-light-hover dark:hover:text-gray-300'}`}
+													>
+														<BiRightArrow size={22} />
+													</Tag>
+												</div>
+											</>
+										))}
 
-									</React.Fragment>
 									<div className='h-[30vh]'>
 
 										<div className={`transition-all ease-in-out duration-500 ${(currentSlide === index + 1) ? 'max-h-[30vh] overflow-y-auto rounded-md custom-scrollbar my-2 bg-gray-800" opacity-100' : 'max-h-0 opacity-0'}`}>
@@ -179,7 +177,7 @@ const History = () => {
 										</div>
 									</div>
 
-								</>
+								</React.Fragment>
 							))}
 						</Slider>
 					</div>

--- a/src/pages/History/History.js
+++ b/src/pages/History/History.js
@@ -138,7 +138,7 @@ const History = () => {
 							{matchingCredentials.map((vcEntity, index) => {
 								const Tag = currentSlide === index + 1 ? 'button' : 'div';
 								return (
-									<React.Fragment key={vcEntity.id}>
+									<React.Fragment key={vcEntity}>
 										<div
 											className="relative rounded-xl xl:w-full md:w-full sm:w-full overflow-hidden transition-shadow shadow-md hover:shadow-lg w-full mb-2"
 											aria-label={`${vcEntity.friendlyName}`}


### PR DESCRIPTION
Fixes these lints that appear when opening details of a credential:

```
Warning: Each child in a list should have a unique "key" prop.
Warning: Invalid DOM property `stroke-linecap`. Did you mean `strokeLinecap`?
Warning: Invalid DOM property `stroke-linejoin`. Did you mean `strokeLinejoin`?
Warning: Invalid DOM property `stroke-width`. Did you mean `strokeWidth`?
Warning: Invalid DOM property `class`. Did you mean `className`?
```
