### PR TITLE
Separate Login Account Selection from Cached Users and Login/Signup

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -67,9 +67,9 @@
 		"learnMoreAboutLaunchpadAriaLabel": "Discover our Launchpad",
 		"learnMoreAboutScenariosAriaLabel": "Learn more about sample scenarios",
 		"login": "Login",
+		"loginCache": "Choose your account",
 		"loginAsUser": "Log in as {{name}}",
 		"loginLocalKeystoreFailed": "Failed to initialize wallet key store, please try again.",
-		"loginOtherPasskey": "Login with other passkey",
 		"loginPasskey": "Login with passkey",
 		"loginSubmit": "Login",
 		"messageOffline": "You are offline. Some features may not be available.",
@@ -104,6 +104,7 @@
 		"submitting": "Submitting...",
 		"usernameExistsError": "Failed to create user account, username already exists",
 		"usernameLabel": "Username",
+		"useOtherAccount": "Use other Account",
 		"weakPasswordError": "Weak password",
 		"welcomeMessage": "Welcome to <highlight>wwWallet</highlight>"
 	},


### PR DESCRIPTION
This PR separates the login process into two distinct steps. First, users can select from cached accounts for quicker access. If the desired account is not listed, users can click "Use Other Account" to proceed with the traditional login/signup flow. This enhancement simplifies the user experience by providing a clear and efficient path to login.