### PR TITLE
Fix `tabIndex` warnings: Correct typo and ensure valid values

### DIFF
--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -134,7 +134,7 @@ const Home = () => {
 												<button key={vcEntity.id} className={`relative rounded-xl xl:w-4/5 md:w-full sm:w-full overflow-hidden transition-shadow shadow-md hover:shadow-lg cursor-pointer w-full mb-2 ${latestCredentials.has(vcEntity.id) ? 'fade-in' : ''}`}
 													onClick={() => { setShowFullscreenImgPopup(true); setSelectedVcEntity(vcEntity); }}
 													aria-label={`${vcEntity.friendlyName}`}
-													tabIndex={(currentSlide !== index + 1) && -1}
+													tabIndex={currentSlide !== index + 1 ? -1 : 0}
 													title={t('pageCredentials.credentialFullScreenTitle', { friendlyName: vcEntity.friendlyName })}
 												>
 													<CredentialImage credential={vcEntity.credential} className={`w-full h-full object-cover rounded-xl ${latestCredentials.has(vcEntity.id) ? 'highlight-filter' : ''}`} />

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -134,7 +134,7 @@ const Home = () => {
 												<button key={vcEntity.id} className={`relative rounded-xl xl:w-4/5 md:w-full sm:w-full overflow-hidden transition-shadow shadow-md hover:shadow-lg cursor-pointer w-full mb-2 ${latestCredentials.has(vcEntity.id) ? 'fade-in' : ''}`}
 													onClick={() => { setShowFullscreenImgPopup(true); setSelectedVcEntity(vcEntity); }}
 													aria-label={`${vcEntity.friendlyName}`}
-													tabindex={(currentSlide !== index + 1) && -1}
+													tabIndex={(currentSlide !== index + 1) && -1}
 													title={t('pageCredentials.credentialFullScreenTitle', { friendlyName: vcEntity.friendlyName })}
 												>
 													<CredentialImage credential={vcEntity.credential} className={`w-full h-full object-cover rounded-xl ${latestCredentials.has(vcEntity.id) ? 'highlight-filter' : ''}`} />


### PR DESCRIPTION
This PR addresses two issues related to the `tabIndex` attribute in the slide component:

1. **Fix typo in `tabIndex` property**: Corrects the casing from `tabindex` to `tabIndex` to comply with React's DOM property conventions, eliminating the associated warning in the console.
`console.js:288 Warning: Invalid DOM property tabindex. Did you mean tabIndex? 
`

3. **Fix invalid `tabIndex` value**: Ensures that a valid number is passed to the `tabIndex` attribute by using conditional rendering. This resolves the warning about receiving a `false` value for a non-boolean attribute.
`react-dom.development.js:74 Warning: Received false for a non-boolean attribute tabIndex.
`
   