### PR TITLE
Ignore downlink property if browser doesn't support navigator.connection

### DIFF
--- a/src/context/OnlineStatusContext.js
+++ b/src/context/OnlineStatusContext.js
@@ -4,7 +4,12 @@ import React, { useEffect, createContext, useState } from 'react';
 const OnlineStatusContext = createContext();
 
 function getOnlineStatus() {
-	return navigator.onLine && (navigator.connection?.downlink ?? 0 !== 0);
+	const downlink = (
+		navigator.connection?.downlink
+		// Ignore downlink if browser doesn't support navigator.connection
+		?? Infinity
+	);
+	return navigator.onLine && downlink > 0;
 }
 
 export const OnlineStatusProvider = ({ children }) => {

--- a/src/context/OnlineStatusContext.js
+++ b/src/context/OnlineStatusContext.js
@@ -1,12 +1,17 @@
 import React, { useEffect, createContext, useState } from 'react';
 
+
 const OnlineStatusContext = createContext();
 
+function getOnlineStatus() {
+	return navigator.onLine && (navigator.connection?.downlink ?? 0 !== 0);
+}
+
 export const OnlineStatusProvider = ({ children }) => {
-	const [isOnline, setIsOnline] = useState(() => navigator.onLine && (navigator.connection?.downlink ?? 0) !== 0);
+	const [isOnline, setIsOnline] = useState(getOnlineStatus);
 
 	const updateOnlineStatus = () => {
-		setIsOnline(navigator.onLine && (navigator.connection?.downlink ?? 0) !== 0);
+		setIsOnline(getOnlineStatus());
 	};
 
 	useEffect(() => {


### PR DESCRIPTION
Safari now supports the PRF extension, and Firefox [might support it soon](https://bugzilla.mozilla.org/show_bug.cgi?id=1863819), but neither of these browsers support the Network Information API, including the [`navigator.connection`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/connection#browser_compatibility) property. This disables the "Sign up" link in these browsers with no option for the user to override it. We should fall back to ignoring the `navigator.connection.downlink` property when it does not exist, instead of assuming it has a value of zero.