### PR TITLE
Extract OnlineStatusContext value type declaration and get api from SessionContext

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -232,7 +232,11 @@ export function useApi(isOnline: boolean = true): BackendApi {
 		events.dispatchEvent(new CustomEvent<ClearSessionEvent>(CLEAR_SESSION_EVENT));
 	}
 
-	async function setSession(response: AxiosResponse, credential: PublicKeyCredential | null, authenticationType: 'signup' | 'login', showWelcome: boolean): Promise<void> {
+	async function setSession(
+		response: AxiosResponse,
+		credential: PublicKeyCredential | null,
+		authenticationType: 'signup' | 'login',
+	): Promise<void> {
 		setAppToken(response.data.appToken);
 		setSessionState({
 			uuid: response.data.uuid,
@@ -240,7 +244,7 @@ export function useApi(isOnline: boolean = true): BackendApi {
 			username: response.data.username,
 			webauthnCredentialCredentialId: credential?.id,
 			authenticationType,
-			showWelcome,
+			showWelcome: authenticationType === 'signup',
 		});
 
 		await addItem('users', response.data.uuid, response.data);
@@ -269,7 +273,7 @@ export function useApi(isOnline: boolean = true): BackendApi {
 						return Err('loginKeystoreFailed');
 					}
 				}
-				await setSession(response, null, 'login', false);
+				await setSession(response, null, 'login');
 				return Ok.EMPTY;
 			} catch (e) {
 				console.error("Failed to unlock local keystore", e);
@@ -296,7 +300,7 @@ export function useApi(isOnline: boolean = true): BackendApi {
 				}));
 				const userData = response.data as UserData;
 				setUserHandleB64u(toBase64Url(UserId.fromId(userData.uuid).asUserHandle()));
-				await setSession(response, null, 'signup', true);
+				await setSession(response, null, 'signup');
 				return Ok.EMPTY;
 
 			} catch (e) {
@@ -469,7 +473,7 @@ export function useApi(isOnline: boolean = true): BackendApi {
 								return Err('loginKeystoreFailed');
 							}
 						}
-						await setSession(finishResp, credential, 'login', false);
+						await setSession(finishResp, credential, 'login');
 						return Ok.EMPTY;
 					} catch (e) {
 						console.error("Failed to open keystore", e);
@@ -550,7 +554,7 @@ export function useApi(isOnline: boolean = true): BackendApi {
 								clientExtensionResults: credential.getClientExtensionResults(),
 							},
 						}));
-						await setSession(finishResp, credential, 'signup', true);
+						await setSession(finishResp, credential, 'signup');
 						return Ok.EMPTY;
 
 					} catch (e) {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,7 +6,7 @@ import { fromBase64Url, jsonParseTaggedBinary, jsonStringifyTaggedBinary, toBase
 import { EncryptedContainer, makeAssertionPrfExtensionInputs, parsePrivateData, serializePrivateData } from '../services/keystore';
 import { CachedUser, LocalStorageKeystore } from '../services/LocalStorageKeystore';
 import { UserData, UserId, Verifier } from './types';
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { UseStorageHandle, useClearStorages, useLocalStorage, useSessionStorage } from '../components/useStorage';
 import { addItem, getItem } from '../indexedDB';
 import { loginWebAuthnBeginOffline } from './LocalAuthentication';
@@ -75,6 +75,8 @@ export interface BackendApi {
 	updatePrivateData(newPrivateData: EncryptedContainer): Promise<void>,
 	updatePrivateDataEtag(resp: AxiosResponse): AxiosResponse,
 
+	updateShowWelcome(showWelcome: boolean): void,
+
 	addEventListener(type: ApiEventType, listener: EventListener, options?: boolean | AddEventListenerOptions): void,
 	removeEventListener(type: ApiEventType, listener: EventListener, options?: boolean | EventListenerOptions): void,
 	/** Register a storage hook handle to be cleared when `useApi().clearSession()` is invoked. */
@@ -93,553 +95,536 @@ export function useApi(isOnline: boolean = true): BackendApi {
 	 */
 	const [privateDataEtag, setPrivateDataEtag] = useLocalStorage<string | null>("privateDataEtag", null);
 
-	return useMemo(
-		() => {
-			function getAppToken(): string | null {
-				return appToken;
-			}
+	function getAppToken(): string | null {
+		return appToken;
+	}
 
-			function transformResponse(data: any): any {
-				if (data) {
-					return jsonParseTaggedBinary(data);
-				} else {
-					return data;
-				}
-			}
+	function transformResponse(data: any): any {
+		if (data) {
+			return jsonParseTaggedBinary(data);
+		} else {
+			return data;
+		}
+	}
 
-			function updatePrivateDataEtag(resp: AxiosResponse): AxiosResponse {
-				const newValue = resp.headers['x-private-data-etag']
-				if (newValue) {
-					setPrivateDataEtag(newValue);
-				}
-				return resp;
-			}
+	function updatePrivateDataEtag(resp: AxiosResponse): AxiosResponse {
+		const newValue = resp.headers['x-private-data-etag']
+		if (newValue) {
+			setPrivateDataEtag(newValue);
+		}
+		return resp;
+	}
 
-			function buildGetHeaders(headers: { appToken?: string }): { [header: string]: string } {
-				const authz = headers?.appToken || appToken;
-				return {
-					...(authz ? { Authorization: `Bearer ${authz}` } : {}),
-				};
-			}
+	function buildGetHeaders(headers: { appToken?: string }): { [header: string]: string } {
+		const authz = headers?.appToken || appToken;
+		return {
+			...(authz ? { Authorization: `Bearer ${authz}` } : {}),
+		};
+	}
 
-			function buildMutationHeaders(headers: { appToken?: string }): { [header: string]: string } {
-				return {
-					...buildGetHeaders(headers),
-					...(privateDataEtag ? { 'X-Private-Data-If-Match': privateDataEtag } : {}),
-				};
-			}
+	function buildMutationHeaders(headers: { appToken?: string }): { [header: string]: string } {
+		return {
+			...buildGetHeaders(headers),
+			...(privateDataEtag ? { 'X-Private-Data-If-Match': privateDataEtag } : {}),
+		};
+	}
 
-			async function getWithLocalDbKey(path: string, dbKey: string, options?: { appToken?: string }): Promise<AxiosResponse> {
-				console.log(`Get: ${path} ${isOnline ? 'online' : 'offline'} mode ${isOnline}`);
+	async function getWithLocalDbKey(path: string, dbKey: string, options?: { appToken?: string }): Promise<AxiosResponse> {
+		console.log(`Get: ${path} ${isOnline ? 'online' : 'offline'} mode ${isOnline}`);
 
-				// Offline case
-				if (!isOnline) {
-					return {
-						data: await getItem(path, dbKey),
-					} as AxiosResponse;
-				}
+		// Offline case
+		if (!isOnline) {
+			return {
+				data: await getItem(path, dbKey),
+			} as AxiosResponse;
+		}
 
-				// Online case
-				const respBackend = await axios.get(
-					`${walletBackendUrl}${path}`,
-					{
-						headers: buildGetHeaders({ appToken: options?.appToken }),
-						transformResponse,
+		// Online case
+		const respBackend = await axios.get(
+			`${walletBackendUrl}${path}`,
+			{
+				headers: buildGetHeaders({ appToken: options?.appToken }),
+				transformResponse,
+			},
+		);
+		await addItem(path, dbKey, respBackend.data);
+		return respBackend;
+	}
+
+	async function get(path: string, userUuid?: string, options?: { appToken?: string }): Promise<AxiosResponse> {
+		return getWithLocalDbKey(path, sessionState?.uuid || userUuid, options);
+	}
+
+	async function getExternalEntity(path: string, options?: { appToken?: string }): Promise<AxiosResponse> {
+		return getWithLocalDbKey(path, path, options);
+	}
+
+	async function fetchInitialData(appToken: string, userUuid: string): Promise<void> {
+		try {
+			await get('/storage/vc', userUuid, { appToken });
+			await get('/storage/vp', userUuid, { appToken });
+			await get('/user/session/account-info', userUuid, { appToken });
+			await getExternalEntity('/legal_person/issuers/all', { appToken });
+			await getExternalEntity('/verifiers/all', { appToken });
+
+		} catch (error) {
+			console.error('Failed to perform get requests', error);
+		}
+	}
+
+	async function post(path: string, body: object, options?: { appToken?: string }): Promise<AxiosResponse> {
+		try {
+			return await axios.post(
+				`${walletBackendUrl}${path}`,
+				body,
+				{
+					headers: {
+						'Content-Type': 'application/json',
+						...buildMutationHeaders({ appToken: options?.appToken }),
 					},
-				);
-				await addItem(path, dbKey, respBackend.data);
-				return respBackend;
+					transformRequest: (data, headers) => jsonStringifyTaggedBinary(data),
+					transformResponse,
+				},
+			);
+		} catch (e) {
+			if (e?.response?.status === 412 && (e?.response?.headers ?? {})['x-private-data-etag']) {
+				return Promise.reject({ cause: 'x-private-data-etag' });
 			}
+			throw e;
+		}
+	}
 
-			async function get(path: string, userUuid?: string, options?: { appToken?: string }): Promise<AxiosResponse> {
-				return getWithLocalDbKey(path, sessionState?.uuid || userUuid, options);
-			}
-
-			async function getExternalEntity(path: string, options?: { appToken?: string }): Promise<AxiosResponse> {
-				return getWithLocalDbKey(path, path, options);
-			}
-
-			async function fetchInitialData(appToken: string, userUuid: string): Promise<void> {
-				try {
-					await get('/storage/vc', userUuid, { appToken });
-					await get('/storage/vp', userUuid, { appToken });
-					await get('/user/session/account-info', userUuid, { appToken });
-					await getExternalEntity('/legal_person/issuers/all', { appToken });
-					await getExternalEntity('/verifiers/all', { appToken });
-
-				} catch (error) {
-					console.error('Failed to perform get requests', error);
-				}
-			}
-
-			async function post(path: string, body: object, options?: { appToken?: string }): Promise<AxiosResponse> {
-				try {
-					return await axios.post(
-						`${walletBackendUrl}${path}`,
-						body,
-						{
-							headers: {
-								'Content-Type': 'application/json',
-								...buildMutationHeaders({ appToken: options?.appToken }),
-							},
-							transformRequest: (data, headers) => jsonStringifyTaggedBinary(data),
-							transformResponse,
-						},
-					);
-				} catch (e) {
-					if (e?.response?.status === 412 && (e?.response?.headers ?? {})['x-private-data-etag']) {
-						return Promise.reject({ cause: 'x-private-data-etag' });
-					}
-					throw e;
-				}
-			}
-
-			async function del(path: string, options?: { appToken?: string }): Promise<AxiosResponse> {
-				try {
-					return await axios.delete(
-						`${walletBackendUrl}${path}`,
-						{
-							headers: buildMutationHeaders({ appToken: options?.appToken }),
-							transformResponse,
-						});
-				} catch (e) {
-					if (e?.response?.status === 412 && (e?.response?.headers ?? {})['x-private-data-etag']) {
-						return Promise.reject({ cause: 'x-private-data-etag' });
-					}
-					throw e;
-				}
-			}
-
-			function updateShowWelcome(showWelcome: boolean): void {
-				if (sessionState) {
-					setSessionState((prevState) => ({
-						...prevState,
-						showWelcome: showWelcome,
-					}));
-				}
-			}
-
-			function getSession(): SessionState {
-				return sessionState;
-			}
-
-			function isLoggedIn(): boolean {
-				return getSession() !== null;
-			}
-
-			function clearSession(): void {
-				clearSessionStorage();
-				events.dispatchEvent(new CustomEvent<ClearSessionEvent>(CLEAR_SESSION_EVENT));
-			}
-
-			async function setSession(response: AxiosResponse, credential: PublicKeyCredential | null, authenticationType: 'signup' | 'login', showWelcome: boolean): Promise<void> {
-				setAppToken(response.data.appToken);
-				setSessionState({
-					uuid: response.data.uuid,
-					displayName: response.data.displayName,
-					username: response.data.username,
-					webauthnCredentialCredentialId: credential?.id,
-					authenticationType,
-					showWelcome,
+	async function del(path: string, options?: { appToken?: string }): Promise<AxiosResponse> {
+		try {
+			return await axios.delete(
+				`${walletBackendUrl}${path}`,
+				{
+					headers: buildMutationHeaders({ appToken: options?.appToken }),
+					transformResponse,
 				});
+		} catch (e) {
+			if (e?.response?.status === 412 && (e?.response?.headers ?? {})['x-private-data-etag']) {
+				return Promise.reject({ cause: 'x-private-data-etag' });
+			}
+			throw e;
+		}
+	}
 
-				await addItem('users', response.data.uuid, response.data);
-				if (isOnline) {
-					await fetchInitialData(response.data.appToken, response.data.uuid).catch((error) => console.error('Error in performGetRequests', error));
+	function updateShowWelcome(showWelcome: boolean): void {
+		if (sessionState) {
+			setSessionState((prevState) => ({
+				...prevState,
+				showWelcome: showWelcome,
+			}));
+		}
+	}
+
+	function getSession(): SessionState {
+		return sessionState;
+	}
+
+	function isLoggedIn(): boolean {
+		return getSession() !== null;
+	}
+
+	function clearSession(): void {
+		clearSessionStorage();
+		events.dispatchEvent(new CustomEvent<ClearSessionEvent>(CLEAR_SESSION_EVENT));
+	}
+
+	async function setSession(response: AxiosResponse, credential: PublicKeyCredential | null, authenticationType: 'signup' | 'login', showWelcome: boolean): Promise<void> {
+		setAppToken(response.data.appToken);
+		setSessionState({
+			uuid: response.data.uuid,
+			displayName: response.data.displayName,
+			username: response.data.username,
+			webauthnCredentialCredentialId: credential?.id,
+			authenticationType,
+			showWelcome,
+		});
+
+		await addItem('users', response.data.uuid, response.data);
+		if (isOnline) {
+			await fetchInitialData(response.data.appToken, response.data.uuid).catch((error) => console.error('Error in performGetRequests', error));
+		}
+	}
+
+	async function login(username: string, password: string, keystore: LocalStorageKeystore): Promise<Result<void, any>> {
+		try {
+			const response = updatePrivateDataEtag(await post('/user/login', { username, password }));
+			const userData = response.data as UserData;
+			const privateData = await parsePrivateData(userData.privateData);
+			try {
+				const privateDataUpdate = await keystore.unlockPassword(privateData, password, { displayName: userData.displayName, userHandle: UserId.fromId(userData.uuid).asUserHandle() });
+				if (privateDataUpdate) {
+					const [newPrivateData, keystoreCommit] = privateDataUpdate;
+					try {
+						await updatePrivateData(newPrivateData, { appToken: response.data.appToken });
+						await keystoreCommit();
+					} catch (e) {
+						console.error("Failed to upgrade password key", e, e.status);
+						if (e?.cause === 'x-private-data-etag') {
+							return Err('x-private-data-etag');
+						}
+						return Err('loginKeystoreFailed');
+					}
 				}
+				await setSession(response, null, 'login', false);
+				return Ok.EMPTY;
+			} catch (e) {
+				console.error("Failed to unlock local keystore", e);
+				return Err(e);
 			}
 
-			async function login(username: string, password: string, keystore: LocalStorageKeystore): Promise<Result<void, any>> {
+		} catch (error) {
+			console.error('Failed to log in', error);
+			return Err(error);
+		}
+	};
+
+	async function signup(username: string, password: string, keystore: LocalStorageKeystore): Promise<Result<void, any>> {
+
+		try {
+			const [privateData, setUserHandleB64u] = await keystore.initPassword(password);
+
+			try {
+				const response = updatePrivateDataEtag(await post('/user/register', {
+					username,
+					password,
+					displayName: username,
+					privateData: serializePrivateData(privateData),
+				}));
+				const userData = response.data as UserData;
+				setUserHandleB64u(toBase64Url(UserId.fromId(userData.uuid).asUserHandle()));
+				await setSession(response, null, 'signup', true);
+				return Ok.EMPTY;
+
+			} catch (e) {
+				console.error("Signup failed", e);
+				return Err(e);
+			}
+
+		} catch (e) {
+			console.error("Failed to initialize local keystore", e);
+			return Err(e);
+		}
+	}
+
+	async function updatePrivateData(newPrivateData: EncryptedContainer, options?: { appToken?: string }): Promise<void> {
+		try {
+			const updateResp = updatePrivateDataEtag(
+				await post('/user/session/private-data', serializePrivateData(newPrivateData), options),
+			);
+			if (updateResp.status === 204) {
+				return;
+			} else {
+				console.error("Failed to update private data", updateResp.status, updateResp);
+				return Promise.reject(updateResp);
+			}
+		} catch (e) {
+			console.error("Failed to update private data", e, e?.response?.status);
+			if (e?.response?.status === 412 && (e?.headers ?? {})['x-private-data-etag']) {
+				throw new Error("Private data version conflict", { cause: 'x-private-data-etag' });
+			}
+			throw e;
+		}
+	}
+
+	async function getAllVerifiers(): Promise<Verifier[]> {
+		try {
+			const result = await getExternalEntity('/verifiers/all');
+			const { verifiers } = result.data;
+			console.log("verifiers = ", verifiers)
+			return verifiers;
+		}
+		catch (error) {
+			console.error("Failed to fetch all verifiers", error);
+			throw error;
+		}
+	}
+
+	async function getAllPresentations(): Promise<{ vp_list: any[] }> {
+		try {
+			const result = await get('/storage/vp');
+			return result.data; // Return the Axios response.
+		}
+		catch (error) {
+			console.error("Failed to fetch all presentations", error);
+			throw error;
+		}
+	}
+
+	async function initiatePresentationExchange(verifier_id: number, scope_name: string): Promise<{ redirect_to?: string }> {
+		try {
+			const result = await post('/presentation/initiate', { verifier_id, scope_name });
+			const { redirect_to } = result.data;
+			return { redirect_to };
+		}
+		catch (error) {
+			console.error("Failed to fetch all verifiers", error);
+			throw error;
+		}
+	}
+
+	async function loginWebauthn(
+		keystore: LocalStorageKeystore,
+		promptForPrfRetry: () => Promise<boolean | AbortSignal>,
+		cachedUser: CachedUser | undefined,
+	): Promise<
+		Result<void, 'loginKeystoreFailed' | 'passkeyInvalid' | 'passkeyLoginFailedTryAgain' | 'passkeyLoginFailedServerError' | 'x-private-data-etag'>
+	> {
+		try {
+			const beginData = await (async (): Promise<{
+				challengeId?: string,
+				getOptions: { publicKey: PublicKeyCredentialRequestOptions },
+			}> => {
+				if (isOnline) {
+					const beginResp = await post('/user/login-webauthn-begin', {});
+					console.log("begin", beginResp);
+					return beginResp.data;
+				}
+				else {
+					return loginWebAuthnBeginOffline();
+				}
+			})();
+
+			try {
+				const prfInputs = cachedUser && makeAssertionPrfExtensionInputs(cachedUser.prfKeys);
+				const getOptions = prfInputs
+					? {
+						...beginData.getOptions,
+						publicKey: {
+							...beginData.getOptions.publicKey,
+							allowCredentials: prfInputs.allowCredentials,
+							extensions: {
+								...beginData.getOptions.publicKey.extensions,
+								prf: prfInputs.prfInput,
+							},
+						},
+					}
+					: beginData.getOptions;
+				const credential = await navigator.credentials.get(getOptions) as PublicKeyCredential;
+				const response = credential.response as AuthenticatorAssertionResponse;
+
 				try {
-					const response = updatePrivateDataEtag(await post('/user/login', { username, password }));
-					const userData = response.data as UserData;
-					const privateData = await parsePrivateData(userData.privateData);
+					const finishResp = await (async () => {
+						if (isOnline) {
+							return updatePrivateDataEtag(await post('/user/login-webauthn-finish', {
+								challengeId: beginData.challengeId,
+								credential: {
+									type: credential.type,
+									id: credential.id,
+									rawId: credential.rawId,
+									response: {
+										authenticatorData: response.authenticatorData,
+										clientDataJSON: response.clientDataJSON,
+										signature: response.signature,
+										userHandle: response.userHandle ?? fromBase64Url(cachedUser?.userHandleB64u),
+									},
+									authenticatorAttachment: credential.authenticatorAttachment,
+									clientExtensionResults: credential.getClientExtensionResults(),
+								},
+							}));
+						}
+						else {
+							const userId = UserId.fromUserHandle(response.userHandle);
+							const user = await getItem("users", userId.id);
+							return {
+								data: {
+									uuid: user.uuid,
+									appToken: "",
+									did: user.did,
+									displayName: user.displayName,
+									privateData: user.privateData,
+									username: null,
+								},
+							};
+						}
+					})() as any;
+
 					try {
-						const privateDataUpdate = await keystore.unlockPassword(privateData, password, { displayName: userData.displayName, userHandle: UserId.fromId(userData.uuid).asUserHandle() });
+						const userData = finishResp.data as UserData;
+						const privateData = await parsePrivateData(userData.privateData);
+						const privateDataUpdate = await keystore.unlockPrf(
+							privateData,
+							credential,
+							promptForPrfRetry,
+							cachedUser || {
+								...userData,
+								// response.userHandle will always be non-null if cachedUser is
+								// null, because then allowCredentials was empty
+								userHandle: new Uint8Array(response.userHandle),
+							},
+						);
 						if (privateDataUpdate) {
 							const [newPrivateData, keystoreCommit] = privateDataUpdate;
 							try {
-								await updatePrivateData(newPrivateData, { appToken: response.data.appToken });
+								await updatePrivateData(newPrivateData, { appToken: finishResp.data.appToken });
 								await keystoreCommit();
 							} catch (e) {
-								console.error("Failed to upgrade password key", e, e.status);
+								console.error("Failed to upgrade PRF key", e, e.status);
 								if (e?.cause === 'x-private-data-etag') {
 									return Err('x-private-data-etag');
 								}
 								return Err('loginKeystoreFailed');
 							}
 						}
-						await setSession(response, null, 'login', false);
+						await setSession(finishResp, credential, 'login', false);
 						return Ok.EMPTY;
 					} catch (e) {
-						console.error("Failed to unlock local keystore", e);
-						return Err(e);
-					}
-
-				} catch (error) {
-					console.error('Failed to log in', error);
-					return Err(error);
-				}
-			};
-
-			async function signup(username: string, password: string, keystore: LocalStorageKeystore): Promise<Result<void, any>> {
-
-				try {
-					const [privateData, setUserHandleB64u] = await keystore.initPassword(password);
-
-					try {
-						const response = updatePrivateDataEtag(await post('/user/register', {
-							username,
-							password,
-							displayName: username,
-							privateData: serializePrivateData(privateData),
-						}));
-						const userData = response.data as UserData;
-						setUserHandleB64u(toBase64Url(UserId.fromId(userData.uuid).asUserHandle()));
-						await setSession(response, null, 'signup', true);
-						return Ok.EMPTY;
-
-					} catch (e) {
-						console.error("Signup failed", e);
-						return Err(e);
+						console.error("Failed to open keystore", e);
+						return Err('loginKeystoreFailed');
 					}
 
 				} catch (e) {
-					console.error("Failed to initialize local keystore", e);
-					return Err(e);
+					return Err('passkeyInvalid');
 				}
+
+			} catch (e) {
+				return Err('passkeyLoginFailedTryAgain');
 			}
 
-			async function updatePrivateData(newPrivateData: EncryptedContainer, options?: { appToken?: string }): Promise<void> {
-				try {
-					const updateResp = updatePrivateDataEtag(
-						await post('/user/session/private-data', serializePrivateData(newPrivateData), options),
-					);
-					if (updateResp.status === 204) {
-						return;
-					} else {
-						console.error("Failed to update private data", updateResp.status, updateResp);
-						return Promise.reject(updateResp);
-					}
-				} catch (e) {
-					console.error("Failed to update private data", e, e?.response?.status);
-					if (e?.response?.status === 412 && (e?.headers ?? {})['x-private-data-etag']) {
-						throw new Error("Private data version conflict", { cause: 'x-private-data-etag' });
-					}
-					throw e;
-				}
-			}
+		} catch (e) {
+			return Err('passkeyLoginFailedServerError');
+		}
+	};
 
-			async function getAllVerifiers(): Promise<Verifier[]> {
-				try {
-					const result = await getExternalEntity('/verifiers/all');
-					const { verifiers } = result.data;
-					console.log("verifiers = ", verifiers)
-					return verifiers;
-				}
-				catch (error) {
-					console.error("Failed to fetch all verifiers", error);
-					throw error;
-				}
-			}
+	async function signupWebauthn(
+		name: string,
+		keystore: LocalStorageKeystore,
+		promptForPrfRetry: () => Promise<boolean | AbortSignal>,
+		retryFrom?: SignupWebauthnRetryParams,
+	): Promise<Result<void, SignupWebauthnError>> {
+		try {
+			const beginData = retryFrom?.beginData || (await post('/user/register-webauthn-begin', {})).data;
+			console.log("begin", beginData);
 
-			async function getAllPresentations(): Promise<{ vp_list: any[] }> {
-				try {
-					const result = await get('/storage/vp');
-					return result.data; // Return the Axios response.
-				}
-				catch (error) {
-					console.error("Failed to fetch all presentations", error);
-					throw error;
-				}
-			}
-
-
-
-			async function initiatePresentationExchange(verifier_id: number, scope_name: string): Promise<{ redirect_to?: string }> {
-				try {
-					const result = await post('/presentation/initiate', { verifier_id, scope_name });
-					const { redirect_to } = result.data;
-					return { redirect_to };
-				}
-				catch (error) {
-					console.error("Failed to fetch all verifiers", error);
-					throw error;
-				}
-			}
-
-
-			async function loginWebauthn(
-				keystore: LocalStorageKeystore,
-				promptForPrfRetry: () => Promise<boolean | AbortSignal>,
-				cachedUser: CachedUser | undefined,
-			): Promise<
-				Result<void, 'loginKeystoreFailed' | 'passkeyInvalid' | 'passkeyLoginFailedTryAgain' | 'passkeyLoginFailedServerError' | 'x-private-data-etag'>
-			> {
-				try {
-					const beginData = await (async (): Promise<{
-						challengeId?: string,
-						getOptions: { publicKey: PublicKeyCredentialRequestOptions },
-					}> => {
-						if (isOnline) {
-							const beginResp = await post('/user/login-webauthn-begin', {});
-							console.log("begin", beginResp);
-							return beginResp.data;
-						}
-						else {
-							return loginWebAuthnBeginOffline();
-						}
-					})();
-
-					try {
-						const prfInputs = cachedUser && makeAssertionPrfExtensionInputs(cachedUser.prfKeys);
-						const getOptions = prfInputs
-							? {
-								...beginData.getOptions,
-								publicKey: {
-									...beginData.getOptions.publicKey,
-									allowCredentials: prfInputs.allowCredentials,
-									extensions: {
-										...beginData.getOptions.publicKey.extensions,
-										prf: prfInputs.prfInput,
-									},
-								},
-							}
-							: beginData.getOptions;
-						const credential = await navigator.credentials.get(getOptions) as PublicKeyCredential;
-						const response = credential.response as AuthenticatorAssertionResponse;
-
-						try {
-							const finishResp = await (async () => {
-								if (isOnline) {
-									return updatePrivateDataEtag(await post('/user/login-webauthn-finish', {
-										challengeId: beginData.challengeId,
-										credential: {
-											type: credential.type,
-											id: credential.id,
-											rawId: credential.rawId,
-											response: {
-												authenticatorData: response.authenticatorData,
-												clientDataJSON: response.clientDataJSON,
-												signature: response.signature,
-												userHandle: response.userHandle ?? fromBase64Url(cachedUser?.userHandleB64u),
-											},
-											authenticatorAttachment: credential.authenticatorAttachment,
-											clientExtensionResults: credential.getClientExtensionResults(),
-										},
-									}));
-								}
-								else {
-									const userId = UserId.fromUserHandle(response.userHandle);
-									const user = await getItem("users", userId.id);
-									return {
-										data: {
-											uuid: user.uuid,
-											appToken: "",
-											did: user.did,
-											displayName: user.displayName,
-											privateData: user.privateData,
-											username: null,
-										},
-									};
-								}
-							})() as any;
-
-							try {
-								const userData = finishResp.data as UserData;
-								const privateData = await parsePrivateData(userData.privateData);
-								const privateDataUpdate = await keystore.unlockPrf(
-									privateData,
-									credential,
-									promptForPrfRetry,
-									cachedUser || {
-										...userData,
-										// response.userHandle will always be non-null if cachedUser is
-										// null, because then allowCredentials was empty
-										userHandle: new Uint8Array(response.userHandle),
-									},
-								);
-								if (privateDataUpdate) {
-									const [newPrivateData, keystoreCommit] = privateDataUpdate;
-									try {
-										await updatePrivateData(newPrivateData, { appToken: finishResp.data.appToken });
-										await keystoreCommit();
-									} catch (e) {
-										console.error("Failed to upgrade PRF key", e, e.status);
-										if (e?.cause === 'x-private-data-etag') {
-											return Err('x-private-data-etag');
-										}
-										return Err('loginKeystoreFailed');
-									}
-								}
-								await setSession(finishResp, credential, 'login', false);
-								return Ok.EMPTY;
-							} catch (e) {
-								console.error("Failed to open keystore", e);
-								return Err('loginKeystoreFailed');
-							}
-
-						} catch (e) {
-							return Err('passkeyInvalid');
-						}
-
-					} catch (e) {
-						return Err('passkeyLoginFailedTryAgain');
-					}
-
-				} catch (e) {
-					return Err('passkeyLoginFailedServerError');
-				}
-			};
-
-			async function signupWebauthn(
-				name: string,
-				keystore: LocalStorageKeystore,
-				promptForPrfRetry: () => Promise<boolean | AbortSignal>,
-				retryFrom?: SignupWebauthnRetryParams,
-			): Promise<Result<void, SignupWebauthnError>> {
-				try {
-					const beginData = retryFrom?.beginData || (await post('/user/register-webauthn-begin', {})).data;
-					console.log("begin", beginData);
-
-					try {
-						const prfSalt = crypto.getRandomValues(new Uint8Array(32))
-						const credential = retryFrom?.credential || await navigator.credentials.create({
-							...beginData.createOptions,
-							publicKey: {
-								...beginData.createOptions.publicKey,
-								user: {
-									...beginData.createOptions.publicKey.user,
-									name,
-									displayName: name,
-								},
-								extensions: {
-									prf: {
-										eval: {
-											first: prfSalt,
-										},
-									},
+			try {
+				const prfSalt = crypto.getRandomValues(new Uint8Array(32))
+				const credential = retryFrom?.credential || await navigator.credentials.create({
+					...beginData.createOptions,
+					publicKey: {
+						...beginData.createOptions.publicKey,
+						user: {
+							...beginData.createOptions.publicKey.user,
+							name,
+							displayName: name,
+						},
+						extensions: {
+							prf: {
+								eval: {
+									first: prfSalt,
 								},
 							},
-						}) as PublicKeyCredential;
-						const response = credential.response as AuthenticatorAttestationResponse;
-						console.log("created", credential);
+						},
+					},
+				}) as PublicKeyCredential;
+				const response = credential.response as AuthenticatorAttestationResponse;
+				console.log("created", credential);
 
-						try {
-							const privateData = await keystore.initPrf(
-								credential,
-								prfSalt,
-								promptForPrfRetry,
-								{ displayName: name, userHandle: beginData.createOptions.publicKey.user.id },
-							);
+				try {
+					const privateData = await keystore.initPrf(
+						credential,
+						prfSalt,
+						promptForPrfRetry,
+						{ displayName: name, userHandle: beginData.createOptions.publicKey.user.id },
+					);
 
-							try {
+					try {
 
 
-								const finishResp = updatePrivateDataEtag(await post('/user/register-webauthn-finish', {
-									challengeId: beginData.challengeId,
-									displayName: name,
-									privateData: serializePrivateData(privateData),
-									credential: {
-										type: credential.type,
-										id: credential.id,
-										rawId: credential.rawId,
-										response: {
-											attestationObject: response.attestationObject,
-											clientDataJSON: response.clientDataJSON,
-											transports: response.getTransports(),
-										},
-										authenticatorAttachment: credential.authenticatorAttachment,
-										clientExtensionResults: credential.getClientExtensionResults(),
-									},
-								}));
-								await setSession(finishResp, credential, 'signup', true);
-								return Ok.EMPTY;
-
-							} catch (e) {
-								return Err('passkeySignupFailedServerError');
-							}
-
-						} catch (e) {
-							if (e?.cause?.errorId === "prf_retry_failed") {
-								return Err({ errorId: 'prfRetryFailed', retryFrom: { credential, beginData } });
-							} else if (e?.cause?.errorId === "prf_not_supported") {
-								return Err('passkeySignupPrfNotSupported');
-							} else {
-								return Err('passkeySignupKeystoreFailed');
-							}
-						}
+						const finishResp = updatePrivateDataEtag(await post('/user/register-webauthn-finish', {
+							challengeId: beginData.challengeId,
+							displayName: name,
+							privateData: serializePrivateData(privateData),
+							credential: {
+								type: credential.type,
+								id: credential.id,
+								rawId: credential.rawId,
+								response: {
+									attestationObject: response.attestationObject,
+									clientDataJSON: response.clientDataJSON,
+									transports: response.getTransports(),
+								},
+								authenticatorAttachment: credential.authenticatorAttachment,
+								clientExtensionResults: credential.getClientExtensionResults(),
+							},
+						}));
+						await setSession(finishResp, credential, 'signup', true);
+						return Ok.EMPTY;
 
 					} catch (e) {
-						return Err('passkeySignupFailedTryAgain');
+						return Err('passkeySignupFailedServerError');
 					}
 
 				} catch (e) {
-					return Err('passkeySignupFinishFailedServerError');
+					if (e?.cause?.errorId === "prf_retry_failed") {
+						return Err({ errorId: 'prfRetryFailed', retryFrom: { credential, beginData } });
+					} else if (e?.cause?.errorId === "prf_not_supported") {
+						return Err('passkeySignupPrfNotSupported');
+					} else {
+						return Err('passkeySignupKeystoreFailed');
+					}
 				}
+
+			} catch (e) {
+				return Err('passkeySignupFailedTryAgain');
 			}
 
-			function addEventListener(type: ApiEventType, listener: EventListener, options?: boolean | AddEventListenerOptions): void {
-				events.addEventListener(type, listener, options);
-			}
+		} catch (e) {
+			return Err('passkeySignupFinishFailedServerError');
+		}
+	}
 
-			function removeEventListener(type: ApiEventType, listener: EventListener, options?: boolean | EventListenerOptions): void {
-				events.removeEventListener(type, listener, options);
-			}
+	function addEventListener(type: ApiEventType, listener: EventListener, options?: boolean | AddEventListenerOptions): void {
+		events.addEventListener(type, listener, options);
+	}
 
-			function useClearOnClearSession<T>(storageHandle: UseStorageHandle<T>): UseStorageHandle<T> {
-				const [, , clearHandle] = storageHandle;
-				useEffect(
-					() => {
-						const listener = () => { clearHandle(); };
-						addEventListener(CLEAR_SESSION_EVENT, listener);
-						return () => {
-							removeEventListener(CLEAR_SESSION_EVENT, listener);
-						};
-					},
-					[clearHandle]
-				);
-				return storageHandle;
-			}
+	function removeEventListener(type: ApiEventType, listener: EventListener, options?: boolean | EventListenerOptions): void {
+		events.removeEventListener(type, listener, options);
+	}
 
-			return {
-				del,
-				get,
-				getExternalEntity,
-				post,
+	function useClearOnClearSession<T>(storageHandle: UseStorageHandle<T>): UseStorageHandle<T> {
+		const [, , clearHandle] = storageHandle;
+		useEffect(
+			() => {
+				const listener = () => { clearHandle(); };
+				addEventListener(CLEAR_SESSION_EVENT, listener);
+				return () => {
+					removeEventListener(CLEAR_SESSION_EVENT, listener);
+				};
+			},
+			[clearHandle]
+		);
+		return storageHandle;
+	}
 
-				updateShowWelcome,
+	return {
+		del,
+		get,
+		getExternalEntity,
+		post,
 
-				getSession,
-				isLoggedIn,
-				clearSession,
+		updateShowWelcome,
 
-				login,
-				signup,
-				getAllVerifiers,
-				getAllPresentations,
-				getAppToken,
-				initiatePresentationExchange,
+		getSession,
+		isLoggedIn,
+		clearSession,
 
-				loginWebauthn,
-				signupWebauthn,
-				updatePrivateData,
-				updatePrivateDataEtag,
+		login,
+		signup,
+		getAllVerifiers,
+		getAllPresentations,
+		getAppToken,
+		initiatePresentationExchange,
 
-				addEventListener,
-				removeEventListener,
-				useClearOnClearSession,
-			}
-		},
-		[
-			appToken,
-			clearSessionStorage,
-			isOnline,
-			privateDataEtag,
-			sessionState,
-			setAppToken,
-			setPrivateDataEtag,
-			setSessionState,
-		],
-	);
+		loginWebauthn,
+		signupWebauthn,
+		updatePrivateData,
+		updatePrivateDataEtag,
+
+		addEventListener,
+		removeEventListener,
+		useClearOnClearSession,
+	};
 }

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -8,11 +8,11 @@ import WelcomeTourGuide from './WelcomeTourGuide/WelcomeTourGuide';
 import { CSSTransition } from 'react-transition-group';
 import { useSessionStorage } from '../components/useStorage';
 import { Trans, useTranslation } from 'react-i18next';
-import { useApi } from '../api';
 import BottomNav from './BottomNav';
 import OnlineStatusContext from '../context/OnlineStatusContext';
 import { notificationApiIsSupported } from '../firebase';
 import { PiWifiHighBold, PiWifiSlashBold } from "react-icons/pi";
+import SessionContext from '../context/SessionContext';
 
 const Layout = ({ children, isPermissionGranted, tokenSentInSession }) => {
 	const { isOnline } = useContext(OnlineStatusContext);
@@ -21,7 +21,7 @@ const Layout = ({ children, isPermissionGranted, tokenSentInSession }) => {
 	const [isContentVisible, setIsContentVisible] = useState(false);
 	const [isOpen, setIsOpen] = useState(false);
 	const toggleSidebar = () => setIsOpen(!isOpen);
-	const api = useApi();
+	const { api } = useContext(SessionContext);
 	const [isMessageNoGrantedVisible, setIsMessageNoGrantedVisible,] = api.useClearOnClearSession(useSessionStorage('isMessageNoGrantedVisible', false));
 	const [isMessageGrantedVisible, setIsMessageGrantedVisible,] = api.useClearOnClearSession(useSessionStorage('isMessageGrantedVisible', false));
 	const [isMessageOfflineVisible, setIsMessageOfflineVisible,] = api.useClearOnClearSession(useSessionStorage('isMessageOfflineVisible', false));

--- a/src/components/Popups/PinInput.js
+++ b/src/components/Popups/PinInput.js
@@ -1,14 +1,14 @@
 // PinInput.js
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useContext } from 'react';
 import Modal from 'react-modal';
 import { useNavigate } from 'react-router-dom';
 import { FaLock } from "react-icons/fa";
 import { useTranslation } from 'react-i18next';
-import { useApi } from '../../api';
 import GetButton from '../Buttons/GetButton';
+import SessionContext from '../../context/SessionContext';
 
 function PinInput({ showPopup, setShowPopup }) {
-	const api = useApi();
+	const { api } = useContext(SessionContext);
 	const navigate = useNavigate();
 	const [errMessage, setErrMessage] = useState('');
 	const [pin, setPin] = useState(['', '', '', '']);

--- a/src/components/Popups/SelectCredentials.js
+++ b/src/components/Popups/SelectCredentials.js
@@ -3,12 +3,11 @@ import Modal from 'react-modal';
 import { useNavigate } from 'react-router-dom';
 import { FaShare, FaRegCircle, FaCheckCircle } from 'react-icons/fa';
 import { useTranslation, Trans } from 'react-i18next';
-import { useApi } from '../../api';
 import { CredentialImage } from '../Credentials/CredentialImage';
 import CredentialInfo from '../Credentials/CredentialInfo';
 import GetButton from '../Buttons/GetButton';
 import { extractCredentialFriendlyName } from "../../functions/extractCredentialFriendlyName";
-import OnlineStatusContext from '../../context/OnlineStatusContext';
+import SessionContext from '../../context/SessionContext';
 
 const formatTitle = (title) => {
 	if (title) {
@@ -57,8 +56,7 @@ const StepBar = ({ totalSteps, currentStep, stepTitles }) => {
 };
 
 function SelectCredentials({ showPopup, setShowPopup, setSelectionMap, conformantCredentialsMap, verifierDomainName }) {
-	const { isOnline } = useContext(OnlineStatusContext);
-	const api = useApi(isOnline);
+	const { api } = useContext(SessionContext);
 	const [vcEntities, setVcEntities] = useState([]);
 	const navigate = useNavigate();
 	const { t } = useTranslation();

--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -1,6 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
-import { useApi } from '../api';
 import { fetchToken, notificationApiIsSupported } from '../firebase';
 import Layout from './Layout';
 import Spinner from './Spinner'; // Import your spinner component
@@ -11,8 +10,7 @@ import SessionContext from '../context/SessionContext';
 
 const PrivateRoute = ({ children }) => {
 	const { isOnline } = useContext(OnlineStatusContext);
-	const { isLoggedIn, keystore, logout } = useContext(SessionContext);
-	const api = useApi(isOnline);
+	const { api, isLoggedIn, keystore, logout } = useContext(SessionContext);
 	const [isPermissionGranted, setIsPermissionGranted] = useState(null);
 	const [loading, setLoading] = useState(false);
 	const [tokenSentInSession, setTokenSentInSession,] = api.useClearOnClearSession(useSessionStorage('tokenSentInSession', null));

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -4,7 +4,6 @@ import { FaWallet, FaUserCircle } from "react-icons/fa";
 import { IoIosTime, IoIosAddCircle, IoIosSend, IoMdSettings } from "react-icons/io";
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import { useApi } from '../api';
 import logo from '../assets/images/wallet_white.png';
 import { Trans, useTranslation } from 'react-i18next';
 import OnlineStatusContext from '../context/OnlineStatusContext';
@@ -31,8 +30,7 @@ const NavItem = ({
 
 const Sidebar = ({ isOpen, toggle }) => {
 	const { isOnline } = useContext(OnlineStatusContext);
-	const api = useApi();
-	const { logout } = useContext(SessionContext);
+	const { api, logout } = useContext(SessionContext);
 	const { username, displayName } = api.getSession();
 	const location = useLocation();
 	const navigate = useNavigate();

--- a/src/components/WelcomeTourGuide/WelcomeTourGuide.js
+++ b/src/components/WelcomeTourGuide/WelcomeTourGuide.js
@@ -1,15 +1,18 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import Tour from 'reactour';
 import { useTranslation } from 'react-i18next';
+
+import SessionContext from '../../context/SessionContext';
+
 import WelcomeModal from './WecomeModal';
-import { useApi } from '../../api';
 import GetButton from '../Buttons/GetButton';
+
 
 const TourGuide = ({ toggleMenu, isOpen }) => {
 	const [isTourOpen, setIsTourOpen] = useState(false);
 	const [isModalOpen, setIsModalOpen] = useState(true);
 	const [steps, setSteps] = useState([]);
-	const api = useApi();
+	const { api } = useContext(SessionContext);
 	const { authenticationType, showWelcome } = api.getSession();
 	const { t } = useTranslation();
 

--- a/src/components/useCheckURL.ts
+++ b/src/components/useCheckURL.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState, Dispatch, SetStateAction, useContext } from 'react';
-import { useApi } from '../api';
 import { useTranslation } from 'react-i18next';
+
 import SessionContext from '../context/SessionContext';
+
 
 export enum HandleOutboundRequestError {
 	INSUFFICIENT_CREDENTIALS = "INSUFFICIENT_CREDENTIALS",
@@ -25,8 +26,7 @@ function useCheckURL(urlToCheck: string): {
 	textMessagePopup: { title: string, description: string };
 	typeMessagePopup: string;
 } {
-	const api = useApi();
-	const { isLoggedIn, keystore } = useContext(SessionContext);
+	const { api, isLoggedIn, keystore } = useContext(SessionContext);
 	const [showSelectCredentialsPopup, setShowSelectCredentialsPopup] = useState<boolean>(false);
 	const [showPinInputPopup, setShowPinInputPopup] = useState<boolean>(false);
 	const [selectionMap, setSelectionMap] = useState<string | null>(null);

--- a/src/context/CredentialsContext.js
+++ b/src/context/CredentialsContext.js
@@ -1,14 +1,12 @@
 import React, { createContext, useState, useCallback, useContext, useRef } from 'react';
-import { useApi } from '../api';
 import { extractCredentialFriendlyName } from '../functions/extractCredentialFriendlyName';
-import OnlineStatusContext from '../context/OnlineStatusContext';
 import { getItem } from '../indexedDB';
+import SessionContext from './SessionContext';
 
 const CredentialsContext = createContext();
 
 export const CredentialsProvider = ({ children }) => {
-	const { isOnline } = useContext(OnlineStatusContext);
-	const api = useApi(isOnline);
+	const { api } = useContext(SessionContext);
 	const [vcEntityList, setVcEntityList] = useState([]);
 	const [latestCredentials, setLatestCredentials] = useState(new Set());
 	const intervalId = useRef(null);

--- a/src/context/OnlineStatusContext.tsx
+++ b/src/context/OnlineStatusContext.tsx
@@ -1,9 +1,25 @@
 import React, { useEffect, createContext, useState } from 'react';
 
 
-const OnlineStatusContext = createContext();
+/**
+ * Type polyfill for https://wicg.github.io/netinfo/#networkinformation-interface
+ * but defining only the properties we use here.
+ */
+interface NetworkInformation extends EventTarget {
+	rtt: Millisecond,
+}
+type Millisecond = number;
 
-function getOnlineStatus() {
+declare global {
+	export interface Navigator {
+		connection?: NetworkInformation;
+	}
+}
+
+
+const OnlineStatusContext = createContext({});
+
+function getOnlineStatus(): boolean {
 	const rtt = (
 		navigator.connection?.rtt
 		// Ignore rtt if browser doesn't support navigator.connection
@@ -12,7 +28,7 @@ function getOnlineStatus() {
 	return navigator.onLine && rtt > 0;
 }
 
-export const OnlineStatusProvider = ({ children }) => {
+export const OnlineStatusProvider = ({ children }: { children: React.ReactNode }) => {
 	const [isOnline, setIsOnline] = useState(getOnlineStatus);
 
 	const updateOnlineStatus = () => {

--- a/src/context/OnlineStatusContext.tsx
+++ b/src/context/OnlineStatusContext.tsx
@@ -16,8 +16,14 @@ declare global {
 	}
 }
 
+interface OnlineStatusContextValue {
+	isOnline: boolean;
+}
 
-const OnlineStatusContext = createContext({});
+
+const OnlineStatusContext: React.Context<OnlineStatusContextValue> = createContext({
+	isOnline: null,
+});
 
 function getOnlineStatus(): boolean {
 	const rtt = (

--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -1,26 +1,32 @@
-import React, { createContext } from 'react';
-import { useApi } from '../api';
+import React, { createContext, useContext } from 'react';
+
+import OnlineStatusContext from './OnlineStatusContext';
+import { BackendApi, useApi } from '../api';
 import { useLocalStorageKeystore } from '../services/LocalStorageKeystore';
 import type { LocalStorageKeystore } from '../services/LocalStorageKeystore';
 
 
 type SessionContextValue = {
+	api: BackendApi,
 	isLoggedIn: boolean,
 	keystore: LocalStorageKeystore,
 	logout: () => Promise<void>,
 };
 
 const SessionContext: React.Context<SessionContextValue> = createContext({
+	api: undefined,
 	isLoggedIn: false,
 	keystore: undefined,
 	logout: async () => {},
 });
 
 export const SessionContextProvider = ({ children }) => {
-	const api = useApi();
+	const { isOnline } = useContext(OnlineStatusContext);
+	const api = useApi(isOnline);
 	const keystore = useLocalStorageKeystore();
 
 	const value: SessionContextValue = {
+		api,
 		isLoggedIn: api.isLoggedIn() && keystore.isOpen(),
 		keystore,
 		logout: async () => {

--- a/src/hoc/handleServerMessagesGuard.js
+++ b/src/hoc/handleServerMessagesGuard.js
@@ -4,7 +4,6 @@ import * as config from '../config';
 import { SignatureAction } from "../types/shared.types";
 import Spinner from '../components/Spinner';
 import { SigningRequestHandlerService } from '../services/SigningRequestHandlers';
-import { useApi } from "../api";
 import OnlineStatusContext from '../context/OnlineStatusContext';
 import SessionContext from "../context/SessionContext";
 
@@ -12,14 +11,13 @@ import SessionContext from "../context/SessionContext";
 export default function handleServerMessagesGuard(Component) {
 
 	return (props) => {
-		const api = useApi();
-		const appToken = api.getAppToken();
 
 		const [handshakeEstablished, setHandshakeEstablished] = useState(false);
 		const socketRef = useRef(null);
 		const signingRequestHandlerService = SigningRequestHandlerService();
 		const { isOnline } = useContext(OnlineStatusContext);
-		const { keystore } = useContext(SessionContext);
+		const { api, keystore } = useContext(SessionContext);
+		const appToken = api.getAppToken();
 
 		useEffect(() => {
 			if (appToken) {

--- a/src/pages/AddCredentials/AddCredentials.js
+++ b/src/pages/AddCredentials/AddCredentials.js
@@ -1,12 +1,14 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import OnlineStatusContext from '../../context/OnlineStatusContext';
+import SessionContext from '../../context/SessionContext';
+
 import QRCodeScanner from '../../components/QRCodeScanner/QRCodeScanner';
 import RedirectPopup from '../../components/Popups/RedirectPopup';
 import QRButton from '../../components/Buttons/QRButton';
-import { useApi } from '../../api';
-import OnlineStatusContext from '../../context/OnlineStatusContext';
 import { H1 } from '../../components/Heading';
+
 
 function highlightBestSequence(issuer, search) {
 	if (typeof issuer !== 'string' || typeof search !== 'string') {
@@ -21,7 +23,7 @@ function highlightBestSequence(issuer, search) {
 
 const Issuers = () => {
 	const { isOnline } = useContext(OnlineStatusContext);
-	const api = useApi(isOnline);
+	const { api } = useContext(SessionContext);
 	const [searchQuery, setSearchQuery] = useState('');
 	const [issuers, setIssuers] = useState([]);
 	const [filteredIssuers, setFilteredIssuers] = useState([]);

--- a/src/pages/History/History.js
+++ b/src/pages/History/History.js
@@ -7,18 +7,17 @@ import Slider from 'react-slick';
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 
-import { useApi } from '../../api';
+import SessionContext from '../../context/SessionContext';
 
 import CredentialInfo from '../../components/Credentials/CredentialInfo';
 import { formatDate } from '../../functions/DateFormat';
 import { base64url } from 'jose';
 import { CredentialImage } from '../../components/Credentials/CredentialImage';
-import OnlineStatusContext from '../../context/OnlineStatusContext';
 import { H1 } from '../../components/Heading';
 
+
 const History = () => {
-	const { isOnline } = useContext(OnlineStatusContext);
-	const api = useApi(isOnline);
+	const { api } = useContext(SessionContext);
 	const [history, setHistory] = useState([]);
 	const [matchingCredentials, setMatchingCredentials] = useState([]);
 	const [isImageModalOpen, setImageModalOpen] = useState(false);

--- a/src/pages/Home/CredentialDetail.js
+++ b/src/pages/Home/CredentialDetail.js
@@ -1,12 +1,10 @@
-// CredentialDetail.js
-
 import React, { useState, useEffect, useContext } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useTranslation, Trans } from 'react-i18next';
 import { extractCredentialFriendlyName } from "../../functions/extractCredentialFriendlyName";
 import { BiRightArrowAlt } from 'react-icons/bi';
 
-import { useApi } from '../../api';
+import SessionContext from '../../context/SessionContext';
 
 import CredentialInfo from '../../components/Credentials/CredentialInfo';
 import CredentialJson from '../../components/Credentials/CredentialJson';
@@ -14,12 +12,11 @@ import CredentialDeleteButton from '../../components/Credentials/CredentialDelet
 import FullscreenPopup from '../../components/Popups/FullscreenImg';
 import DeletePopup from '../../components/Popups/DeletePopup';
 import { CredentialImage } from '../../components/Credentials/CredentialImage';
-import OnlineStatusContext from '../../context/OnlineStatusContext';
 import { H1 } from '../../components/Heading';
 
+
 const CredentialDetail = () => {
-	const { isOnline } = useContext(OnlineStatusContext);
-	const api = useApi(isOnline);
+	const { api } = useContext(SessionContext);
 	const { id } = useParams();
 	const [vcEntity, setVcEntity] = useState(null);
 	const [showFullscreenImgPopup, setShowFullscreenImgPopup] = useState(false);

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -9,9 +9,10 @@ import Slider from 'react-slick';
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 
-import addImage from '../../assets/images/cred.png';
+import CredentialsContext from '../../context/CredentialsContext';
+import SessionContext from '../../context/SessionContext';
 
-import { useApi } from '../../api';
+import addImage from '../../assets/images/cred.png';
 import CredentialInfo from '../../components/Credentials/CredentialInfo';
 import CredentialJson from '../../components/Credentials/CredentialJson';
 import CredentialDeleteButton from '../../components/Credentials/CredentialDeleteButton';
@@ -20,11 +21,11 @@ import FullscreenPopup from '../../components/Popups/FullscreenImg';
 import DeletePopup from '../../components/Popups/DeletePopup';
 import { CredentialImage } from '../../components/Credentials/CredentialImage';
 import QRButton from '../../components/Buttons/QRButton';
-import CredentialsContext from '../../context/CredentialsContext';
 import { H1 } from '../../components/Heading';
 
+
 const Home = () => {
-	const api = useApi();
+	const { api } = useContext(SessionContext);
 	const { vcEntityList, latestCredentials, getData } = useContext(CredentialsContext);
 	const [isSmallScreen, setIsSmallScreen] = useState(window.innerWidth < 768);
 	const [currentSlide, setCurrentSlide] = useState(1);

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -6,9 +6,10 @@ import { AiOutlineUnlock } from 'react-icons/ai';
 import { Trans, useTranslation } from 'react-i18next';
 import { CSSTransition } from 'react-transition-group';
 
-import * as config from '../../config';
 import OnlineStatusContext from '../../context/OnlineStatusContext';
-import { useApi } from '../../api';
+import SessionContext from '../../context/SessionContext';
+
+import * as config from '../../config';
 import logo from '../../assets/images/logo.png';
 import GetButton from '../../components/Buttons/GetButton';
 import { PiWifiHighBold, PiWifiSlashBold } from "react-icons/pi";
@@ -16,7 +17,6 @@ import { PiWifiHighBold, PiWifiSlashBold } from "react-icons/pi";
 // import LanguageSelector from '../../components/LanguageSelector/LanguageSelector'; // Import the LanguageSelector component
 import * as CheckBrowserSupport from '../../components/BrowserSupport';
 import SeparatorLine from '../../components/SeparatorLine';
-import SessionContext from '../../context/SessionContext';
 
 
 const FormInputRow = ({
@@ -113,9 +113,8 @@ const WebauthnSignupLogin = ({
 	setError,
 }) => {
 	const { isOnline } = useContext(OnlineStatusContext);
-	const { keystore } = useContext(SessionContext);
+	const { api, keystore } = useContext(SessionContext);
 
-	const api = useApi(isOnline);
 	const [inProgress, setInProgress] = useState(false);
 	const [name, setName] = useState("");
 	const [needPrfRetry, setNeedPrfRetry] = useState(false);
@@ -475,8 +474,7 @@ const WebauthnSignupLogin = ({
 
 const Login = () => {
 	const { isOnline } = useContext(OnlineStatusContext);
-	const { isLoggedIn, keystore } = useContext(SessionContext);
-	const api = useApi(isOnline);
+	const { api, isLoggedIn, keystore } = useContext(SessionContext);
 	const { t } = useTranslation();
 	const location = useLocation();
 

--- a/src/pages/Login/LoginState.js
+++ b/src/pages/Login/LoginState.js
@@ -4,20 +4,19 @@ import { FaInfoCircle } from 'react-icons/fa';
 import { GoPasskeyFill } from 'react-icons/go';
 import { Trans, useTranslation } from 'react-i18next';
 import { CSSTransition } from 'react-transition-group';
+
 import OnlineStatusContext from '../../context/OnlineStatusContext';
-import { useApi } from '../../api';
+import SessionContext from '../../context/SessionContext';
+
 import logo from '../../assets/images/logo.png';
 import GetButton from '../../components/Buttons/GetButton';
 import { PiWifiHighBold, PiWifiSlashBold } from "react-icons/pi";
-import SessionContext from '../../context/SessionContext';
 
 
 const WebauthnLogin = ({
 	filteredUser,
 }) => {
-	const { isOnline } = useContext(OnlineStatusContext);
-	const { keystore } = useContext(SessionContext);
-	const api = useApi(isOnline);
+	const { api, keystore } = useContext(SessionContext);
 	const [error, setError] = useState('');
 	const navigate = useNavigate();
 	const location = useLocation();

--- a/src/pages/SendCredentials/SendCredentials.js
+++ b/src/pages/SendCredentials/SendCredentials.js
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import OnlineStatusContext from '../../context/OnlineStatusContext';
+import SessionContext from '../../context/SessionContext';
+
 import QRCodeScanner from '../../components/QRCodeScanner/QRCodeScanner'; // Replace with the actual import path
 import RedirectPopup from '../../components/Popups/RedirectPopup';
 import QRButton from '../../components/Buttons/QRButton';
-import { useApi } from '../../api';
-import OnlineStatusContext from '../../context/OnlineStatusContext';
 import { H1 } from '../../components/Heading';
 
 
@@ -22,7 +23,7 @@ function highlightBestSequence(verifier, search) {
 
 const Verifiers = () => {
 	const { isOnline } = useContext(OnlineStatusContext);
-	const api = useApi(isOnline);
+	const { api } = useContext(SessionContext);
 	const [searchQuery, setSearchQuery] = useState('');
 	const [verifiers, setVerifiers] = useState([]);
 	const [filteredVerifiers, setFilteredVerifiers] = useState([]);

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -3,16 +3,17 @@ import { Trans, useTranslation } from 'react-i18next';
 import { FaEdit, FaSyncAlt, FaTrash } from 'react-icons/fa';
 import { BsLock, BsPlusCircle, BsUnlock } from 'react-icons/bs';
 
-import { useApi } from '../../api';
+import OnlineStatusContext from '../../context/OnlineStatusContext';
+import SessionContext from '../../context/SessionContext';
+
 import { UserData, WebauthnCredential } from '../../api/types';
 import { compareBy, toBase64Url } from '../../util';
 import { formatDate } from '../../functions/DateFormat';
 import type { WebauthnPrfEncryptionKeyInfo, WrappedKeyInfo } from '../../services/keystore';
 import { isPrfKeyV2, serializePrivateData } from '../../services/keystore';
+
 import DeletePopup from '../../components/Popups/DeletePopup';
 import GetButton from '../../components/Buttons/GetButton';
-import OnlineStatusContext from '../../context/OnlineStatusContext';
-import SessionContext from '../../context/SessionContext';
 import { H1, H2, H3 } from '../../components/Heading';
 
 
@@ -87,8 +88,7 @@ const WebauthnRegistation = ({
 	wrappedMainKey?: WrappedKeyInfo,
 }) => {
 	const { isOnline } = useContext(OnlineStatusContext);
-	const { keystore } = useContext(SessionContext);
-	const api = useApi();
+	const { api, keystore } = useContext(SessionContext);
 	const [beginData, setBeginData] = useState(null);
 	const [pendingCredential, setPendingCredential] = useState(null);
 	const [nickname, setNickname] = useState("");
@@ -679,8 +679,7 @@ const WebauthnCredentialItem = ({
 
 const Settings = () => {
 	const { isOnline } = useContext(OnlineStatusContext);
-	const { logout, keystore } = useContext(SessionContext);
-	const api = useApi(isOnline);
+	const { api, logout, keystore } = useContext(SessionContext);
 	const [userData, setUserData] = useState<UserData>(null);
 	const { webauthnCredentialCredentialId: loggedInPasskeyCredentialId } = api.getSession();
 	const [unwrappingKey, setUnwrappingKey] = useState<CryptoKey | null>(null);

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -15,10 +15,6 @@ import OnlineStatusContext from '../../context/OnlineStatusContext';
 import SessionContext from '../../context/SessionContext';
 import { H1, H2, H3 } from '../../components/Heading';
 
-interface OnlineStatusContextType {
-	isOnline: boolean | null;
-}
-
 
 function useWebauthnCredentialNickname(credential: WebauthnCredential): string {
 	const { t } = useTranslation();
@@ -90,7 +86,7 @@ const WebauthnRegistation = ({
 	onSuccess: () => void,
 	wrappedMainKey?: WrappedKeyInfo,
 }) => {
-	const { isOnline } = useContext(OnlineStatusContext) as OnlineStatusContextType;
+	const { isOnline } = useContext(OnlineStatusContext);
 	const { keystore } = useContext(SessionContext);
 	const api = useApi();
 	const [beginData, setBeginData] = useState(null);
@@ -324,7 +320,7 @@ const UnlockMainKey = ({
 	onUnlock: (unwrappingKey: CryptoKey, wrappedMainKey: WrappedKeyInfo) => void,
 	unlocked: boolean,
 }) => {
-	const { isOnline } = useContext(OnlineStatusContext) as OnlineStatusContextType;
+	const { isOnline } = useContext(OnlineStatusContext);
 	const { keystore } = useContext(SessionContext);
 	const [inProgress, setInProgress] = useState(false);
 	const [resolvePasswordPromise, setResolvePasswordPromise] = useState<((password: string) => void) | null>(null);
@@ -488,7 +484,7 @@ const WebauthnCredentialItem = ({
 	onUpgradePrfKey: (prfKeyInfo: WebauthnPrfEncryptionKeyInfo) => void,
 	unlocked: boolean,
 }) => {
-	const { isOnline } = useContext(OnlineStatusContext) as OnlineStatusContextType;
+	const { isOnline } = useContext(OnlineStatusContext);
 	const [nickname, setNickname] = useState(credential.nickname || '');
 	const [editing, setEditing] = useState(false);
 	const { t } = useTranslation();
@@ -682,7 +678,7 @@ const WebauthnCredentialItem = ({
 };
 
 const Settings = () => {
-	const { isOnline } = useContext(OnlineStatusContext) as OnlineStatusContextType;
+	const { isOnline } = useContext(OnlineStatusContext);
 	const { logout, keystore } = useContext(SessionContext);
 	const api = useApi(isOnline);
 	const [userData, setUserData] = useState<UserData>(null);


### PR DESCRIPTION
These are a couple of somewhat independent changes, but bundling them together in one PR avoids conflicts as they modify adjacent lines of code:

- Translate `OnlineStatusContext` to TypeScript and move value type declaration into this module.
- Get `api` from `SessionContext` instead of using `useApi`, like we now do with `LocalStorageKeystore`.
- Remove `useMemo` from `api/index.ts`, as this is no longer needed since we have only one instance in the `SessionContext`. This simplifies the code by removing hook dependencies etc.
- Remove `useCallback` uses from `<WebauthnSignupLogin>` since they don't noticeably affect performance and this simplifies the code by removing hook dependencies etc.