### PR TITLE
Fix sort order in CredentialsContext and History

### DIFF
--- a/src/context/CredentialsContext.js
+++ b/src/context/CredentialsContext.js
@@ -2,7 +2,7 @@ import React, { createContext, useState, useCallback, useContext, useRef } from 
 import { extractCredentialFriendlyName } from '../functions/extractCredentialFriendlyName';
 import { getItem } from '../indexedDB';
 import SessionContext from './SessionContext';
-import { compareBy } from '../util';
+import { compareBy, reverse } from '../util';
 
 const CredentialsContext = createContext();
 
@@ -22,7 +22,7 @@ export const CredentialsProvider = ({ children }) => {
 			return { ...vcEntity, friendlyName: name };
 		}));
 
-		vcEntityList.sort(compareBy(vc => new Date(vc.issuanceDate)));
+		vcEntityList.sort(reverse(compareBy(vc => new Date(vc.issuanceDate))));
 
 		return vcEntityList;
 	};

--- a/src/pages/History/History.js
+++ b/src/pages/History/History.js
@@ -14,7 +14,7 @@ import { formatDate } from '../../functions/DateFormat';
 import { base64url } from 'jose';
 import { CredentialImage } from '../../components/Credentials/CredentialImage';
 import { H1 } from '../../components/Heading';
-import { compareBy } from '../../util';
+import { compareBy, reverse } from '../../util';
 
 
 const History = () => {
@@ -64,7 +64,7 @@ const History = () => {
 				console.log(fetchedPresentations.vp_list);
 				// Extract and map the vp_list from fetchedPresentations.
 				const vpListFromApi = fetchedPresentations.vp_list
-					.sort(compareBy(vp => vp.issuanceDate))
+					.sort(reverse(compareBy(vp => vp.issuanceDate)))
 					.map((item) => ({
 						id: item.id,
 						presentation: item.presentation,

--- a/src/util.ts
+++ b/src/util.ts
@@ -91,6 +91,11 @@ export function compareBy<T, U>(f: (v: T) => U): (a: T, b: T) => number {
 	};
 }
 
+/** Reverse the given comparator function. */
+export function reverse<T>(f: (a: T, b: T) => number): (a: T, b: T) => number {
+	return (a: T, b: T) => -f(a, b);
+}
+
 /**
  * Wrap `action` so that it will not execute again for `timeoutMillis` milliseconds after each execution.
  */


### PR DESCRIPTION
My bad, I misread the original sort order in 30f120a4c91bf660fc5f2f24633830da235e47a9. I remembered it being that `(a, b) => b - a` sorts in ascending order, but that's backwards. This introduces the `reverse` utility function and applies it to the uses of `compareBy` where descending order was intended.