### PR TITLE
Improve Service Worker and Content Update Handling for already open tab/PWA

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -93,6 +93,17 @@ function App() {
 
 	useEffect(() => {
 		setUrl(window.location.href);
+
+		const checkForUpdates = async () => {
+			if (navigator.serviceWorker) {
+				const registration = await navigator.serviceWorker.getRegistration();
+				if (registration) {
+					registration.update();
+				}
+			}
+		};
+
+		checkForUpdates();
 	}, [location])
 
 	useEffect(() => {

--- a/src/App.js
+++ b/src/App.js
@@ -8,12 +8,13 @@ import i18n from './i18n';
 import useCheckURL from './hooks/useCheckURL';
 import { CredentialsProvider } from './context/CredentialsContext';
 import { withSessionContext } from './context/SessionContext';
+import { checkForUpdates } from './offlineRegistrationSW';
 
 import FadeInContentTransition from './components/FadeInContentTransition';
 import HandlerNotification from './components/HandlerNotification';
 import Snowfalling from './components/ChistmasAnimation/Snowfalling';
 import Spinner from './components/Spinner';
-
+import UpdateNotification from './components/UpdateNotification';
 
 const reactLazyWithNonDefaultExports = (load, ...names) => {
 	const nonDefaults = (names ?? []).map(name => {
@@ -93,16 +94,6 @@ function App() {
 
 	useEffect(() => {
 		setUrl(window.location.href);
-
-		const checkForUpdates = async () => {
-			if (navigator.serviceWorker) {
-				const registration = await navigator.serviceWorker.getRegistration();
-				if (registration) {
-					registration.update();
-				}
-			}
-		};
-
 		checkForUpdates();
 	}, [location])
 
@@ -132,6 +123,7 @@ function App() {
 				<Snowfalling />
 				<Suspense fallback={<Spinner />}>
 					<HandlerNotification />
+					<UpdateNotification/>
 					<Routes>
 						<Route element={
 							<PrivateRoute>

--- a/src/components/BottomNav.js
+++ b/src/components/BottomNav.js
@@ -1,10 +1,13 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { FaWallet, FaUserCircle } from "react-icons/fa";
 import { IoIosTime, IoIosAddCircle, IoIosSend } from "react-icons/io";
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { MdNotifications } from "react-icons/md";
+import StatusContext from '../context/StatusContext';
 
 const BottomNav = ({ isOpen, toggle }) => {
+	const { updateAvailable } = useContext(StatusContext);
 	const location = useLocation();
 	const navigate = useNavigate();
 	const { t } = useTranslation();
@@ -45,12 +48,18 @@ const BottomNav = ({ isOpen, toggle }) => {
 			))}
 			<button
 				key={t("common.navItemProfile")}
-				className={`cursor-pointer flex flex-col items-center w-[20%] ${isOpen ? 'text-primary dark:text-white' : 'text-gray-400 dark:text-gray-400'} transition-colors duration-200`}
+				className={`cursor-pointer flex flex-col items-center w-[20%] relative ${isOpen ? 'text-primary dark:text-white' : 'text-gray-400 dark:text-gray-400'} transition-colors duration-200`}
 				onClick={toggle}
 				title={t("common.navItemProfile")}
 			>
 				<FaUserCircle size={26} />
 				<span className="text-xs">{t("common.navItemProfile")}</span>
+				{updateAvailable && (
+					<MdNotifications
+						size={22}
+						className="text-red-500 absolute top-[-10px] right-0"
+					/>
+				)}
 			</button>
 		</div>
 	);

--- a/src/components/BottomNav.js
+++ b/src/components/BottomNav.js
@@ -57,7 +57,7 @@ const BottomNav = ({ isOpen, toggle }) => {
 				{updateAvailable && (
 					<MdNotifications
 						size={22}
-						className="text-red-500 absolute top-[-10px] right-0"
+						className="text-green-500 absolute top-[-10px] right-0"
 					/>
 				)}
 			</button>

--- a/src/components/Credentials/CredentialDeleteButton.js
+++ b/src/components/Credentials/CredentialDeleteButton.js
@@ -2,11 +2,11 @@ import React, { useContext } from 'react';
 import { MdDelete } from 'react-icons/md';
 import { useTranslation } from 'react-i18next';
 import Button from '../Buttons/Button';
-import OnlineStatusContext from '../../context/OnlineStatusContext';
+import StatusContext from '../../context/StatusContext';
 
 const CredentialDeleteButton = ({ onDelete }) => {
 	const { t } = useTranslation();
-	const { isOnline } = useContext(OnlineStatusContext);
+	const { isOnline } = useContext(StatusContext);
 
 	const handleClick = () => {
 		onDelete();

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -7,12 +7,12 @@ import Sidebar from './Sidebar';
 import logo from '../assets/images/wallet_white.png';
 import WelcomeTourGuide from './WelcomeTourGuide/WelcomeTourGuide';
 import BottomNav from './BottomNav';
-import OnlineStatusContext from '../context/OnlineStatusContext';
+import StatusContext from '../context/StatusContext';
 import { PiWifiHighBold, PiWifiSlashBold } from "react-icons/pi";
 
 
 const Layout = ({ children }) => {
-	const { isOnline } = useContext(OnlineStatusContext);
+	const { isOnline } = useContext(StatusContext);
 	const location = useLocation();
 	const navigate = useNavigate();
 	const [isOpen, setIsOpen] = useState(false);

--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -6,7 +6,7 @@ import { Trans } from 'react-i18next';
 
 import Spinner from './Spinner'; // Import your spinner component
 import { useSessionStorage } from '../hooks/useStorage';
-import OnlineStatusContext from '../context/OnlineStatusContext';
+import StatusContext from '../context/StatusContext';
 import SessionContext from '../context/SessionContext';
 
 
@@ -22,7 +22,7 @@ const PrivateRouteContext: React.Context<PrivateRouteContextValue> = createConte
 
 
 export function NotificationPermissionWarning(): React.ReactNode {
-	const { isOnline } = useContext(OnlineStatusContext);
+	const { isOnline } = useContext(StatusContext);
 	const { api } = useContext(SessionContext);
 	const [isMessageNoGrantedVisible, setIsMessageNoGrantedVisible,] = api.useClearOnClearSession(useSessionStorage('isMessageNoGrantedVisible', false));
 	const [isMessageGrantedVisible, setIsMessageGrantedVisible,] = api.useClearOnClearSession(useSessionStorage('isMessageGrantedVisible', false));
@@ -133,7 +133,7 @@ export function NotificationPermissionWarning(): React.ReactNode {
 }
 
 const PrivateRoute = ({ children }: { children?: React.ReactNode }): React.ReactNode => {
-	const { isOnline } = useContext(OnlineStatusContext);
+	const { isOnline } = useContext(StatusContext);
 	const { api, isLoggedIn, keystore, logout } = useContext(SessionContext);
 	const [isPermissionGranted, setIsPermissionGranted] = useState(null);
 	const [loading, setLoading] = useState(false);

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -6,7 +6,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import logo from '../assets/images/wallet_white.png';
 import { Trans, useTranslation } from 'react-i18next';
-import OnlineStatusContext from '../context/OnlineStatusContext';
+import StatusContext from '../context/StatusContext';
 import SessionContext from '../context/SessionContext';
 import { PiWifiHighBold, PiWifiSlashBold } from "react-icons/pi";
 
@@ -29,7 +29,7 @@ const NavItem = ({
 };
 
 const Sidebar = ({ isOpen, toggle }) => {
-	const { isOnline } = useContext(OnlineStatusContext);
+	const { isOnline } = useContext(StatusContext);
 	const { api, logout } = useContext(SessionContext);
 	const { username, displayName } = api.getSession();
 	const location = useLocation();

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -158,7 +158,7 @@ const Sidebar = ({ isOpen, toggle }) => {
 									{updateAvailable && (
 										<MdNotifications
 											size={22}
-											className="text-red-500"
+											className="text-green-500"
 										/>
 									)}
 								</div>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -9,6 +9,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import StatusContext from '../context/StatusContext';
 import SessionContext from '../context/SessionContext';
 import { PiWifiHighBold, PiWifiSlashBold } from "react-icons/pi";
+import { MdNotifications } from "react-icons/md";
 
 const NavItem = ({
 	children,
@@ -29,7 +30,7 @@ const NavItem = ({
 };
 
 const Sidebar = ({ isOpen, toggle }) => {
-	const { isOnline } = useContext(StatusContext);
+	const { isOnline, updateAvailable } = useContext(StatusContext);
 	const { api, logout } = useContext(SessionContext);
 	const { username, displayName } = api.getSession();
 	const location = useLocation();
@@ -152,7 +153,15 @@ const Sidebar = ({ isOpen, toggle }) => {
 						<div className='step-7'>
 							<NavItem path="/settings" location={location} handleNavigate={handleNavigate}>
 								<IoMdSettings size={30} />
-								<span>{t("common.navItemSettings")}</span>
+								<div className='flex gap-2 items-center'>
+									<span>{t("common.navItemSettings")}</span>
+									{updateAvailable && (
+										<MdNotifications
+											size={22}
+											className="text-red-500"
+										/>
+									)}
+								</div>
 							</NavItem>
 						</div>
 

--- a/src/components/UpdateNotification.js
+++ b/src/components/UpdateNotification.js
@@ -1,0 +1,47 @@
+import React, { useContext, useState } from 'react';
+import StatusContext from '../context/StatusContext';
+import { useTranslation } from 'react-i18next';
+import Button from './Buttons/Button';
+import { FaTimes } from 'react-icons/fa';
+import { MdNotifications } from "react-icons/md";
+
+const UpdateNotification = () => {
+	const { updateAvailable } = useContext(StatusContext);
+	const [visible, setVisible] = useState(updateAvailable);
+	const { t } = useTranslation();
+
+	const handleReload = () => {
+		window.location.reload();
+	};
+
+	const handleClose = () => {
+		setVisible(false);
+	};
+
+	if (!visible) return null;
+
+	return (
+		<div className={`fixed right-4 bottom-4 sm:top-4 sm:bottom-auto bg-green-600 bg-opacity-80 z-50 text-white px-4 py-2 rounded-lg shadow-lg flex items-center space-x-2 
+      animate-slide-in-up sm:animate-slide-in-down`}>
+			<MdNotifications
+				size={22}
+				className="text-white"
+			/>
+			{t('updateNotification.description')}
+			<Button
+				variant="tertiary"
+				onClick={handleReload}
+			>
+				{t('common.refresh')}
+			</Button>
+			<button
+				className="ml-2 text-white hover:text-gray-300"
+				onClick={handleClose}
+			>
+				<FaTimes />
+			</button>
+		</div>
+	);
+};
+
+export default UpdateNotification;

--- a/src/components/UpdateNotification.js
+++ b/src/components/UpdateNotification.js
@@ -21,8 +21,7 @@ const UpdateNotification = () => {
 	if (!visible) return null;
 
 	return (
-		<div className={`fixed right-4 bottom-4 sm:top-4 sm:bottom-auto bg-green-600 bg-opacity-80 z-50 text-white px-4 py-2 rounded-lg shadow-lg flex items-center space-x-2 
-      animate-slide-in-up sm:animate-slide-in-down`}>
+		<div className="fixed right-4 bottom-4 sm:top-4 sm:bottom-auto bg-green-600 bg-opacity-80 z-50 text-white px-4 py-2 rounded-lg shadow-lg flex items-center space-x-2 animate-slide-in-up sm:animate-slide-in-down">
 			<MdNotifications
 				size={22}
 				className="text-white"

--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext } from 'react';
 
-import OnlineStatusContext from './OnlineStatusContext';
+import StatusContext from './StatusContext';
 import { BackendApi, useApi } from '../api';
 import { useLocalStorageKeystore } from '../services/LocalStorageKeystore';
 import type { LocalStorageKeystore } from '../services/LocalStorageKeystore';
@@ -21,7 +21,7 @@ const SessionContext: React.Context<SessionContextValue> = createContext({
 });
 
 export const SessionContextProvider = ({ children }) => {
-	const { isOnline } = useContext(OnlineStatusContext);
+	const { isOnline } = useContext(StatusContext);
 	const api = useApi(isOnline);
 	const keystore = useLocalStorageKeystore();
 

--- a/src/context/StatusContext.tsx
+++ b/src/context/StatusContext.tsx
@@ -1,6 +1,4 @@
 import React, { useEffect, createContext, useState } from 'react';
-import { useLocalStorageKeystore } from '../services/LocalStorageKeystore';
-import { useApi } from '../api';
 /**
  * Type polyfill for https://wicg.github.io/netinfo/#networkinformation-interface
  * but defining only the properties we use here.
@@ -39,8 +37,6 @@ function getOnlineStatus(): boolean {
 export const StatusProvider = ({ children }: { children: React.ReactNode }) => {
 	const [isOnline, setIsOnline] = useState(getOnlineStatus);
 	const [updateAvailable, setUpdateAvailable] = useState(false);
-	const api = useApi(isOnline);
-	const keystore = useLocalStorageKeystore();
 	const updateOnlineStatus = () => {
 		setIsOnline(getOnlineStatus());
 	};
@@ -63,10 +59,9 @@ export const StatusProvider = ({ children }: { children: React.ReactNode }) => {
 
 	navigator.serviceWorker.addEventListener('message', (event) => {
 		if (event.data && event.data.type === 'NEW_CONTENT_AVAILABLE') {
+			const isWindowHidden = document.hidden;
 
-			const isLoggedIn = api.isLoggedIn() && keystore.isOpen();
-
-			if (!isLoggedIn) {
+			if (isWindowHidden) {
 				window.location.reload();
 			} else {
 				setUpdateAvailable(true);

--- a/src/context/StatusContext.tsx
+++ b/src/context/StatusContext.tsx
@@ -16,13 +16,13 @@ declare global {
 	}
 }
 
-interface OnlineStatusContextValue {
+interface StatusContextValue {
 	isOnline: boolean;
 	updateAvailable: boolean;
 }
 
 
-const OnlineStatusContext: React.Context<OnlineStatusContextValue> = createContext({
+const StatusContext: React.Context<StatusContextValue> = createContext({
 	isOnline: null,
 	updateAvailable: false,
 });
@@ -36,7 +36,7 @@ function getOnlineStatus(): boolean {
 	return navigator.onLine && rtt > 0;
 }
 
-export const OnlineStatusProvider = ({ children }: { children: React.ReactNode }) => {
+export const StatusProvider = ({ children }: { children: React.ReactNode }) => {
 	const [isOnline, setIsOnline] = useState(getOnlineStatus);
 	const [updateAvailable, setUpdateAvailable] = useState(false);
 	const api = useApi(isOnline);
@@ -75,10 +75,10 @@ export const OnlineStatusProvider = ({ children }: { children: React.ReactNode }
 	});
 
 	return (
-		<OnlineStatusContext.Provider value={{ isOnline, updateAvailable }}>
+		<StatusContext.Provider value={{ isOnline, updateAvailable }}>
 			{children}
-		</OnlineStatusContext.Provider>
+		</StatusContext.Provider>
 	);
 };
 
-export default OnlineStatusContext;
+export default StatusContext;

--- a/src/hoc/handleServerMessagesGuard.js
+++ b/src/hoc/handleServerMessagesGuard.js
@@ -4,7 +4,7 @@ import * as config from '../config';
 import { SignatureAction } from "../types/shared.types";
 import Spinner from '../components/Spinner';
 import { SigningRequestHandlerService } from '../services/SigningRequestHandlers';
-import OnlineStatusContext from '../context/OnlineStatusContext';
+import StatusContext from '../context/StatusContext';
 import SessionContext from "../context/SessionContext";
 
 
@@ -15,7 +15,7 @@ export default function handleServerMessagesGuard(Component) {
 		const [handshakeEstablished, setHandshakeEstablished] = useState(false);
 		const socketRef = useRef(null);
 		const signingRequestHandlerService = SigningRequestHandlerService();
-		const { isOnline } = useContext(OnlineStatusContext);
+		const { isOnline } = useContext(StatusContext);
 		const { api, keystore } = useContext(SessionContext);
 		const appToken = api.getAppToken();
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import ConsoleBehavior from './ConsoleBehavior';
-import { OnlineStatusProvider } from './context/OnlineStatusContext';
+import { StatusProvider } from './context/StatusContext';
 import { initializeDataSource } from './indexedDB';
 import * as offlineSW from './offlineRegistrationSW';
 import * as firebaseSW from './firebase';
@@ -32,9 +32,9 @@ const RootComponent = () => {
 
 const root = createRoot(document.getElementById('root'));
 root.render(
-	<OnlineStatusProvider>
+	<StatusProvider>
 		<RootComponent />
-	</OnlineStatusProvider>
+	</StatusProvider>
 );
 
 firebaseSW.register()

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -22,6 +22,7 @@
 		"previous": "Previous",
 		"privateDataConflict": "Your session is out of sync with the server. Please log out, then log in and try again.",
 		"save": "Save",
+		"refresh": "Refresh",
 		"submit": "Submit",
 		"tryAgain": "Try again",
 		"walletName": "wwWallet"
@@ -281,6 +282,9 @@
 		"tourStep7": "In the 'Settings' page you can manage your passkeys and account settings.",
 		"tourComplete": "Thank you for completing the tour, we hope it was helpful!",
 		"closeTourButton": "Close Tour"
+	},
+	"updateNotification": {
+		"description": "New Version is available!"
 	},
 	"welcomeModal": {
 		"title": "Welcome to $t(common.walletName)!",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -209,7 +209,8 @@
 			"confirmDeletePopup": "Are You Sure?",
 			"loggedInPasskey": "Logged in Passkey",
 			"manageAcount": "Manage Account",
-			"manageOtherPasskeys": "Manage other Passkeys"
+			"manageOtherPasskeys": "Manage other Passkeys",
+			"appVersion":"App Version"
 		},
 		"unlockPasskeyManagement": "Unlock management",
 		"unlockPasskeyManagementTitle": "Click to Unlock management",
@@ -223,6 +224,10 @@
 			"description": "Please authenticate with the passkey \"{{passkeyLabel}}\"...",
 			"error": "<p>Something went wrong, please try again.</p><p>Please note that you need to authenticate with the passkey \"{{passkeyLabel}}\".</p>",
 			"title": "Upgrading passkey encryption key"
+		},
+		"appVersion": {
+			"descriptionLatestVersion": "You are currently using the latest $t(common.walletName) version {{react_app_version}}",
+			"descriptionOldVersion": "You are currently using wwWallet version {{react_app_version}}.<br/> <strong>A newer version is available.</strong> Please <reloadButton>reload</reloadButton> to update!"
 		}
 	},
 	"PinInputPopup": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -228,7 +228,7 @@
 		},
 		"appVersion": {
 			"descriptionLatestVersion": "You are currently using the latest $t(common.walletName) version {{react_app_version}}",
-			"descriptionOldVersion": "You are currently using wwWallet version {{react_app_version}}.<br/> <strong>A newer version is available.</strong> Please <reloadButton>reload</reloadButton> to update!"
+			"descriptionOldVersion": "You are currently using wwWallet version {{react_app_version}}.<br/> <strong>A new version is available.</strong> Please <reloadButton>refresh</reloadButton> to update!"
 		}
 	},
 	"PinInputPopup": {

--- a/src/offlineRegistrationSW.js
+++ b/src/offlineRegistrationSW.js
@@ -63,15 +63,6 @@ function registerValidSW(swUrl, config) {
 		});
 }
 
-if ('serviceWorker' in navigator) {
-	navigator.serviceWorker.addEventListener('message', (event) => {
-		if (event.data && event.data.type === 'NEW_CONTENT_AVAILABLE') {
-			console.log('New version is available. Would you like to reload to get the latest now?')
-			window.location.reload();
-		}
-	});
-}
-
 function checkValidServiceWorker(swUrl, config) {
 	// Check if the service worker can be found. If it can't reload the page.
 	fetch(swUrl, {

--- a/src/offlineRegistrationSW.js
+++ b/src/offlineRegistrationSW.js
@@ -91,6 +91,15 @@ function checkValidServiceWorker(swUrl, config) {
 		});
 }
 
+export const checkForUpdates = async () => {
+	if (navigator.serviceWorker) {
+		const registration = await navigator.serviceWorker.getRegistration();
+		if (registration) {
+			registration.update();
+		}
+	}
+};
+
 export function unregister() {
 	if ('serviceWorker' in navigator) {
 		navigator.serviceWorker.ready

--- a/src/pages/AddCredentials/AddCredentials.js
+++ b/src/pages/AddCredentials/AddCredentials.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import OnlineStatusContext from '../../context/OnlineStatusContext';
+import StatusContext from '../../context/StatusContext';
 import SessionContext from '../../context/SessionContext';
 
 import QRCodeScanner from '../../components/QRCodeScanner/QRCodeScanner';
@@ -23,7 +23,7 @@ function highlightBestSequence(issuer, search) {
 }
 
 const Issuers = () => {
-	const { isOnline } = useContext(OnlineStatusContext);
+	const { isOnline } = useContext(StatusContext);
 	const { api } = useContext(SessionContext);
 	const [searchQuery, setSearchQuery] = useState('');
 	const [issuers, setIssuers] = useState([]);

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -19,7 +19,7 @@ import { PiWifiHighBold, PiWifiSlashBold } from "react-icons/pi";
 import SeparatorLine from '../../components/SeparatorLine';
 import PasswordStrength from '../../components/PasswordStrength';
 import LoginPageLayout from './LoginPageLayout';
-
+import { checkForUpdates } from '../../offlineRegistrationSW';
 
 const FormInputRow = ({
 	IconComponent,
@@ -355,6 +355,7 @@ const WebauthnSignupLogin = ({
 
 		setInProgress(false);
 		setIsSubmitting(false);
+		checkForUpdates();
 	};
 
 	const onLoginCachedUser = async (cachedUser: CachedUser) => {
@@ -364,6 +365,7 @@ const WebauthnSignupLogin = ({
 		await onLogin(cachedUser);
 		setInProgress(false);
 		setIsSubmitting(false);
+		checkForUpdates();
 	};
 
 	const onForgetCachedUser = (cachedUser: CachedUser) => {
@@ -637,6 +639,7 @@ const Login = () => {
 		if (isOnline || !isLogin) {
 			setIsLogin(!isLogin);
 			setError('');
+			checkForUpdates();
 		};
 	}
 
@@ -644,6 +647,7 @@ const Login = () => {
 		setIsLoginCache(false);
 		setError('');
 		setWebauthnError('');
+		checkForUpdates();
 	}
 
 	return (

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -8,7 +8,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import type { CachedUser } from '../../services/LocalStorageKeystore';
 import { calculateByteSize } from '../../util';
 
-import OnlineStatusContext from '../../context/OnlineStatusContext';
+import StatusContext from '../../context/StatusContext';
 import SessionContext from '../../context/SessionContext';
 
 import * as config from '../../config';
@@ -212,7 +212,7 @@ const WebauthnSignupLogin = ({
 	error: React.ReactNode,
 	setError: (error: React.ReactNode) => void,
 }) => {
-	const { isOnline } = useContext(OnlineStatusContext);
+	const { isOnline } = useContext(StatusContext);
 	const { api, keystore } = useContext(SessionContext);
 
 	const [inProgress, setInProgress] = useState(false);
@@ -555,7 +555,7 @@ const WebauthnSignupLogin = ({
 };
 
 const Login = () => {
-	const { isOnline } = useContext(OnlineStatusContext);
+	const { isOnline } = useContext(StatusContext);
 	const { api, isLoggedIn, keystore } = useContext(SessionContext);
 	const { t } = useTranslation();
 	const location = useLocation();

--- a/src/pages/Login/LoginState.js
+++ b/src/pages/Login/LoginState.js
@@ -10,7 +10,7 @@ import SessionContext from '../../context/SessionContext';
 import Button from '../../components/Buttons/Button';
 import { PiWifiHighBold, PiWifiSlashBold } from "react-icons/pi";
 import LoginPageLayout from './LoginPageLayout';
-
+import { checkForUpdates } from '../../offlineRegistrationSW';
 
 const WebauthnLogin = ({
 	filteredUser,
@@ -63,6 +63,7 @@ const WebauthnLogin = ({
 		setIsSubmitting(true);
 		await onLogin(cachedUser);
 		setIsSubmitting(false);
+		checkForUpdates();
 	};
 
 	return (

--- a/src/pages/Login/LoginState.js
+++ b/src/pages/Login/LoginState.js
@@ -4,7 +4,7 @@ import { FaInfoCircle } from 'react-icons/fa';
 import { GoPasskeyFill } from 'react-icons/go';
 import { Trans, useTranslation } from 'react-i18next';
 
-import OnlineStatusContext from '../../context/OnlineStatusContext';
+import StatusContext from '../../context/StatusContext';
 import SessionContext from '../../context/SessionContext';
 
 import Button from '../../components/Buttons/Button';
@@ -96,7 +96,7 @@ const WebauthnLogin = ({
 };
 
 const LoginState = () => {
-	const { isOnline } = useContext(OnlineStatusContext);
+	const { isOnline } = useContext(StatusContext);
 	const { isLoggedIn, keystore } = useContext(SessionContext);
 	const { t } = useTranslation();
 	const location = useLocation();

--- a/src/pages/SendCredentials/SendCredentials.js
+++ b/src/pages/SendCredentials/SendCredentials.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import OnlineStatusContext from '../../context/OnlineStatusContext';
+import StatusContext from '../../context/StatusContext';
 import SessionContext from '../../context/SessionContext';
 
 import QRCodeScanner from '../../components/QRCodeScanner/QRCodeScanner'; // Replace with the actual import path
@@ -23,7 +23,7 @@ function highlightBestSequence(verifier, search) {
 }
 
 const Verifiers = () => {
-	const { isOnline } = useContext(OnlineStatusContext);
+	const { isOnline } = useContext(StatusContext);
 	const { api } = useContext(SessionContext);
 	const [searchQuery, setSearchQuery] = useState('');
 	const [verifiers, setVerifiers] = useState([]);

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -918,7 +918,7 @@ const Settings = () => {
 								{updateAvailable && (
 									<MdNotifications
 										size={22}
-										className="text-red-500 absolute top-0 left-[105px]"
+										className="text-green-500 absolute top-0 left-[105px]"
 									/>
 								)}
 							</div>

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -2,6 +2,7 @@ import React, { FormEvent, KeyboardEvent, ReactNode, useCallback, useContext, us
 import { Trans, useTranslation } from 'react-i18next';
 import { FaEdit, FaSyncAlt, FaTrash } from 'react-icons/fa';
 import { BsLock, BsPlusCircle, BsUnlock } from 'react-icons/bs';
+import { MdNotifications } from "react-icons/md";
 
 import StatusContext from '../../context/StatusContext';
 import SessionContext from '../../context/SessionContext';
@@ -678,7 +679,7 @@ const WebauthnCredentialItem = ({
 };
 
 const Settings = () => {
-	const { isOnline } = useContext(StatusContext);
+	const { isOnline, updateAvailable } = useContext(StatusContext);
 	const { api, logout, keystore } = useContext(SessionContext);
 	const [userData, setUserData] = useState<UserData>(null);
 	const { webauthnCredentialCredentialId: loggedInPasskeyCredentialId } = api.getSession();
@@ -912,10 +913,31 @@ const Settings = () => {
 
 						</div>
 						<div className="my-2 py-2">
-							<H2 heading={t('pageSettings.title.appVersion')} />
-							<p className='mb-2 dark:text-white'>
-								{t('pageSettings.appVersion.description', { react_app_version: process.env.REACT_APP_VERSION })}
-							</p>
+							<div className='relative'>
+								<H2 heading={t('pageSettings.title.appVersion')} />
+								{updateAvailable && (
+									<MdNotifications
+										size={22}
+										className="text-red-500 absolute top-0 left-[105px]"
+									/>
+								)}
+							</div>
+							{updateAvailable ? (
+								<p className='mb-2 dark:text-white'>
+									<Trans
+										i18nKey="pageSettings.appVersion.descriptionOldVersion"
+										values={{ react_app_version: process.env.REACT_APP_VERSION }}
+										components={{
+											reloadButton: <button className='text-primary dark:text-extra-light underline' onClick={() => window.location.reload()} />, strong: <strong />, br: <br />,
+										}}
+									/>
+								</p>
+							) : (
+								<p className='mb-2 dark:text-white'>
+									{t('pageSettings.appVersion.descriptionLatestVersion', { react_app_version: process.env.REACT_APP_VERSION })}
+								</p>
+							)}
+
 						</div>
 					</>
 				)}

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -911,6 +911,12 @@ const Settings = () => {
 							</div>
 
 						</div>
+						<div className="my-2 py-2">
+							<H2 heading={t('pageSettings.title.appVersion')} />
+							<p className='mb-2 dark:text-white'>
+								{t('pageSettings.appVersion.description', { react_app_version: process.env.REACT_APP_VERSION })}
+							</p>
+						</div>
 					</>
 				)}
 				<DeletePopup

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -3,7 +3,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { FaEdit, FaSyncAlt, FaTrash } from 'react-icons/fa';
 import { BsLock, BsPlusCircle, BsUnlock } from 'react-icons/bs';
 
-import OnlineStatusContext from '../../context/OnlineStatusContext';
+import StatusContext from '../../context/StatusContext';
 import SessionContext from '../../context/SessionContext';
 
 import { UserData, WebauthnCredential } from '../../api/types';
@@ -87,7 +87,7 @@ const WebauthnRegistation = ({
 	onSuccess: () => void,
 	wrappedMainKey?: WrappedKeyInfo,
 }) => {
-	const { isOnline } = useContext(OnlineStatusContext);
+	const { isOnline } = useContext(StatusContext);
 	const { api, keystore } = useContext(SessionContext);
 	const [beginData, setBeginData] = useState(null);
 	const [pendingCredential, setPendingCredential] = useState(null);
@@ -321,7 +321,7 @@ const UnlockMainKey = ({
 	onUnlock: (unwrappingKey: CryptoKey, wrappedMainKey: WrappedKeyInfo) => void,
 	unlocked: boolean,
 }) => {
-	const { isOnline } = useContext(OnlineStatusContext);
+	const { isOnline } = useContext(StatusContext);
 	const { keystore } = useContext(SessionContext);
 	const [inProgress, setInProgress] = useState(false);
 	const [resolvePasswordPromise, setResolvePasswordPromise] = useState<((password: string) => void) | null>(null);
@@ -484,7 +484,7 @@ const WebauthnCredentialItem = ({
 	onUpgradePrfKey: (prfKeyInfo: WebauthnPrfEncryptionKeyInfo) => void,
 	unlocked: boolean,
 }) => {
-	const { isOnline } = useContext(OnlineStatusContext);
+	const { isOnline } = useContext(StatusContext);
 	const [nickname, setNickname] = useState(credential.nickname || '');
 	const [editing, setEditing] = useState(false);
 	const { t } = useTranslation();
@@ -678,7 +678,7 @@ const WebauthnCredentialItem = ({
 };
 
 const Settings = () => {
-	const { isOnline } = useContext(OnlineStatusContext);
+	const { isOnline } = useContext(StatusContext);
 	const { api, logout, keystore } = useContext(SessionContext);
 	const [userData, setUserData] = useState<UserData>(null);
 	const { webauthnCredentialCredentialId: loggedInPasskeyCredentialId } = api.getSession();

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,7 +19,21 @@ module.exports = {
 			},
 			screens: {
 				'max480': { 'max': '480px' },
-			}
+			},
+			keyframes: {
+				'slide-in-up': {
+					'0%': { transform: 'translateY(100%)' },
+					'100%': { transform: 'translateY(0)' },
+				},
+				'slide-in-down': {
+					'0%': { transform: 'translateY(-100%)' },
+					'100%': { transform: 'translateY(0)' },
+				},
+			},
+			animation: {
+				'slide-in-up': 'slide-in-up 0.5s ease-out forwards',
+				'slide-in-down': 'slide-in-down 0.5s ease-out forwards',
+			},
 		},
 	},
 	plugins: [],


### PR DESCRIPTION
**Current Implementation (PR #333):**
The wwWallet currently triggers an automatic update by skipping the waiting service worker and reloading when a user opens a new tab, reopens the PWA, or manually reloads the tab/PWA. However, this approach does not address scenarios where the user already has a tab/PWA open and may not be aware of any updates available until they manually reload or close and reopen the application.

**Gap Addressed in This PR:**
This PR aims to bridge the gap by ensuring that users with an already open tab/PWA are notified when an update is available. Specifically, we have implemented the following changes:

**Service Worker Update on Navigation:** We now call `registration.update()` during `location` changes within the wallet and also during specific user interactions on the login page, such as button clicks or other actions that do not trigger a full navigation. This ensures that the app checks for updates regularly, even in scenarios where navigation does not occur.

**User Notification on Update Detection:**

- **Active Tab/PWA Users:** When a user is in an active tab or PWA and a new update is detected, a notification is displayed informing them about the new version. This notification allows the user to reload at their convenience. If the user dismisses the notification, an additional section in the settings page will be available to remind them of the update.

- **Other Tabs/PWA:** When a new update is detected, all other open tabs or PWAs that are not active will automatically reload with the new version, ensuring a consistent experience across all instances of the application.

   This enhancement ensures a more seamless experience for users, particularly those who keep the app open for extended periods, by keeping them informed of updates without unnecessary interruptions.

**Testing Instructions:**

1. Run `node ecosystem.js up` to start the environment.
2. Stop the frontend container.
3. Navigate to the `cd wallet-frontend` directory.
4. Build the project with `npm run build`.
5. Serve the build using `serve -s build`.

Now, you can navigate through a local production environment with the offline service worker running. To review this PR:

- Open several tabs, log in to one of them, and also open the PWA.
- Repeat steps 4 and 5 to rebuild and serve the frontend.
- Test the behavior by interacting with the tabs and PWA, observing the update handling process.