### PR TITLE
Fix false-positive offline status when rtt === 0

### DIFF
--- a/src/context/OnlineStatusContext.js
+++ b/src/context/OnlineStatusContext.js
@@ -7,9 +7,9 @@ function getOnlineStatus() {
 	const rtt = (
 		navigator.connection?.rtt
 		// Ignore rtt if browser doesn't support navigator.connection
-		?? Infinity
+		?? -Infinity
 	);
-	return navigator.onLine && rtt > 0;
+	return navigator.onLine && rtt < 30000;
 }
 
 export const OnlineStatusProvider = ({ children }) => {


### PR DESCRIPTION
If `navigator.connection.rtt` is less than 12 ms, it'll be [rounded down to 0](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/rtt), causing the app to incorrectly decide that it's offline. This happened to me a few times when running locally, for example.