### PR TITLE
Auto-reload on new content detection

### DIFF
--- a/src/offlineRegistrationSW.js
+++ b/src/offlineRegistrationSW.js
@@ -44,6 +44,7 @@ function registerValidSW(swUrl, config) {
 							console.log(
 								'New content is available and will be used when all tabs for this page are closed. See https://cra.link/PWA.'
 							);
+							window.location.reload();
 
 							if (config && config.onUpdate) {
 								config.onUpdate(registration);

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -40,3 +40,11 @@ registerRoute(
 		],
 	})
 );
+
+self.addEventListener('install', (event) => {
+	self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+	clientsClaim();
+});


### PR DESCRIPTION
The service worker has been updated to automatically reload the page whenever new content is detected. This ensures that users always get the latest version of the application without needing to manually clean cookies. The new version of the service worker takes control immediately upon installation, triggering a seamless update experience.