### PR TITLE
Fix lint and streamline button component

### DIFF
--- a/src/components/BrowserSupport.tsx
+++ b/src/components/BrowserSupport.tsx
@@ -5,7 +5,7 @@ import { useSessionStorage } from '../hooks/useStorage';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { FaCheckCircle, FaExclamationTriangle } from 'react-icons/fa';
-import GetButton from './Buttons/GetButton';
+import Button from './Buttons/Button';
 
 const noWarnPlatforms = [
 	{ browser: /chrome/ui, not: { os: /ios/ui } },
@@ -134,7 +134,7 @@ export function WarningPortal({
 
 				<p className="text-sm dark:text-gray-300">{t('browserSupportWarningPortal.outro')}</p>
 
-				<GetButton
+				<Button
 					content={t('browserSupportWarningPortal.continueAnyway')}
 					onClick={() => setBypass(true)}
 					additionalClassName='text-white bg-gray-300 hover:bg-gray-400 w-full'

--- a/src/components/BrowserSupport.tsx
+++ b/src/components/BrowserSupport.tsx
@@ -135,10 +135,11 @@ export function WarningPortal({
 				<p className="text-sm dark:text-gray-300">{t('browserSupportWarningPortal.outro')}</p>
 
 				<Button
-					content={t('browserSupportWarningPortal.continueAnyway')}
 					onClick={() => setBypass(true)}
 					additionalClassName='text-white bg-gray-300 hover:bg-gray-400 w-full'
-				/>
+				>
+					t('browserSupportWarningPortal.continueAnyway')
+				</Button>
 			</>
 		);
 	}

--- a/src/components/Buttons/Button.js
+++ b/src/components/Buttons/Button.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const GetButton = ({ type = 'button', content, onClick, variant = 'custom', additionalClassName = '', disabled = false, ariaLabel, title }) => {
+const Button = ({ type = 'button', content, onClick, variant = 'custom', additionalClassName = '', disabled = false, ariaLabel, title }) => {
 
 	const getVariantClassName = () => {
 		const commonClasses = 'rounded-lg shadow-sm text-sm px-4 py-2 text-center flex flex-row flex-nowrap items-center justify-center';
@@ -37,4 +37,4 @@ const GetButton = ({ type = 'button', content, onClick, variant = 'custom', addi
 	);
 };
 
-export default GetButton;
+export default Button;

--- a/src/components/Buttons/Button.tsx
+++ b/src/components/Buttons/Button.tsx
@@ -6,6 +6,7 @@ export type Variant = (
 	| 'tertiary'
 	| 'cancel'
 	| 'delete'
+	| 'link'
 	| 'custom'
 );
 
@@ -44,6 +45,8 @@ const Button = ({
 				return `${commonClasses} ${!disabled ? "text-gray-900 bg-gray-300 hover:bg-gray-400" : "text-white bg-gray-300 cursor-not-allowed hover:bg-gray-300"}`;
 			case 'delete':
 				return `${commonClasses} ${!disabled ? "text-white bg-red-600 hover:bg-red-700" : "text-red-400 bg-gray-300 hover:bg-gray-300 cursor-not-allowed"}`;
+			case 'link':
+				return `font-medium ${!disabled ? "text-primary dark:text-primary-light hover:underline" : "text-gray-400 cursor-not-allowed"}`;
 			default:
 				return `${commonClasses}`;
 		}

--- a/src/components/Buttons/Button.tsx
+++ b/src/components/Buttons/Button.tsx
@@ -11,7 +11,7 @@ export type Variant = (
 
 export type Props = {
 	type?: 'button' | 'reset' | 'submit',
-	content: React.ReactNode,
+	children?: React.ReactNode,
 	onClick?: React.MouseEventHandler<HTMLButtonElement>,
 	variant?: Variant,
 	additionalClassName?: string,
@@ -22,7 +22,7 @@ export type Props = {
 
 const Button = ({
 	type = 'button',
-	content,
+	children,
 	onClick,
 	variant = 'custom',
 	additionalClassName = '',
@@ -61,7 +61,7 @@ const Button = ({
 			{...(ariaLabel && { 'aria-label': ariaLabel })}
 			{...(title && { title })}
 		>
-			{content}
+			{children}
 		</button>
 	);
 };

--- a/src/components/Buttons/Button.tsx
+++ b/src/components/Buttons/Button.tsx
@@ -1,6 +1,35 @@
 import React from 'react';
 
-const Button = ({ type = 'button', content, onClick, variant = 'custom', additionalClassName = '', disabled = false, ariaLabel, title }) => {
+export type Variant = (
+	'primary'
+	| 'secondary'
+	| 'tertiary'
+	| 'cancel'
+	| 'delete'
+	| 'custom'
+);
+
+export type Props = {
+	type?: 'button' | 'reset' | 'submit',
+	content: React.ReactNode,
+	onClick?: React.MouseEventHandler<HTMLButtonElement>,
+	variant?: Variant,
+	additionalClassName?: string,
+	disabled?: boolean,
+	ariaLabel?: string,
+	title?: string,
+};
+
+const Button = ({
+	type = 'button',
+	content,
+	onClick,
+	variant = 'custom',
+	additionalClassName = '',
+	disabled = false,
+	ariaLabel,
+	title,
+}: Props) => {
 
 	const getVariantClassName = () => {
 		const commonClasses = 'rounded-lg shadow-sm text-sm px-4 py-2 text-center flex flex-row flex-nowrap items-center justify-center';

--- a/src/components/Buttons/Button.tsx
+++ b/src/components/Buttons/Button.tsx
@@ -6,6 +6,7 @@ export type Variant = (
 	| 'tertiary'
 	| 'cancel'
 	| 'delete'
+	| 'outline'
 	| 'link'
 	| 'custom'
 );
@@ -45,6 +46,8 @@ const Button = ({
 				return `${commonClasses} ${!disabled ? "text-gray-900 bg-gray-300 hover:bg-gray-400" : "text-white bg-gray-300 cursor-not-allowed hover:bg-gray-300"}`;
 			case 'delete':
 				return `${commonClasses} ${!disabled ? "text-white bg-red-600 hover:bg-red-700" : "text-red-400 bg-gray-300 hover:bg-gray-300 cursor-not-allowed"}`;
+			case 'outline':
+				return `bg-white px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-100 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-white ${!disabled ? 'cursor-pointer' : 'text-gray-300 border-gray-300 dark:text-gray-700 dark:border-gray-700 cursor-not-allowed' }`;
 			case 'link':
 				return `font-medium ${!disabled ? "text-primary dark:text-primary-light hover:underline" : "text-gray-400 cursor-not-allowed"}`;
 			default:

--- a/src/components/Buttons/QRButton.js
+++ b/src/components/Buttons/QRButton.js
@@ -9,13 +9,12 @@ const QRButton = ({ openQRScanner, isSmallScreen }) => {
 		return (
 			<div className="mb-2">
 				<Button
-					content={
-						<BsQrCodeScan size={20} className="text-white" />
-					}
 					onClick={openQRScanner}
 					variant="primary"
 					additionalClassName={`${isMobile ? "fixed z-20 bottom-[85px] right-5" : ""} step-2`}
-				/>
+				>
+					<BsQrCodeScan size={20} className="text-white" />
+				</Button>
 			</div>
 
 		);

--- a/src/components/Buttons/QRButton.js
+++ b/src/components/Buttons/QRButton.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BsQrCodeScan } from 'react-icons/bs';
-import GetButton from './GetButton';
+import Button from './Button';
 
 const QRButton = ({ openQRScanner, isSmallScreen }) => {
 	const isMobile = window.innerWidth <= 480;
@@ -8,7 +8,7 @@ const QRButton = ({ openQRScanner, isSmallScreen }) => {
 	if (isSmallScreen) {
 		return (
 			<div className="mb-2">
-				<GetButton
+				<Button
 					content={
 						<BsQrCodeScan size={20} className="text-white" />
 					}

--- a/src/components/Credentials/CredentialDeleteButton.js
+++ b/src/components/Credentials/CredentialDeleteButton.js
@@ -15,17 +15,13 @@ const CredentialDeleteButton = ({ onDelete }) => {
 	return (
 		<div className="lg:p-0 p-2 w-full lg:mt-5 mt-2">
 			<Button
-				content={
-					<>
-						<MdDelete size={20} /> {t('common.delete')}
-					</>
-				}
 				onClick={handleClick}
 				variant="delete"
 				disabled={!isOnline}
 				title={!isOnline && t('common.offlineTitle')}
-
-			/>
+			>
+				<MdDelete size={20} /> {t('common.delete')}
+			</Button>
 		</div>
 	);
 };

--- a/src/components/Credentials/CredentialDeleteButton.js
+++ b/src/components/Credentials/CredentialDeleteButton.js
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import { MdDelete } from 'react-icons/md';
 import { useTranslation } from 'react-i18next';
-import GetButton from '../../components/Buttons/GetButton';
+import Button from '../Buttons/Button';
 import OnlineStatusContext from '../../context/OnlineStatusContext';
 
 const CredentialDeleteButton = ({ onDelete }) => {
@@ -14,7 +14,7 @@ const CredentialDeleteButton = ({ onDelete }) => {
 
 	return (
 		<div className="lg:p-0 p-2 w-full lg:mt-5 mt-2">
-			<GetButton
+			<Button
 				content={
 					<>
 						<MdDelete size={20} /> {t('common.delete')}

--- a/src/components/Credentials/CredentialJson.js
+++ b/src/components/Credentials/CredentialJson.js
@@ -21,19 +21,16 @@ const CredentialJson = ({ credential }) => {
 		<div className=" lg:p-0 p-2 w-full">
 			<div className="mb-4 flex items-center">
 				<Button
-					content={
-						<>
-							{showJsonCredentials ? 'Hide Credentials Details' : 'Show Credentials Details'}
-							{showJsonCredentials ? (
-								<AiOutlineUp className="ml-1" />
-							) : (
-								<AiOutlineDown className="ml-1" />
-							)}
-						</>
-					}
 					onClick={() => setShowJsonCredentials(!showJsonCredentials)}
 					variant="primary"
-				/>
+				>
+					{showJsonCredentials ? 'Hide Credentials Details' : 'Show Credentials Details'}
+					{showJsonCredentials ? (
+						<AiOutlineUp className="ml-1" />
+					) : (
+						<AiOutlineDown className="ml-1" />
+					)}
+				</Button>
 			</div>
 
 			<hr className="my-2 border-t border-primary dark:border-primary-light py-2" />

--- a/src/components/Credentials/CredentialJson.js
+++ b/src/components/Credentials/CredentialJson.js
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from 'react';
 
 import { AiOutlineDown, AiOutlineUp } from 'react-icons/ai';
 import { parseCredential } from '../../functions/parseCredential';
-import GetButton from '../Buttons/GetButton';
+import Button from '../Buttons/Button';
 
 const CredentialJson = ({ credential }) => {
 	const [showJsonCredentials, setShowJsonCredentials] = useState(false);
@@ -20,7 +20,7 @@ const CredentialJson = ({ credential }) => {
 	return (
 		<div className=" lg:p-0 p-2 w-full">
 			<div className="mb-4 flex items-center">
-				<GetButton
+				<Button
 					content={
 						<>
 							{showJsonCredentials ? 'Hide Credentials Details' : 'Show Credentials Details'}

--- a/src/components/Popups/DeletePopup.js
+++ b/src/components/Popups/DeletePopup.js
@@ -2,7 +2,7 @@ import Modal from 'react-modal';
 import { useTranslation } from 'react-i18next';
 import { FaTrash } from 'react-icons/fa';
 import Spinner from '../Spinner';
-import GetButton from '../Buttons/GetButton';
+import Button from '../Buttons/Button';
 
 const DeletePopup = ({ isOpen, onConfirm, onCancel, message, loading }) => {
 	const { t } = useTranslation();
@@ -36,12 +36,12 @@ const DeletePopup = ({ isOpen, onConfirm, onCancel, message, loading }) => {
 			<hr className="mb-2 border-t border-red-500/80" />
 			<p className="mb-2 mt-4 text-gray-700 dark:text-white">{message}</p>
 			<div className="flex justify-end space-x-2 pt-4">
-				<GetButton
+				<Button
 					content={t('common.cancel')}
 					onClick={onCancel}
 					variant="cancel"
 				/>
-				<GetButton
+				<Button
 					content={t('common.delete')}
 					onClick={onConfirm}
 					variant="delete"

--- a/src/components/Popups/DeletePopup.js
+++ b/src/components/Popups/DeletePopup.js
@@ -36,16 +36,12 @@ const DeletePopup = ({ isOpen, onConfirm, onCancel, message, loading }) => {
 			<hr className="mb-2 border-t border-red-500/80" />
 			<p className="mb-2 mt-4 text-gray-700 dark:text-white">{message}</p>
 			<div className="flex justify-end space-x-2 pt-4">
-				<Button
-					content={t('common.cancel')}
-					onClick={onCancel}
-					variant="cancel"
-				/>
-				<Button
-					content={t('common.delete')}
-					onClick={onConfirm}
-					variant="delete"
-				/>
+				<Button variant="cancel" onClick={onCancel}>
+					{t('common.cancel')}
+				</Button>
+				<Button variant="delete" onClick={onConfirm}>
+					{t('common.delete')}
+				</Button>
 			</div>
 		</Modal>
 	);

--- a/src/components/Popups/MessagePopup.js
+++ b/src/components/Popups/MessagePopup.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Modal from 'react-modal';
 import { FaCheckCircle, FaExclamationCircle } from 'react-icons/fa';
 import { useTranslation } from 'react-i18next';
-import GetButton from '../Buttons/GetButton';
+import Button from '../Buttons/Button';
 
 const MessagePopup = ({ type, message, onClose }) => {
 	const { title, description } = message || {};
@@ -37,7 +37,7 @@ const MessagePopup = ({ type, message, onClose }) => {
 					{description}
 				</p>
 				<div className="flex justify-end space-x-2 pt-4">
-					<GetButton
+					<Button
 						content={t('messagePopup.close')}
 						onClick={onClose}
 						variant="cancel"

--- a/src/components/Popups/MessagePopup.js
+++ b/src/components/Popups/MessagePopup.js
@@ -37,11 +37,9 @@ const MessagePopup = ({ type, message, onClose }) => {
 					{description}
 				</p>
 				<div className="flex justify-end space-x-2 pt-4">
-					<Button
-						content={t('messagePopup.close')}
-						onClick={onClose}
-						variant="cancel"
-					/>
+					<Button variant="cancel" onClick={onClose}>
+						{t('messagePopup.close')}
+					</Button>
 				</div>
 		</Modal>
 	);

--- a/src/components/Popups/PinInput.js
+++ b/src/components/Popups/PinInput.js
@@ -4,7 +4,7 @@ import Modal from 'react-modal';
 import { useNavigate } from 'react-router-dom';
 import { FaLock } from "react-icons/fa";
 import { useTranslation } from 'react-i18next';
-import GetButton from '../Buttons/GetButton';
+import Button from '../Buttons/Button';
 import SessionContext from '../../context/SessionContext';
 
 function PinInput({ showPopup, setShowPopup }) {
@@ -152,12 +152,12 @@ function PinInput({ showPopup, setShowPopup }) {
 			</div>
 
 			<div className="flex justify-end space-x-2 pt-4">
-				<GetButton
+				<Button
 					content={t('common.cancel')}
 					onClick={handleCancel}
 					variant="cancel"
 				/>
-				<GetButton
+				<Button
 					content={t('common.submit')}
 					onClick={handleSubmit}
 					variant="primary"

--- a/src/components/Popups/PinInput.js
+++ b/src/components/Popups/PinInput.js
@@ -152,16 +152,12 @@ function PinInput({ showPopup, setShowPopup }) {
 			</div>
 
 			<div className="flex justify-end space-x-2 pt-4">
-				<Button
-					content={t('common.cancel')}
-					onClick={handleCancel}
-					variant="cancel"
-				/>
-				<Button
-					content={t('common.submit')}
-					onClick={handleSubmit}
-					variant="primary"
-				/>
+				<Button variant="cancel" onClick={handleCancel}>
+					{t('common.cancel')}
+				</Button>
+				<Button variant="primary" onClick={handleSubmit}>
+					{t('common.submit')}
+				</Button>
 			</div>
 		</Modal>
 	);

--- a/src/components/Popups/RedirectPopup.js
+++ b/src/components/Popups/RedirectPopup.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Modal from 'react-modal';
 import { FaShare } from 'react-icons/fa';
 import { useTranslation } from 'react-i18next';
-import GetButton from '../Buttons/GetButton';
+import Button from '../Buttons/Button';
 import Spinner from '../../components/Spinner';
 
 
@@ -37,12 +37,12 @@ const RedirectPopup = ({ loading, handleClose, handleContinue, popupTitle, popup
 				{popupMessage}
 			</p>
 			<div className="flex justify-end space-x-2 pt-4">
-				<GetButton
+				<Button
 					content={t('common.cancel')}
 					onClick={handleClose}
 					variant="cancel"
 				/>
-				<GetButton
+				<Button
 					content={t('common.continue')}
 					onClick={handleContinue}
 					variant="primary"
@@ -53,4 +53,3 @@ const RedirectPopup = ({ loading, handleClose, handleContinue, popupTitle, popup
 };
 
 export default RedirectPopup;
-

--- a/src/components/Popups/RedirectPopup.js
+++ b/src/components/Popups/RedirectPopup.js
@@ -37,16 +37,12 @@ const RedirectPopup = ({ loading, handleClose, handleContinue, popupTitle, popup
 				{popupMessage}
 			</p>
 			<div className="flex justify-end space-x-2 pt-4">
-				<Button
-					content={t('common.cancel')}
-					onClick={handleClose}
-					variant="cancel"
-				/>
-				<Button
-					content={t('common.continue')}
-					onClick={handleContinue}
-					variant="primary"
-				/>
+				<Button variant="cancel" onClick={handleClose}>
+					{t('common.cancel')}
+				</Button>
+				<Button variant="primary" onClick={handleContinue}>
+					{t('common.continue')}
+				</Button>
 			</div>
 		</Modal>
 	);

--- a/src/components/Popups/SelectCredentials.js
+++ b/src/components/Popups/SelectCredentials.js
@@ -240,11 +240,15 @@ function SelectCredentials({ showPopup, setShowPopup, setSelectionMap, conforman
 							</button>
 							<div className='w-2/3 mt-2'>
 								<Button
-									content={credentialDisplay[vcEntity.credentialIdentifier] ? t('selectCredentialPopup.detailsHide') : t('selectCredentialPopup.detailsShow')}
 									onClick={() => toggleCredentialDisplay(vcEntity.credentialIdentifier)}
 									variant="primary"
 									additionalClassName='text-xs w-full'
-								/>
+								>
+									{credentialDisplay[vcEntity.credentialIdentifier]
+										? t('selectCredentialPopup.detailsHide')
+										: t('selectCredentialPopup.detailsShow')
+									}
+								</Button>
 								<div
 									className={`transition-all ease-in-out duration-1000 overflow-hidden shadow-md rounded-lg dark:bg-gray-700 ${credentialDisplay[vcEntity.credentialIdentifier] ? 'max-h-[500px] opacity-100' : 'max-h-0 opacity-0'}`}
 								>
@@ -257,29 +261,30 @@ function SelectCredentials({ showPopup, setShowPopup, setSelectionMap, conforman
 			</div>
 			<div className="flex justify-between mt-4">
 				<Button
-					content={t('common.cancel')}
 					onClick={handleCancel}
 					variant="cancel"
 					className="mr-2"
-				/>
+				>
+					{t('common.cancel')}
+				</Button>
 
 				<div className="flex gap-2">
 					{currentIndex > 0 && (
-						<Button
-							content={t('common.previous')}
-							onClick={goToPreviousSelection}
-							variant="secondary"
-						/>
+						<Button variant="secondary" onClick={goToPreviousSelection}>
+							{t('common.previous')}
+						</Button>
 					)}
 
 					<Button
-						content={currentIndex < keys.length - 1 ? t('common.next') : t('common.navItemSendCredentialsSimple')}
 						onClick={goToNextSelection}
 						variant="primary"
 						disabled={!selectedCredential}
 						title={!selectedCredential ? t('selectCredentialPopup.nextButtonDisabledTitle') : ''}
-
-					/>
+					>
+						{currentIndex < keys.length - 1
+							? t('common.next')
+							: t('common.navItemSendCredentialsSimple')}
+					</Button>
 				</div>
 			</div>
 

--- a/src/components/Popups/SelectCredentials.js
+++ b/src/components/Popups/SelectCredentials.js
@@ -5,7 +5,7 @@ import { FaShare, FaRegCircle, FaCheckCircle } from 'react-icons/fa';
 import { useTranslation, Trans } from 'react-i18next';
 import { CredentialImage } from '../Credentials/CredentialImage';
 import CredentialInfo from '../Credentials/CredentialInfo';
-import GetButton from '../Buttons/GetButton';
+import Button from '../Buttons/Button';
 import { extractCredentialFriendlyName } from "../../functions/extractCredentialFriendlyName";
 import SessionContext from '../../context/SessionContext';
 
@@ -239,7 +239,7 @@ function SelectCredentials({ showPopup, setShowPopup, setSelectionMap, conforman
 								</div>
 							</button>
 							<div className='w-2/3 mt-2'>
-								<GetButton
+								<Button
 									content={credentialDisplay[vcEntity.credentialIdentifier] ? t('selectCredentialPopup.detailsHide') : t('selectCredentialPopup.detailsShow')}
 									onClick={() => toggleCredentialDisplay(vcEntity.credentialIdentifier)}
 									variant="primary"
@@ -256,7 +256,7 @@ function SelectCredentials({ showPopup, setShowPopup, setSelectionMap, conforman
 				))}
 			</div>
 			<div className="flex justify-between mt-4">
-				<GetButton
+				<Button
 					content={t('common.cancel')}
 					onClick={handleCancel}
 					variant="cancel"
@@ -265,14 +265,14 @@ function SelectCredentials({ showPopup, setShowPopup, setSelectionMap, conforman
 
 				<div className="flex gap-2">
 					{currentIndex > 0 && (
-						<GetButton
+						<Button
 							content={t('common.previous')}
 							onClick={goToPreviousSelection}
 							variant="secondary"
 						/>
 					)}
 
-					<GetButton
+					<Button
 						content={currentIndex < keys.length - 1 ? t('common.next') : t('common.navItemSendCredentialsSimple')}
 						onClick={goToNextSelection}
 						variant="primary"

--- a/src/components/WelcomeTourGuide/WecomeModal.js
+++ b/src/components/WelcomeTourGuide/WecomeModal.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Modal from 'react-modal';
 import { FaHandshake } from "react-icons/fa";
 import { useTranslation, Trans } from 'react-i18next';
-import GetButton from '../Buttons/GetButton';
+import Button from '../Buttons/Button';
 
 const WecomeModal = ({ isOpen, onStartTour, onClose }) => {
 	const { t } = useTranslation();
@@ -35,12 +35,12 @@ const WecomeModal = ({ isOpen, onStartTour, onClose }) => {
 			</p>
 
 			<div className="flex justify-center gap-2 pt-4">
-				<GetButton
+				<Button
 					content={t("welcomeModal.dismissButton")}
 					onClick={onClose}
 					variant="cancel"
 				/>
-				<GetButton
+				<Button
 					content={t("welcomeModal.startTourButton")}
 					onClick={onStartTour}
 					variant="primary"

--- a/src/components/WelcomeTourGuide/WecomeModal.js
+++ b/src/components/WelcomeTourGuide/WecomeModal.js
@@ -35,16 +35,12 @@ const WecomeModal = ({ isOpen, onStartTour, onClose }) => {
 			</p>
 
 			<div className="flex justify-center gap-2 pt-4">
-				<Button
-					content={t("welcomeModal.dismissButton")}
-					onClick={onClose}
-					variant="cancel"
-				/>
-				<Button
-					content={t("welcomeModal.startTourButton")}
-					onClick={onStartTour}
-					variant="primary"
-				/>
+				<Button variant="cancel" onClick={onClose}>
+					{t("welcomeModal.dismissButton")}
+				</Button>
+				<Button variant="primary" onClick={onStartTour}>
+					{t("welcomeModal.startTourButton")}
+				</Button>
 			</div>
 		</Modal>
 	);

--- a/src/components/WelcomeTourGuide/WelcomeTourGuide.js
+++ b/src/components/WelcomeTourGuide/WelcomeTourGuide.js
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import SessionContext from '../../context/SessionContext';
 
 import WelcomeModal from './WecomeModal';
-import GetButton from '../Buttons/GetButton';
+import Button from '../Buttons/Button';
 
 
 const TourGuide = ({ toggleMenu, isOpen }) => {
@@ -60,7 +60,7 @@ const TourGuide = ({ toggleMenu, isOpen }) => {
 					<>
 						<p className='mt-2'>{t("tourGuide.tourComplete")}</p>
 						<div className='flex justify-center mt-2'>
-							<GetButton
+							<Button
 								content={t("tourGuide.closeTourButton")}
 								onClick={() => setIsTourOpen(false)}
 								variant="primary"

--- a/src/components/WelcomeTourGuide/WelcomeTourGuide.js
+++ b/src/components/WelcomeTourGuide/WelcomeTourGuide.js
@@ -60,14 +60,11 @@ const TourGuide = ({ toggleMenu, isOpen }) => {
 					<>
 						<p className='mt-2'>{t("tourGuide.tourComplete")}</p>
 						<div className='flex justify-center mt-2'>
-							<Button
-								content={t("tourGuide.closeTourButton")}
-								onClick={() => setIsTourOpen(false)}
-								variant="primary"
-							/>
+							<Button variant="primary" onClick={() => setIsTourOpen(false)}>
+								{t("tourGuide.closeTourButton")}
+							</Button>
 						</div>
 					</>
-
 				)
 			}
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,7 +15,7 @@ export const FIREBASE = {
 };
 export const FIREBASE_VAPIDKEY = process.env.REACT_APP_FIREBASE_VAPIDKEY;
 export const INACTIVE_LOGOUT_MILLIS = (process.env.REACT_APP_INACTIVE_LOGOUT_SECONDS ? parseInt(process.env.REACT_APP_INACTIVE_LOGOUT_SECONDS, 10) : 60 * 15) * 1000
-export const LOGIN_WITH_PASSWORD: boolean = process.env.REACT_APP_LOGIN_WITH_PASSWORD ? JSON.parse(process.env.REACT_APP_LOGIN_WITH_PASSWORD) == true : false;
+export const LOGIN_WITH_PASSWORD: boolean = process.env.REACT_APP_LOGIN_WITH_PASSWORD ? JSON.parse(process.env.REACT_APP_LOGIN_WITH_PASSWORD) === true : false;
 export const WEBAUTHN_RPID = process.env.REACT_APP_WEBAUTHN_RPID ?? "localhost";
 export const WS_URL = process.env.REACT_APP_WS_URL;
 

--- a/src/context/CredentialsContext.js
+++ b/src/context/CredentialsContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useCallback, useContext, useRef } from 'react';
+import React, { createContext, useState, useContext, useRef } from 'react';
 import { extractCredentialFriendlyName } from '../functions/extractCredentialFriendlyName';
 import { getItem } from '../indexedDB';
 import SessionContext from './SessionContext';
@@ -77,7 +77,7 @@ export const CredentialsProvider = ({ children }) => {
 		}, 1000);
 	};
 
-	const getData = useCallback(async () => {
+	const getData = async () => {
 		try {
 			const userId = api.getSession().uuid;
 			const previousVcList = await getItem("vc", userId);
@@ -101,7 +101,7 @@ export const CredentialsProvider = ({ children }) => {
 		} catch (error) {
 			console.error('Failed to fetch data', error);
 		}
-	}, [api]);
+	};
 
 	return (
 		<CredentialsContext.Provider value={{ vcEntityList, latestCredentials, getData }}>

--- a/src/pages/AddCredentials/AddCredentials.js
+++ b/src/pages/AddCredentials/AddCredentials.js
@@ -8,6 +8,7 @@ import QRCodeScanner from '../../components/QRCodeScanner/QRCodeScanner';
 import RedirectPopup from '../../components/Popups/RedirectPopup';
 import QRButton from '../../components/Buttons/QRButton';
 import { H1 } from '../../components/Heading';
+import Button from '../../components/Buttons/Button';
 
 
 function highlightBestSequence(issuer, search) {
@@ -153,16 +154,17 @@ const Issuers = () => {
 						style={{ maxHeight: '80vh' }}
 					>
 						{filteredIssuers.map((issuer) => (
-							<button
+							<Button
+								variant="outline"
+								additionalClassName="break-words w-full text-left"
 								key={issuer.id}
-								className={`bg-white px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-100 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-white break-words w-full text-left ${!isOnline ? ' text-gray-300 border-gray-300 dark:text-gray-700 dark:border-gray-700 cursor-not-allowed' : 'cursor-pointer'}`}
 								style={{ wordBreak: 'break-all' }}
 								onClick={() => handleIssuerClick(issuer.did)}
 								disabled={!isOnline}
 								title={!isOnline ? t('common.offlineTitle') : ''}
 							>
 								<div dangerouslySetInnerHTML={{ __html: highlightBestSequence(issuer.friendlyName, searchQuery) }} />
-							</button>
+							</Button>
 						))}
 					</div>
 				)}

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -12,7 +12,6 @@ import OnlineStatusContext from '../../context/OnlineStatusContext';
 import SessionContext from '../../context/SessionContext';
 
 import * as config from '../../config';
-import logo from '../../assets/images/logo.png';
 import GetButton from '../../components/Buttons/GetButton';
 import { PiWifiHighBold, PiWifiSlashBold } from "react-icons/pi";
 
@@ -234,7 +233,7 @@ const WebauthnSignupLogin = ({
 		() => {
 			setError("");
 		},
-		[isLogin],
+		[isLogin, setError],
 	);
 
 	const promptForPrfRetry = async (): Promise<boolean> => {

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -185,11 +185,12 @@ const UsernamePasswordForm = ({
 				)}
 				<Button
 					type="submit"
-					content={submitButtonContent}
 					variant="primary"
 					disabled={disabled}
 					additionalClassName='w-full'
-				/>
+				>
+					{submitButtonContent}
+				</Button>
 			</form>
 		</>
 	);
@@ -412,16 +413,18 @@ const WebauthnSignupLogin = ({
 								}
 								<div className='flex justify-center gap-4'>
 									<Button
-										content={t('common.cancel')}
 										onClick={() => resolvePrfRetryPrompt(false)}
 										variant="cancel"
-									/>
+									>
+										{t('common.cancel')}
+									</Button>
 									<Button
-										content={t('common.continue')}
 										onClick={() => resolvePrfRetryPrompt(true)}
 										variant="secondary"
 										disabled={prfRetryAccepted}
-									/>
+									>
+										{t('common.continue')}
+									</Button>
 								</div>
 							</div>
 						)
@@ -437,16 +440,12 @@ const WebauthnSignupLogin = ({
 										</p>
 										<div className='flex justify-center gap-4'>
 
-											<Button
-												content={t('common.cancel')}
-												onClick={onCancel}
-												variant="cancel"
-											/>
-											<Button
-												type="submit"
-												content={t('common.tryAgain')}
-												variant="secondary"
-											/>
+											<Button variant="cancel" onClick={onCancel}>
+												{t('common.cancel')}
+											</Button>
+											<Button type="submit" variant="secondary">
+												{t('common.tryAgain')}
+											</Button>
 										</div>
 									</div>
 								)
@@ -454,11 +453,12 @@ const WebauthnSignupLogin = ({
 									<>
 										<p className="dark:text-white pb-3">{t('registerPasskey.messageInteract')}</p>
 										<Button
-											content={t('common.cancel')}
 											onClick={onCancel}
 											variant="cancel"
 											additionalClassName='w-full'
-										/>
+										>
+											{t('common.cancel')}
+										</Button>
 									</>
 								)
 						)
@@ -503,29 +503,27 @@ const WebauthnSignupLogin = ({
 									>
 										<div className='flex-grow mr-2'>
 											<Button
-												content={
-													<>
-														<GoPasskeyFill className="inline text-xl mr-2" />
-														{isSubmitting ? t('loginSignup.submitting') : t('loginSignup.loginAsUser', { name: cachedUser.displayName })}
-													</>
-												}
 												onClick={() => onLoginCachedUser(cachedUser)}
 												variant="tertiary"
 												disabled={isSubmitting}
 												additionalClassName='w-full'
-											/>
+											>
+												<GoPasskeyFill className="inline text-xl mr-2" />
+												{isSubmitting
+													? t('loginSignup.submitting')
+													: t('loginSignup.loginAsUser', { name: cachedUser.displayName })}
+											</Button>
 										</div>
 										<div>
 											<Button
-												content={
-													<GoTrash className="inline text-xl" />
-												}
 												onClick={() => onForgetCachedUser(cachedUser)}
 												variant="tertiary"
 												disabled={isSubmitting}
 												ariaLabel={t('loginSignup.forgetCachedUserAriaLabel', { name: cachedUser.displayName })}
 												title={t('loginSignup.forgetCachedUserTitle')}
-											/>
+											>
+												<GoTrash className="inline text-xl" />
+											</Button>
 										</div>
 									</li>
 								))}
@@ -535,22 +533,19 @@ const WebauthnSignupLogin = ({
 						{!isLoginCache && (
 							<Button
 								type="submit"
-								content={
-									<>
-										<GoPasskeyFill className="inline text-xl mr-2" />
-										{isSubmitting
-											? t('loginSignup.submitting')
-											: isLogin
-												? t('loginSignup.loginPasskey')
-												: t('loginSignup.signupPasskey')
-										}
-									</>
-								}
 								variant="primary"
 								disabled={isSubmitting || nameByteLimitReached || (!isLogin && !isOnline)}
 								additionalClassName={`w-full ${nameByteLimitReached || (!isLogin && !isOnline) ? 'cursor-not-allowed bg-gray-300 hover:bg-gray-300' : ''}`}
 								title={!isLogin && !isOnline && t("common.offlineTitle")}
-							/>
+							>
+								<GoPasskeyFill className="inline text-xl mr-2" />
+								{isSubmitting
+									? t('loginSignup.submitting')
+									: isLogin
+										? t('loginSignup.loginPasskey')
+										: t('loginSignup.signupPasskey')
+								}
+							</Button>
 						)}
 						{error && <div className="text-red-500 pt-4">{error}</div>}
 					</>

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -12,7 +12,7 @@ import OnlineStatusContext from '../../context/OnlineStatusContext';
 import SessionContext from '../../context/SessionContext';
 
 import * as config from '../../config';
-import GetButton from '../../components/Buttons/GetButton';
+import Button from '../../components/Buttons/Button';
 import { PiWifiHighBold, PiWifiSlashBold } from "react-icons/pi";
 
 // import LanguageSelector from '../../components/LanguageSelector/LanguageSelector'; // Import the LanguageSelector component
@@ -183,7 +183,7 @@ const UsernamePasswordForm = ({
 						/>
 					</FormInputRow>
 				)}
-				<GetButton
+				<Button
 					type="submit"
 					content={submitButtonContent}
 					variant="primary"
@@ -411,12 +411,12 @@ const WebauthnSignupLogin = ({
 										)
 								}
 								<div className='flex justify-center gap-4'>
-									<GetButton
+									<Button
 										content={t('common.cancel')}
 										onClick={() => resolvePrfRetryPrompt(false)}
 										variant="cancel"
 									/>
-									<GetButton
+									<Button
 										content={t('common.continue')}
 										onClick={() => resolvePrfRetryPrompt(true)}
 										variant="secondary"
@@ -437,12 +437,12 @@ const WebauthnSignupLogin = ({
 										</p>
 										<div className='flex justify-center gap-4'>
 
-											<GetButton
+											<Button
 												content={t('common.cancel')}
 												onClick={onCancel}
 												variant="cancel"
 											/>
-											<GetButton
+											<Button
 												type="submit"
 												content={t('common.tryAgain')}
 												variant="secondary"
@@ -453,7 +453,7 @@ const WebauthnSignupLogin = ({
 								: (
 									<>
 										<p className="dark:text-white pb-3">{t('registerPasskey.messageInteract')}</p>
-										<GetButton
+										<Button
 											content={t('common.cancel')}
 											onClick={onCancel}
 											variant="cancel"
@@ -502,7 +502,7 @@ const WebauthnSignupLogin = ({
 										className="w-full flex flex-row flex-nowrap mb-2"
 									>
 										<div className='flex-grow mr-2'>
-											<GetButton
+											<Button
 												content={
 													<>
 														<GoPasskeyFill className="inline text-xl mr-2" />
@@ -516,7 +516,7 @@ const WebauthnSignupLogin = ({
 											/>
 										</div>
 										<div>
-											<GetButton
+											<Button
 												content={
 													<GoTrash className="inline text-xl" />
 												}
@@ -533,7 +533,7 @@ const WebauthnSignupLogin = ({
 						)}
 
 						{!isLoginCache && (
-							<GetButton
+							<Button
 								type="submit"
 								content={
 									<>

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -634,8 +634,7 @@ const Login = () => {
 		setIsSubmitting(false);
 	};
 
-	const toggleForm = (event) => {
-		event.preventDefault();
+	const toggleForm = () => {
 		if (isOnline || !isLogin) {
 			setIsLogin(!isLogin);
 			setError('');
@@ -756,23 +755,20 @@ const Login = () => {
 					{!isLoginCache ? (
 						<p className="text-sm font-light text-gray-500 dark:text-gray-200">
 							{isLogin ? t('loginSignup.newHereQuestion') : t('loginSignup.alreadyHaveAccountQuestion')}
-							<a
-								href={isLogin && isOnline ? "/" : ""}
-								className={`font-medium ${isLogin && isOnline === false ? 'cursor-not-allowed text-gray-300 dark:text-gray-600 hover:no-underline' : 'text-primary hover:underline dark:text-primary-light '}`}
-								title={`${isOnline === false && t('common.offlineTitle')}`}
+							<Button
+								variant="link"
 								onClick={toggleForm}
+								disabled={!isOnline}
+								title={!isOnline && t('common.offlineTitle')}
 							>
 								{isLogin ? t('loginSignup.signUp') : t('loginSignup.login')}
-							</a>
+							</Button>
 						</p>
 					) : (
 						<p className="text-sm font-light text-gray-500 dark:text-gray-200 cursor-pointer">
-							<a
-								className="font-medium text-primary hover:underline dark:text-primary-light"
-								onClick={useOtherAccount}
-							>
+							<Button variant="link" onClick={useOtherAccount}>
 								{t('loginSignup.useOtherAccount')}
-							</a>
+							</Button>
 						</p>
 					)}
 

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -535,7 +535,7 @@ const WebauthnSignupLogin = ({
 								type="submit"
 								variant="primary"
 								disabled={isSubmitting || nameByteLimitReached || (!isLogin && !isOnline)}
-								additionalClassName={`w-full ${nameByteLimitReached || (!isLogin && !isOnline) ? 'cursor-not-allowed bg-gray-300 hover:bg-gray-300' : ''}`}
+								additionalClassName="w-full"
 								title={!isLogin && !isOnline && t("common.offlineTitle")}
 							>
 								<GoPasskeyFill className="inline text-xl mr-2" />

--- a/src/pages/Login/LoginState.js
+++ b/src/pages/Login/LoginState.js
@@ -70,28 +70,24 @@ const WebauthnLogin = ({
 			<ul className=" p-2">
 				<div className='flex flex-row gap-4 justify-center mr-2'>
 					<Button
-						content={
-							<>
-								{t('common.cancel')}
-							</>
-						}
 						onClick={() => navigate('/')}
 						variant="cancel"
 						disabled={isSubmitting}
 						additionalClassName='w-full'
-					/>
+					>
+						{t('common.cancel')}
+					</Button>
 					<Button
-						content={
-							<>
-								<GoPasskeyFill className="inline text-xl mr-2" />
-								{isSubmitting ? t('loginSignup.submitting') : t('common.continue')}
-							</>
-						}
 						onClick={() => onLoginCachedUser(filteredUser)}
 						variant="primary"
 						disabled={isSubmitting}
 						additionalClassName='w-full'
-					/>
+					>
+						<GoPasskeyFill className="inline text-xl mr-2" />
+						{isSubmitting
+							? t('loginSignup.submitting')
+							: t('common.continue')}
+					</Button>
 				</div>
 			</ul>
 			{error && <div className="text-red-500 pt-4">{error}</div>}

--- a/src/pages/Login/LoginState.js
+++ b/src/pages/Login/LoginState.js
@@ -7,7 +7,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import OnlineStatusContext from '../../context/OnlineStatusContext';
 import SessionContext from '../../context/SessionContext';
 
-import GetButton from '../../components/Buttons/GetButton';
+import Button from '../../components/Buttons/Button';
 import { PiWifiHighBold, PiWifiSlashBold } from "react-icons/pi";
 import LoginPageLayout from './LoginPageLayout';
 
@@ -69,7 +69,7 @@ const WebauthnLogin = ({
 		<>
 			<ul className=" p-2">
 				<div className='flex flex-row gap-4 justify-center mr-2'>
-					<GetButton
+					<Button
 						content={
 							<>
 								{t('common.cancel')}
@@ -80,7 +80,7 @@ const WebauthnLogin = ({
 						disabled={isSubmitting}
 						additionalClassName='w-full'
 					/>
-					<GetButton
+					<Button
 						content={
 							<>
 								<GoPasskeyFill className="inline text-xl mr-2" />

--- a/src/pages/NotFound/NotFound.js
+++ b/src/pages/NotFound/NotFound.js
@@ -32,11 +32,12 @@ const NotFound = () => {
 							{t('notFound.message')}
 						</p>
 						<Button
-							content={t('notFound.homeButton')}
 							onClick={handleBackToHome}
 							variant="secondary"
 							additionalClassName='w-full'
-						/>
+						>
+							{t('notFound.homeButton')}
+						</Button>
 					</div>
 				</div>
 			</div>

--- a/src/pages/NotFound/NotFound.js
+++ b/src/pages/NotFound/NotFound.js
@@ -2,7 +2,7 @@ import React from 'react';
 import logo from '../../assets/images/logo.png';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import GetButton from '../../components/Buttons/GetButton';
+import Button from '../../components/Buttons/Button';
 
 
 const NotFound = () => {
@@ -31,7 +31,7 @@ const NotFound = () => {
 						<p className='text-center'>
 							{t('notFound.message')}
 						</p>
-						<GetButton
+						<Button
 							content={t('notFound.homeButton')}
 							onClick={handleBackToHome}
 							variant="secondary"

--- a/src/pages/SendCredentials/SendCredentials.js
+++ b/src/pages/SendCredentials/SendCredentials.js
@@ -8,6 +8,7 @@ import QRCodeScanner from '../../components/QRCodeScanner/QRCodeScanner'; // Rep
 import RedirectPopup from '../../components/Popups/RedirectPopup';
 import QRButton from '../../components/Buttons/QRButton';
 import { H1 } from '../../components/Heading';
+import Button from '../../components/Buttons/Button';
 
 
 function highlightBestSequence(verifier, search) {
@@ -139,16 +140,17 @@ const Verifiers = () => {
 						style={{ maxHeight: '80vh' }}
 					>
 						{filteredVerifiers.map((verifier) => (
-							<button
+							<Button
 								key={verifier.id}
-								className={`bg-white px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-100 dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-white break-words w-full text-left ${!isOnline ? ' text-gray-300 border-gray-300 dark:text-gray-700 dark:border-gray-700 cursor-not-allowed' : 'cursor-pointer'}`}
+								variant="outline"
+								additionalClassName="break-words w-full text-left"
 								style={{ wordBreak: 'break-all' }}
 								onClick={() => handleVerifierClick(verifier.did)}
 								disabled={!isOnline}
 								title={!isOnline ? t('common.offlineTitle') : ''}
 							>
 								<div dangerouslySetInnerHTML={{ __html: highlightBestSequence(verifier.name, searchQuery) }} />
-							</button>
+							</Button>
 						))}
 					</div>
 				)}

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -13,7 +13,7 @@ import type { WebauthnPrfEncryptionKeyInfo, WrappedKeyInfo } from '../../service
 import { isPrfKeyV2, serializePrivateData } from '../../services/keystore';
 
 import DeletePopup from '../../components/Popups/DeletePopup';
-import GetButton from '../../components/Buttons/GetButton';
+import Button from '../../components/Buttons/Button';
 import { H1, H2, H3 } from '../../components/Heading';
 
 
@@ -201,7 +201,7 @@ const WebauthnRegistation = ({
 
 	return (
 		<>
-			<GetButton
+			<Button
 				content={
 					<div className="flex items-center">
 						<BsPlusCircle size={20} />
@@ -249,7 +249,7 @@ const WebauthnRegistation = ({
 					}
 
 					<div className="pt-2 flex justify-center gap-2">
-						<GetButton
+						<Button
 							content={t('common.cancel')}
 							onClick={onCancel}
 							variant="cancel"
@@ -257,7 +257,7 @@ const WebauthnRegistation = ({
 						/>
 
 						{pendingCredential && (
-							<GetButton
+							<Button
 								type="submit"
 								content={t('common.save')}
 								variant="secondary"
@@ -278,13 +278,13 @@ const WebauthnRegistation = ({
 				<p className='dark:text-white'>{t('registerPasskey.authOnceMore')}</p>
 
 				<div className='flex justify-center gap-2'>
-					<GetButton
+					<Button
 						content={t('common.cancel')}
 						onClick={() => resolvePrfRetryPrompt(false)}
 						variant="cancel"
 					/>
 
-					<GetButton
+					<Button
 						content={t('common.continue')}
 						onClick={() => resolvePrfRetryPrompt(true)}
 						variant="secondary"
@@ -300,7 +300,7 @@ const WebauthnRegistation = ({
 			>
 				<p className='dark:text-white'>{t('registerPasskey.messageInteractNewPasskey')}</p>
 				<div className='flex justify-center'>
-					<GetButton
+					<Button
 						content={t('common.cancel')}
 						onClick={onCancel}
 						variant="cancel"
@@ -396,7 +396,7 @@ const UnlockMainKey = ({
 
 	return (
 		<>
-			<GetButton
+			<Button
 				content={
 					<div className="flex items-center">
 						{unlocked
@@ -616,14 +616,14 @@ const WebauthnCredentialItem = ({
 					? (
 
 						<div className='flex gap-2'>
-							<GetButton
+							<Button
 								content={t('common.cancel')}
 								onClick={onCancelEditing}
 								variant="cancel"
 								disabled={submitting}
 								ariaLabel={t('pageSettings.passkeyItem.cancelChangesAriaLabel', { passkeyLabel: currentLabel })}
 							/>
-							<GetButton
+							<Button
 								type="submit"
 								content={t('common.save')}
 								disabled={submitting}
@@ -632,7 +632,7 @@ const WebauthnCredentialItem = ({
 						</div>
 					)
 					: (
-						<GetButton
+						<Button
 							content={
 								<>
 									<FaEdit size={16} className="mr-2" />
@@ -649,7 +649,7 @@ const WebauthnCredentialItem = ({
 				}
 
 				{onDelete && (
-					<GetButton
+					<Button
 						content={<FaTrash size={16} />}
 						onClick={openDeleteConfirmation}
 						variant="delete"
@@ -899,7 +899,7 @@ const Settings = () => {
 									<p className='mb-2 dark:text-white'>
 										{t('pageSettings.deleteAccount.description')}
 									</p>
-									<GetButton
+									<Button
 										content={t('pageSettings.deleteAccount.buttonText')}
 										onClick={openDeleteConfirmation}
 										variant="delete"

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -202,14 +202,6 @@ const WebauthnRegistation = ({
 	return (
 		<>
 			<Button
-				content={
-					<div className="flex items-center">
-						<BsPlusCircle size={20} />
-						<span className='hidden md:block ml-2'>
-							{t('pageSettings.addPasskey')}
-						</span>
-					</div>
-				}
 				onClick={onBegin}
 				variant="primary"
 				disabled={registrationInProgress || !unlocked || !isOnline}
@@ -217,7 +209,14 @@ const WebauthnRegistation = ({
 
 				ariaLabel={unlocked && !isOnline ? t("common.offlineTitle") : unlocked ? (window.innerWidth < 768 ? t('pageSettings.addPasskey') : "") : t("pageSettings.deletePasskeyButtonTitleLocked")}
 				title={unlocked && !isOnline ? t("common.offlineTitle") : unlocked ? (window.innerWidth < 768 ? t('pageSettings.addPasskeyTitle') : "") : t("pageSettings.deletePasskeyButtonTitleLocked")}
-			/>
+			>
+				<div className="flex items-center">
+					<BsPlusCircle size={20} />
+					<span className='hidden md:block ml-2'>
+						{t('pageSettings.addPasskey')}
+					</span>
+				</div>
+			</Button>
 
 			<Dialog
 				open={stateChooseNickname}
@@ -250,19 +249,21 @@ const WebauthnRegistation = ({
 
 					<div className="pt-2 flex justify-center gap-2">
 						<Button
-							content={t('common.cancel')}
 							onClick={onCancel}
 							variant="cancel"
 							disabled={isSubmitting}
-						/>
+						>
+							{t('common.cancel')}
+						</Button>
 
 						{pendingCredential && (
 							<Button
 								type="submit"
-								content={t('common.save')}
 								variant="secondary"
 								disabled={isSubmitting}
-							/>
+							>
+								{t('common.save')}
+							</Button>
 						)}
 					</div>
 
@@ -279,17 +280,19 @@ const WebauthnRegistation = ({
 
 				<div className='flex justify-center gap-2'>
 					<Button
-						content={t('common.cancel')}
 						onClick={() => resolvePrfRetryPrompt(false)}
 						variant="cancel"
-					/>
+					>
+						{t('common.cancel')}
+					</Button>
 
 					<Button
-						content={t('common.continue')}
 						onClick={() => resolvePrfRetryPrompt(true)}
 						variant="secondary"
 						disabled={prfRetryAccepted}
-					/>
+					>
+						{t('common.continue')}
+					</Button>
 				</div>
 
 			</Dialog>
@@ -300,11 +303,9 @@ const WebauthnRegistation = ({
 			>
 				<p className='dark:text-white'>{t('registerPasskey.messageInteractNewPasskey')}</p>
 				<div className='flex justify-center'>
-					<Button
-						content={t('common.cancel')}
-						onClick={onCancel}
-						variant="cancel"
-					/>
+					<Button variant="cancel" onClick={onCancel}>
+						{t('common.cancel')}
+					</Button>
 				</div>
 			</Dialog>
 		</>
@@ -397,30 +398,29 @@ const UnlockMainKey = ({
 	return (
 		<>
 			<Button
-				content={
-					<div className="flex items-center">
-						{unlocked
-							? <>
-								<BsUnlock size={20} />
-								<span className='hidden md:block ml-2'>
-									{t('pageSettings.lockPasskeyManagement')}
-								</span>
-							</>
-							: <>
-								<BsLock size={20} />
-								<span className='hidden md:block ml-2'>
-									{t('pageSettings.unlockPasskeyManagement')}
-								</span>
-							</>
-						}
-					</div>
-				}
 				onClick={unlocked ? onLock : onBeginUnlock}
 				variant="primary"
 				disabled={inProgress || (!unlocked && !isOnline)}
 				ariaLabel={!unlocked && !isOnline ? t("common.offlineTitle") : window.innerWidth < 768 && (unlocked ? t('pageSettings.lockPasskeyManagement') : t('pageSettings.unlockPasskeyManagement'))}
 				title={!unlocked && !isOnline ? t("common.offlineTitle") : window.innerWidth < 768 && (unlocked ? t('pageSettings.lockPasskeyManagementTitle') : t('pageSettings.unlockPasskeyManagementTitle'))}
-			/>
+			>
+				<div className="flex items-center">
+					{unlocked
+						? <>
+							<BsUnlock size={20} />
+							<span className='hidden md:block ml-2'>
+								{t('pageSettings.lockPasskeyManagement')}
+							</span>
+						</>
+						: <>
+							<BsLock size={20} />
+							<span className='hidden md:block ml-2'>
+								{t('pageSettings.unlockPasskeyManagement')}
+							</span>
+						</>
+					}
+				</div>
+			</Button>
 			<Dialog
 				open={isPromptingForPassword}
 				onCancel={onCancelPassword}
@@ -617,47 +617,47 @@ const WebauthnCredentialItem = ({
 
 						<div className='flex gap-2'>
 							<Button
-								content={t('common.cancel')}
 								onClick={onCancelEditing}
 								variant="cancel"
 								disabled={submitting}
 								ariaLabel={t('pageSettings.passkeyItem.cancelChangesAriaLabel', { passkeyLabel: currentLabel })}
-							/>
+							>
+								{t('common.cancel')}
+							</Button>
 							<Button
 								type="submit"
-								content={t('common.save')}
 								disabled={submitting}
 								variant="secondary"
-							/>
+							>
+								{t('common.save')}
+							</Button>
 						</div>
 					)
 					: (
 						<Button
-							content={
-								<>
-									<FaEdit size={16} className="mr-2" />
-									{t('pageSettings.passkeyItem.rename')}
-								</>
-							}
 							onClick={() => setEditing(true)}
 							variant="secondary"
 							disabled={(onDelete && !unlocked) || !isOnline}
 							aria-label={t('pageSettings.passkeyItem.renameAriaLabel', { passkeyLabel: currentLabel })}
 							title={!isOnline ? t("common.offlineTitle") : onDelete && !unlocked && t("pageSettings.passkeyItem.renameButtonTitleLocked")}
-						/>
+						>
+							<FaEdit size={16} className="mr-2" />
+							{t('pageSettings.passkeyItem.rename')}
+						</Button>
 					)
 				}
 
 				{onDelete && (
 					<Button
-						content={<FaTrash size={16} />}
 						onClick={openDeleteConfirmation}
 						variant="delete"
 						disabled={!unlocked || !isOnline}
 						aria-label={t('pageSettings.passkeyItem.deleteAriaLabel', { passkeyLabel: currentLabel })}
 						title={unlocked && !isOnline ? t("common.offlineTitle") : !unlocked ? t("pageSettings.passkeyItem.deleteButtonTitleLocked") : t("pageSettings.passkeyItem.deleteButtonTitleUnlocked", { passkeyLabel: currentLabel })}
 						additionalClassName='ml-2 py-2.5'
-					/>
+					>
+						<FaTrash size={16} />
+					</Button>
 				)}
 				<DeletePopup
 					isOpen={isDeleteConfirmationOpen}
@@ -900,12 +900,13 @@ const Settings = () => {
 										{t('pageSettings.deleteAccount.description')}
 									</p>
 									<Button
-										content={t('pageSettings.deleteAccount.buttonText')}
 										onClick={openDeleteConfirmation}
 										variant="delete"
 										disabled={!unlocked || !isOnline}
 										title={unlocked && !isOnline ? t("common.offlineTitle") : !unlocked ? t("pageSettings.deleteAccount.deleteButtonTitleLocked") : ""}
-									/>
+									>
+										{t('pageSettings.deleteAccount.buttonText')}
+									</Button>
 								</div>
 							</div>
 


### PR DESCRIPTION
Fixes these lints:

```
src/config.ts
  Line 18:143:  Expected '===' and instead saw '=='  eqeqeq

src/context/CredentialsContext.js
  Line 104:5:  React Hook useCallback has missing dependencies: 'fetchVcData' and 'pollForCredentials'. Either include them or remove the dependency array  react-hooks/exhaustive-deps

src/pages/Login/Login.tsx
  Line 15:8:   'logo' is defined but never used  @typescript-eslint/no-unused-vars
  Line 237:3:  React Hook useEffect has a missing dependency: 'setError'. Either include it or remove the dependency array. If 'setError' changes too often, find the parent component that defines it and wrap that definition in useCallback  react-hooks/exhaustive-deps
  Line 776:8:  The href attribute is required for an anchor to be keyboard accessible. Provide a valid, navigable address as the href value. If you cannot provide an href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md  jsx-a11y/anchor-is-valid
```

The last one (`The href attribute is required for an anchor`) then lead to adding a `variant="link"` to `<GetButton>`, and to renaming `<GetButton>` to `<Button>` and replacing its `content` prop with the `children` prop.