### PR TITLE
Save and recall WebAuthn credential transports into and from PRF key info

### DIFF
--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -123,6 +123,7 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 							...cu,
 							prfKeys: privateData.prfKeys.map((keyInfo) => ({
 								credentialId: keyInfo.credentialId,
+								transports: keyInfo.transports,
 								prfSalt: keyInfo.prfSalt,
 							})),
 						};

--- a/src/services/keystore.test.ts
+++ b/src/services/keystore.test.ts
@@ -24,6 +24,9 @@ function mockPrfCredential(
 		id: toBase64Url(id),
 		rawId: id.buffer,
 		getClientExtensionResults: () => ({ prf: { results: { first: prfOutput.buffer } } }),
+		response: {
+			getTransports: () => [],
+		},
 	} as unknown as PublicKeyCredential;
 }
 

--- a/src/services/keystore.ts
+++ b/src/services/keystore.ts
@@ -140,6 +140,7 @@ export function isAsymmetricPasswordKeyInfo(passwordKeyInfo: PasswordKeyInfo): p
 
 export type WebauthnPrfSaltInfo = {
 	credentialId: Uint8Array,
+	transports?: AuthenticatorTransport[],
 	prfSalt: Uint8Array,
 }
 
@@ -661,6 +662,7 @@ export function makeAssertionPrfExtensionInputs(prfKeys: WebauthnPrfSaltInfo[]):
 			(keyInfo: WebauthnPrfSaltInfo) => ({
 				type: "public-key",
 				id: keyInfo.credentialId,
+				transports: keyInfo.transports ?? [],
 			})
 		),
 		prfInput: {
@@ -763,6 +765,7 @@ async function createPrfKey(
 	const [prfKeypair, prfPrivateKey] = await generateWrappedEncapsulationKeypair(prfKey);
 	const keyInfo: WebauthnPrfEncryptionKeyInfoV2 = {
 		credentialId: new Uint8Array(credential.rawId),
+		transports: (credential.response as AuthenticatorAttestationResponse).getTransports() as AuthenticatorTransport[],
 		prfSalt,
 		...deriveKeyParams,
 		...await encapsulateKey(prfPrivateKey, mainKeyInfo.publicKey, prfKeypair, mainKey),


### PR DESCRIPTION
This may improve the user experience by providing the client better information about how credentials may be reached. For example, one issue we've seen is that without these hints, some platforms incorrectly assume during the second ("Almost done!") authentication that the authentication cannot succeed because none of the IDs in `allowCredentials` match any credential in the platform credential - and don't allow the user to use an external security key instead. These hints should help the client understand which credentials are platform credentials and which exist on external security keys.

This will only take effect for newly created credentials, because the `getTransports` function only exists on `navigator.credentials.create()` results.

We do also have these transports stored in the backend and _could_ use that to retroactively set the transports in the PRF key info in the encrypted container. That seems like more work than it's worth, but could be revisited as an option in the future.