### PR TITLE
Use compareBy in sort() calls

### DIFF
--- a/src/context/CredentialsContext.js
+++ b/src/context/CredentialsContext.js
@@ -2,6 +2,7 @@ import React, { createContext, useState, useCallback, useContext, useRef } from 
 import { extractCredentialFriendlyName } from '../functions/extractCredentialFriendlyName';
 import { getItem } from '../indexedDB';
 import SessionContext from './SessionContext';
+import { compareBy } from '../util';
 
 const CredentialsContext = createContext();
 
@@ -21,7 +22,7 @@ export const CredentialsProvider = ({ children }) => {
 			return { ...vcEntity, friendlyName: name };
 		}));
 
-		vcEntityList.sort((vcA, vcB) => new Date(vcB.issuanceDate) - new Date(vcA.issuanceDate));
+		vcEntityList.sort(compareBy(vc => new Date(vc.issuanceDate)));
 
 		return vcEntityList;
 	};

--- a/src/pages/History/History.js
+++ b/src/pages/History/History.js
@@ -14,6 +14,7 @@ import { formatDate } from '../../functions/DateFormat';
 import { base64url } from 'jose';
 import { CredentialImage } from '../../components/Credentials/CredentialImage';
 import { H1 } from '../../components/Heading';
+import { compareBy } from '../../util';
 
 
 const History = () => {
@@ -63,7 +64,7 @@ const History = () => {
 				console.log(fetchedPresentations.vp_list);
 				// Extract and map the vp_list from fetchedPresentations.
 				const vpListFromApi = fetchedPresentations.vp_list
-					.sort((vpA, vpB) => vpB.issuanceDate - vpA.issuanceDate)
+					.sort(compareBy(vp => vp.issuanceDate))
 					.map((item) => ({
 						id: item.id,
 						presentation: item.presentation,

--- a/src/util.ts
+++ b/src/util.ts
@@ -63,6 +63,20 @@ export function jsonParseTaggedBinary(json: string): any {
 	return JSON.parse(json, reviverTaggedBinaryToUint8Array);
 }
 
+/**
+	Create a comparator function comparing the result of passing each argument through the given function.
+	The function returned by `compareBy` is suitable as an argument to `Array.sort()`, for example.
+
+	Example:
+	```
+	list.sort(compareBy(obj => new Date(obj.issuanceDate)));
+	```
+
+	The above is equivalent to:
+	```
+	list.sort((objA, objB) => new Date(objB.issuanceDate) - new Date(objA.issuanceDate));
+	```
+ */
 export function compareBy<T, U>(f: (v: T) => U): (a: T, b: T) => number {
 	return (a: T, b: T) => {
 		const fa = f(a);


### PR DESCRIPTION
This was something I noticed when during one of my experiments I had translated `CredentialsContext` to TypeScript:

```
ERROR in src/context/CredentialsContext.tsx:24:64
TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
    22 |            }));
    23 |
  > 24 |            vcEntityList.sort((vcA, vcB) => new Date(vcB.issuanceDate) - new Date(vcA.issuanceDate));
       |                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
```
