### PR TITLE
Fix: Handle case when browser does not support notifications and ensure new VC display

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -11,6 +11,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { useApi } from '../api';
 import BottomNav from './BottomNav';
 import OnlineStatusContext from '../context/OnlineStatusContext';
+import { notificationApiIsSupported } from '../firebase';
 import { PiWifiHighBold, PiWifiSlashBold } from "react-icons/pi";
 
 const Layout = ({ children, isPermissionGranted, tokenSentInSession }) => {
@@ -91,7 +92,7 @@ const Layout = ({ children, isPermissionGranted, tokenSentInSession }) => {
 				{/* Content */}
 				<div className="flex-grow bg-gray-100 dark:bg-gray-900 p-6 mt-10 pt-10 sm:mt-0 sm:pt-6 max480:pb-20 overflow-y-auto">
 
-					{((isOnline === false && isMessageOfflineVisible === false)) || (isOnline === true && isPermissionGranted != null && ((!isPermissionGranted && isMessageNoGrantedVisible === false) || (isPermissionGranted && tokenSentInSession === false && isMessageGrantedVisible === false))) ? (
+					{((isOnline === false && isMessageOfflineVisible === false)) || (isOnline === true && isPermissionGranted != null && notificationApiIsSupported() && ((!isPermissionGranted && isMessageNoGrantedVisible === false) || (isPermissionGranted && tokenSentInSession === false && isMessageGrantedVisible === false))) ? (
 						<div className="bg-orange-100 shadow-lg p-4 rounded-lg mb-4 flex items-center">
 							<div className="mr-4 text-orange-500">
 								<FaExclamationTriangle size={24} />

--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -1,12 +1,13 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useApi } from '../api';
-import { fetchToken } from '../firebase';
+import { fetchToken, notificationApiIsSupported } from '../firebase';
 import Layout from './Layout';
 import Spinner from './Spinner'; // Import your spinner component
 import { useSessionStorage } from '../components/useStorage';
 import OnlineStatusContext from '../context/OnlineStatusContext';
 import SessionContext from '../context/SessionContext';
+
 
 const PrivateRoute = ({ children }) => {
 	const { isOnline } = useContext(OnlineStatusContext);
@@ -24,9 +25,14 @@ const PrivateRoute = ({ children }) => {
 
 	useEffect(() => {
 		const requestNotificationPermission = async () => {
-			console.log(Notification.permission);
+			if (!notificationApiIsSupported()) {
+				setIsPermissionGranted(false);
+				setTokenSentInSession(false);
+				return;
+			}
 
 			try {
+				console.log(Notification.permission);
 				if (Notification.permission !== 'granted') {
 					setTokenSentInSession(false);
 					setIsPermissionGranted(false);

--- a/src/context/CredentialsContext.js
+++ b/src/context/CredentialsContext.js
@@ -1,7 +1,8 @@
-import React, { createContext, useState, useCallback, useContext } from 'react';
+import React, { createContext, useState, useCallback, useContext, useRef } from 'react';
 import { useApi } from '../api';
 import { extractCredentialFriendlyName } from '../functions/extractCredentialFriendlyName';
 import OnlineStatusContext from '../context/OnlineStatusContext';
+import { getItem } from '../indexedDB';
 
 const CredentialsContext = createContext();
 
@@ -10,30 +11,96 @@ export const CredentialsProvider = ({ children }) => {
 	const api = useApi(isOnline);
 	const [vcEntityList, setVcEntityList] = useState([]);
 	const [latestCredentials, setLatestCredentials] = useState(new Set());
+	const intervalId = useRef(null);
+	const isPolling = useRef(false);
+
+	const fetchVcData = async () => {
+		const response = await api.get('/storage/vc');
+		const fetchedVcList = response.data.vc_list;
+
+		const vcEntityList = await Promise.all(fetchedVcList.map(async vcEntity => {
+			const name = await extractCredentialFriendlyName(vcEntity.credential);
+			return { ...vcEntity, friendlyName: name };
+		}));
+
+		vcEntityList.sort((vcA, vcB) => new Date(vcB.issuanceDate) - new Date(vcA.issuanceDate));
+
+		return vcEntityList;
+	};
+
+	const updateVcListAndLatestCredentials = (vcEntityList) => {
+		setLatestCredentials(new Set(vcEntityList.filter(vc => vc.issuanceDate === vcEntityList[0].issuanceDate).map(vc => vc.id)));
+
+		setTimeout(() => {
+			setLatestCredentials(new Set());
+		}, 2000);
+
+		setVcEntityList(vcEntityList);
+	};
+
+	const pollForCredentials = () => {
+		let attempts = 0;
+		isPolling.current = true;
+
+		intervalId.current = setInterval(async () => {
+			const urlParams = new URLSearchParams(window.location.search);
+			if (!urlParams.has('code')) {
+				console.log('Code parameter no longer exists, stopping polling');
+				isPolling.current = false;
+				clearInterval(intervalId.current);
+				return;
+			}
+
+			if (!isPolling.current) {
+				clearInterval(intervalId.current);
+				return;
+			}
+
+			attempts += 1;
+			const sessionState = JSON.parse(sessionStorage.getItem('sessionState'));
+			const userId = sessionState.uuid;
+			const previousVcList = await getItem("vc", userId);
+			const previousSize = previousVcList.vc_list.length;
+
+			const vcEntityList = await fetchVcData();
+
+			if (previousSize < vcEntityList.length) {
+				console.log('Found new credentials, stopping polling');
+				isPolling.current = false;
+				clearInterval(intervalId.current);
+				updateVcListAndLatestCredentials(vcEntityList);
+			}
+
+			if (attempts >= 10) {
+				console.log('Max attempts reached, stopping polling');
+				isPolling.current = false;
+				clearInterval(intervalId.current);
+			}
+		}, 1000);
+	};
 
 	const getData = useCallback(async () => {
 		try {
-			const response = await api.get('/storage/vc');
-			const fetchedVcList = response.data.vc_list;
-			const vcEntityList = await Promise.all(fetchedVcList.map(async vcEntity => {
-				const name = await extractCredentialFriendlyName(vcEntity.credential);
-				return { ...vcEntity, friendlyName: name };
-			}));
-			vcEntityList.sort((vcA, vcB) => new Date(vcB.issuanceDate) - new Date(vcA.issuanceDate));
+			const sessionState = JSON.parse(sessionStorage.getItem('sessionState'));
+			const userId = sessionState.uuid;
+			const previousVcList = await getItem("vc", userId);
+			const previousSize = previousVcList.vc_list.length;
+			const vcEntityList = await fetchVcData();
+			setVcEntityList(vcEntityList);
 
-			const latestIssuanceDate = vcEntityList[0]?.issuanceDate;
-			const latestCreds = new Set(vcEntityList.filter(vc => vc.issuanceDate === latestIssuanceDate).map(vc => vc.id));
+			const shouldPoll = window.location.search.includes('code') && sessionStorage.getItem('tokenSentInSession') === 'false';
+			const newCredentialsFound = previousSize < vcEntityList.length;
 
-			if (window.location.search.includes('code')) {
-				setLatestCredentials(latestCreds);
-				setTimeout(() => {
-					setLatestCredentials(new Set());
-				}, 2000);
+			if (shouldPoll && !newCredentialsFound) {
+				console.log("No new credentials, starting polling");
+				pollForCredentials();
+			} else if (newCredentialsFound) {
+				console.log("Found new credentials, no need to poll");
+				updateVcListAndLatestCredentials(vcEntityList);
 			} else {
+				setVcEntityList(vcEntityList);
 				setLatestCredentials(new Set());
 			}
-
-			setVcEntityList(vcEntityList);
 		} catch (error) {
 			console.error('Failed to fetch data', error);
 		}

--- a/src/context/CredentialsContext.js
+++ b/src/context/CredentialsContext.js
@@ -57,8 +57,7 @@ export const CredentialsProvider = ({ children }) => {
 			}
 
 			attempts += 1;
-			const sessionState = JSON.parse(sessionStorage.getItem('sessionState'));
-			const userId = sessionState.uuid;
+			const userId = api.getSession().uuid;
 			const previousVcList = await getItem("vc", userId);
 			const previousSize = previousVcList.vc_list.length;
 
@@ -81,8 +80,7 @@ export const CredentialsProvider = ({ children }) => {
 
 	const getData = useCallback(async () => {
 		try {
-			const sessionState = JSON.parse(sessionStorage.getItem('sessionState'));
-			const userId = sessionState.uuid;
+			const userId = api.getSession().uuid;
 			const previousVcList = await getItem("vc", userId);
 			const previousSize = previousVcList.vc_list.length;
 			const vcEntityList = await fetchVcData();

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -11,7 +11,7 @@ export const notificationApiIsSupported = () =>
 	'Notification' in window &&
 	'serviceWorker' in navigator &&
 	'PushManager' in window
-	
+
 const initializeFirebase = async () => {
 	if (notificationApiIsSupported()) {
 		supported = await isSupported();


### PR DESCRIPTION
- Added check for support of the browser Notification API
- Implement polling to detect new VCs when browser notifications are not supported.
- Enhance logic to properly display new VCs even without notification support.
- Refactor CredentialsContext for better code organization, reducing duplication, and improving maintainability.
- Make sure display new VCs css animation only if we find new one.

**Test it:**
- Use Safari on iOS, which does not support the Notification API, or disable notification permissions.
- Try to obtain a new VC and verify that it is detected and displayed correctly with animation.
