### PR TITLE
Claim clients on service worker activation for update notification

### DIFF
--- a/src/offlineRegistrationSW.js
+++ b/src/offlineRegistrationSW.js
@@ -66,9 +66,8 @@ function registerValidSW(swUrl, config) {
 if ('serviceWorker' in navigator) {
 	navigator.serviceWorker.addEventListener('message', (event) => {
 		if (event.data && event.data.type === 'NEW_CONTENT_AVAILABLE') {
-			if (window.confirm('New version is available. Would you like to reload to get the latest now?')) {
-				window.location.reload();
-			}
+			console.log('New version is available. Would you like to reload to get the latest now?')
+			window.location.reload();
 		}
 	});
 }

--- a/src/offlineRegistrationSW.js
+++ b/src/offlineRegistrationSW.js
@@ -33,6 +33,7 @@ function registerValidSW(swUrl, config) {
 		.register(swUrl)
 		.then((registration) => {
 			console.log('Service worker registered with scope:', registration.scope);
+
 			registration.onupdatefound = () => {
 				const installingWorker = registration.installing;
 				if (installingWorker == null) {
@@ -41,9 +42,7 @@ function registerValidSW(swUrl, config) {
 				installingWorker.onstatechange = () => {
 					if (installingWorker.state === 'installed') {
 						if (navigator.serviceWorker.controller) {
-							console.log(
-								'New content is available and will be used when all tabs for this page are closed. See https://cra.link/PWA.'
-							);
+							console.log('New content is available; please refresh.');
 
 							if (config && config.onUpdate) {
 								config.onUpdate(registration);
@@ -62,6 +61,16 @@ function registerValidSW(swUrl, config) {
 		.catch((error) => {
 			console.error('Error during service worker registration:', error);
 		});
+}
+
+if ('serviceWorker' in navigator) {
+	navigator.serviceWorker.addEventListener('message', (event) => {
+		if (event.data && event.data.type === 'NEW_CONTENT_AVAILABLE') {
+			if (window.confirm('New version is available. Would you like to reload to get the latest now?')) {
+				window.location.reload();
+			}
+		}
+	});
 }
 
 function checkValidServiceWorker(swUrl, config) {

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -40,3 +40,23 @@ registerRoute(
 		],
 	})
 );
+
+self.addEventListener('install', (event) => {
+	self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+	event.waitUntil(
+		self.clients.claim().then(() => {
+			console.log('Service worker activated and claimed all clients.', self.clients.matchAll());
+
+			return self.clients.matchAll().then((clients) => {
+				clients.forEach((client) => {
+					client.postMessage({
+						type: 'NEW_CONTENT_AVAILABLE',
+					});
+				});
+			});
+		})
+	);
+});


### PR DESCRIPTION
- Added `self.clients.claim()` in the service worker's `activate` event to take control of all open tabs.
- Auto page reload in order to get new content( if a tab already opened, maybe requiring a page refresh.)