### PR TITLE
Fix login redirect by replacing useNavigate with window.location.href

### DIFF
--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -152,7 +152,7 @@ const WebauthnSignupLogin = ({
 		async (cachedUser) => {
 			const result = await api.loginWebauthn(keystore, promptForPrfRetry, cachedUser);
 			if (result.ok) {
-				navigate(from, { replace: true });
+				window.location.href = from.pathname + from.search;
 
 			} else {
 				// Using a switch here so the t() argument can be a literal, to ease searching


### PR DESCRIPTION
This PR fixes an issue where the login redirect was not functioning correctly (etc pre-authorized code) after a successful login. Previously, we used `useNavigate` to handle the redirect, but due to recent changes (possibly on browser or `useNavigate` behavior), the navigation was not working as expected.

To resolve this issue, we replaced `navigate(from, { replace: true })` with `window.location.href = from.pathname + from.search`, which ensures the correct redirection to the intended page after login.