### PR TITLE
Fix Online Status Detection by Replacing downlink with rtt

### DIFF
--- a/src/context/OnlineStatusContext.js
+++ b/src/context/OnlineStatusContext.js
@@ -4,12 +4,12 @@ import React, { useEffect, createContext, useState } from 'react';
 const OnlineStatusContext = createContext();
 
 function getOnlineStatus() {
-	const downlink = (
-		navigator.connection?.downlink
-		// Ignore downlink if browser doesn't support navigator.connection
+	const rtt = (
+		navigator.connection?.rtt
+		// Ignore rtt if browser doesn't support navigator.connection
 		?? Infinity
 	);
-	return navigator.onLine && downlink > 0;
+	return navigator.onLine && rtt > 0;
 }
 
 export const OnlineStatusProvider = ({ children }) => {


### PR DESCRIPTION
This PR addresses an issue where the `downlink` value provided by Chrome can be unreliable, particularly in offline scenarios where it might incorrectly show a non-zero value (e.g., `10`). To improve the accuracy of our online status detection, we've switched to using `rtt` (Round-Trip Time) instead.

The new logic checks if `rtt` is greater than `0` in addition to `navigator.onLine` to ensure that the network is actually functional. This should reduce false positives and provide a more reliable online status.