### PR TITLE
Fix FCM Initialization and First-Time Load Registration Failure

### DIFF
--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -47,7 +47,7 @@ export function NotificationPermissionWarning(): React.ReactNode {
 		|| (
 			isOnline === true
 			&& isPermissionGranted != null
-			&& notificationApiIsSupported()
+			&& notificationApiIsSupported
 			&& (
 				(!isPermissionGranted && isMessageNoGrantedVisible === false)
 				|| (
@@ -147,7 +147,7 @@ const PrivateRoute = ({ children }: { children?: React.ReactNode }): React.React
 
 	useEffect(() => {
 		const requestNotificationPermission = async () => {
-			if (!notificationApiIsSupported()) {
+			if (!notificationApiIsSupported) {
 				setIsPermissionGranted(false);
 				setTokenSentInSession(false);
 				return;

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -5,26 +5,14 @@ import * as config from './config';
 
 
 let messaging = null;
-let supported = false;
 
 export const notificationApiIsSupported = () =>
 	'Notification' in window &&
 	'serviceWorker' in navigator &&
 	'PushManager' in window
 
-const initializeFirebase = async () => {
-	if (notificationApiIsSupported()) {
-		supported = await isSupported();
-		if (supported) {
-			initializeApp(config.FIREBASE);
-			messaging = getMessaging();
-		}
-	}
-	console.log("Supported", supported);
-};
-
 export async function register() {
-	if (supported && 'serviceWorker' in navigator) {
+	if (isSupported() && 'serviceWorker' in navigator) {
 		try {
 			const registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js', { scope: '/notifications/' });
 			console.log('App: Firebase Messaging Service Worker registered! Scope is:', registration.scope);
@@ -37,7 +25,7 @@ export async function register() {
 };
 
 const requestForToken = async () => {
-	if (!supported) {
+	if (!isSupported()) {
 		return null;
 	}
 	if (messaging) {
@@ -71,7 +59,7 @@ const requestForToken = async () => {
 
 
 const reRegisterServiceWorkerAndGetToken = async () => {
-	if (!supported) {
+	if (!isSupported()) {
 		return null;
 	}
 	if ('serviceWorker' in navigator) {
@@ -100,7 +88,7 @@ const reRegisterServiceWorkerAndGetToken = async () => {
 };
 
 export const fetchToken = async () => {
-	if (supported && messaging) {
+	if (isSupported() && messaging) {
 		const token = await requestForToken();
 		console.log('token:', token);
 		if (token) {
@@ -123,40 +111,27 @@ export const fetchToken = async () => {
 
 export const onMessageListener = () =>
 	new Promise((resolve) => {
-		if (supported) {
+		if (isSupported()) {
 			onMessage(messaging, (payload) => {
 				resolve(payload);
 			});
 		}
 	});
 
-const initializeMessaging = async () => {
-	// Check for service worker
-	if (supported && 'serviceWorker' in navigator) {
-		try {
-			const registration = await navigator.serviceWorker.getRegistration('/firebase-messaging-sw.js');
-			if (registration) {
-				console.log('Service Worker registered', registration);
-				return getMessaging();
-			} else {
-				console.log('Service Worker registration failed');
-			}
-		} catch (error) {
-			console.error('Service Worker registration failed with', error);
-		}
-	} else {
-		console.log('Service Workers are not supported in this browser.');
-	}
-};
 
 const initializeFirebaseAndMessaging = async () => {
-	await initializeFirebase();
-	const messaging = await initializeMessaging();
-	// Now you can use the messaging object if it's available
-	if (messaging) {
-		// Do something with the messaging object
-	} else {
-		console.log('Messaging is not initialized.');
+	if (notificationApiIsSupported()) {
+		let supported = await isSupported();
+		console.log("Supported", supported);
+		if (supported) {
+			initializeApp(config.FIREBASE);
+			messaging = getMessaging();
+			if (messaging) {
+				console.log('Messaging is initialized.');
+			} else {
+				console.log('Messaging is not initialized.');
+			}
+		}
 	}
 };
 

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -12,8 +12,13 @@ export const notificationApiIsSupported =
 export async function register() {
 	if (await isSupported() && 'serviceWorker' in navigator) {
 		try {
-			const registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js', { scope: '/notifications/' });
-			console.log('App: Firebase Messaging Service Worker registered! Scope is:', registration.scope);
+			const existingRegistration = await navigator.serviceWorker.getRegistration('/notifications/');
+			if (existingRegistration) {
+				console.log('Service Worker is already registered. Scope:', existingRegistration.scope);
+			} else {
+				const registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js', { scope: '/notifications/' });
+				console.log('App: Firebase Messaging Service Worker registered! Scope is:', registration.scope);
+			}
 		} catch (err) {
 			console.log('App: Firebase Messaging Service Worker registration failed:', err);
 		}

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,15 +1,13 @@
 import { initializeApp } from "firebase/app";
 import { getMessaging, getToken, onMessage, isSupported } from 'firebase/messaging';
-
 import * as config from './config';
-
 
 let messaging = null;
 
-export const notificationApiIsSupported = () =>
+export const notificationApiIsSupported =
 	'Notification' in window &&
 	'serviceWorker' in navigator &&
-	'PushManager' in window
+	'PushManager' in window;
 
 export async function register() {
 	if (await isSupported() && 'serviceWorker' in navigator) {
@@ -56,7 +54,6 @@ const requestForToken = async () => {
 		return null;
 	}
 };
-
 
 const reRegisterServiceWorkerAndGetToken = async () => {
 	if (!await isSupported()) {
@@ -108,7 +105,6 @@ export const fetchToken = async () => {
 	return null; // Return null in case of failure
 };
 
-
 export const onMessageListener = () =>
 	new Promise(async (resolve) => {
 		if (await isSupported()) {
@@ -118,9 +114,8 @@ export const onMessageListener = () =>
 		}
 	});
 
-
 const initializeFirebaseAndMessaging = async () => {
-	if (notificationApiIsSupported()) {
+	if (notificationApiIsSupported) {
 		let supported = await isSupported();
 		console.log("Supported", supported);
 		if (supported) {

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -110,8 +110,8 @@ export const fetchToken = async () => {
 
 
 export const onMessageListener = () =>
-	new Promise((resolve) => {
-		if (isSupported()) {
+	new Promise(async (resolve) => {
+		if (await isSupported()) {
 			onMessage(messaging, (payload) => {
 				resolve(payload);
 			});

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -12,7 +12,7 @@ export const notificationApiIsSupported = () =>
 	'PushManager' in window
 
 export async function register() {
-	if (isSupported() && 'serviceWorker' in navigator) {
+	if (await isSupported() && 'serviceWorker' in navigator) {
 		try {
 			const registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js', { scope: '/notifications/' });
 			console.log('App: Firebase Messaging Service Worker registered! Scope is:', registration.scope);
@@ -25,7 +25,7 @@ export async function register() {
 };
 
 const requestForToken = async () => {
-	if (!isSupported()) {
+	if (!await isSupported()) {
 		return null;
 	}
 	if (messaging) {
@@ -59,7 +59,7 @@ const requestForToken = async () => {
 
 
 const reRegisterServiceWorkerAndGetToken = async () => {
-	if (!isSupported()) {
+	if (!await isSupported()) {
 		return null;
 	}
 	if ('serviceWorker' in navigator) {
@@ -88,7 +88,7 @@ const reRegisterServiceWorkerAndGetToken = async () => {
 };
 
 export const fetchToken = async () => {
-	if (isSupported() && messaging) {
+	if (await isSupported() && messaging) {
 		const token = await requestForToken();
 		console.log('token:', token);
 		if (token) {


### PR DESCRIPTION
```
Service Workers are not supported in this browser. firebase.js:35 
Supported true firebase.js:23
Service Worker registration failed firebase.js:142
Messaging is not initialized. firebase.js:159
```

Removed the `supported` variable to avoid first-time load registration failure, using `isSupported()` directly for better reliability.
Refactored Firebase initialization logic to ensure consistent and proper execution during the registration process.