### PR TITLE
Set allowCredentials to a single credential in PRF retry

### DIFF
--- a/src/services/keystore.ts
+++ b/src/services/keystore.ts
@@ -10,7 +10,7 @@ import { SignVerifiablePresentationJWT } from "@wwwallet/ssi-sdk";
 
 import * as config from '../config';
 import type { DidKeyVersion } from '../config';
-import { byteArrayEquals, jsonParseTaggedBinary, jsonStringifyTaggedBinary, toBase64Url } from "../util";
+import { byteArrayEquals, filterObject, jsonParseTaggedBinary, jsonStringifyTaggedBinary, toBase64Url } from "../util";
 import { SdJwt } from "@sd-jwt/core";
 
 
@@ -682,14 +682,9 @@ function filterPrfAllowCredentials(credential: PublicKeyCredential | null, prfIn
 			prfInput: (
 				"evalByCredential" in prfInputs.prfInput
 					? {
-						evalByCredential: Object.entries(prfInputs.prfInput.evalByCredential).reduce(
-							(ebc, [credIdB64u, inputs]) => {
-								if (credIdB64u === credential.id) {
-									ebc[credIdB64u] = inputs;
-								}
-								return ebc;
-							},
-							{},
+						evalByCredential: filterObject(
+							prfInputs.prfInput.evalByCredential,
+							(_, credIdB64u) => credIdB64u === credential.id,
 						),
 					}
 					: prfInputs.prfInput

--- a/src/services/keystore.ts
+++ b/src/services/keystore.ts
@@ -171,6 +171,10 @@ export function isPrfKeyV2(prfKeyInfo: WebauthnPrfEncryptionKeyInfo): prfKeyInfo
 type PrfExtensionInput = { eval: { first: BufferSource } } | { evalByCredential: PrfEvalByCredential };
 type PrfEvalByCredential = { [credentialId: string]: { first: BufferSource } };
 type PrfExtensionOutput = { enabled: boolean, results?: { first?: ArrayBuffer } };
+type PrfInputs = {
+	allowCredentials?: PublicKeyCredentialDescriptor[],
+	prfInput: PrfExtensionInput,
+};
 
 export type KeystoreV0PublicData = {
 	publicKey: JWK,
@@ -673,7 +677,7 @@ export function makeAssertionPrfExtensionInputs(prfKeys: WebauthnPrfSaltInfo[]):
 
 async function getPrfOutput(
 	credential: PublicKeyCredential | null,
-	prfInputs: { allowCredentials?: PublicKeyCredentialDescriptor[], prfInput: PrfExtensionInput },
+	prfInputs: PrfInputs,
 	promptForRetry: () => Promise<boolean | AbortSignal>,
 ): Promise<[ArrayBuffer, PublicKeyCredential]> {
 	const clientExtensionOutputs = credential?.getClientExtensionResults() as { prf?: PrfExtensionOutput } | null;

--- a/src/util.ts
+++ b/src/util.ts
@@ -117,3 +117,16 @@ export function calculateByteSize(s: string): number {
 	const encoded = encoder.encode(s);
 	return encoded.length;
 };
+
+/** Return a shallow copy of `o` containing only the key-value pairs for which `predicate` returns `true`. */
+export function filterObject<T>(o: { [key: string]: T }, predicate: (v: T, k: string) => boolean): { [key: string]: T } {
+	return Object.entries(o).reduce(
+		(result, [k, v]) => {
+			if (predicate(v, k)) {
+				result[k] = v;
+			}
+			return result;
+		},
+		{},
+	);
+}


### PR DESCRIPTION
This fixes an issue on Android where if you have a matching platform credential, Android won't let you override and use a security key instead. This can happen in the "Almost done!" login step as the first authentication is done with an empty `allowCredentials`, but then `allowCredentials` is populated along with the PRF salt(s) for the second authentication.