### PR TITLE
Add SVG rendering with dynamic user data

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "i18next": "^23.2.11",
     "jose": "^4.14.4",
     "js-cookie": "^3.0.5",
+    "jsonpointer": "^5.0.1",
     "key-did-resolver": "^3.0.0",
     "localforage": "^1.10.0",
     "multiformats": "^12.1.3",

--- a/src/components/Credentials/CredentialImage.js
+++ b/src/components/Credentials/CredentialImage.js
@@ -1,10 +1,11 @@
 import { useState, useEffect } from "react";
 import { parseCredential } from "../../functions/parseCredential";
 import StatusRibbon from '../../components/Credentials/StatusRibbon';
-
+import RenderSvgTemplate from "./RenderSvgTemplate";
 
 export const CredentialImage = ({ credential, className, onClick, showRibbon = true }) => {
 	const [parsedCredential, setParsedCredential] = useState(null);
+	const [svgImage, setSvgImage] = useState(null);
 
 	useEffect(() => {
 		parseCredential(credential).then((c) => {
@@ -12,14 +13,23 @@ export const CredentialImage = ({ credential, className, onClick, showRibbon = t
 		});
 	}, [credential]);
 
+	const handleSvgGenerated = (svgUri) => {
+		setSvgImage(svgUri);
+	};
+
 	return (
 		<>
 			{parsedCredential && (
 				<>
-					<img src={parsedCredential.credentialBranding.image.url} alt={"Credential"} className={className} onClick={onClick} />
-					{showRibbon &&
-						<StatusRibbon credential={credential} />
-					}
+					{parsedCredential.renderMethod && (
+						<RenderSvgTemplate credential={parsedCredential} onSvgGenerated={handleSvgGenerated} />
+					)}
+					{svgImage ? (
+						<img src={svgImage} alt={"Credential"} className={className} onClick={onClick} />
+					) : (
+						<img src={parsedCredential.credentialBranding.image.url} alt={"Credential"} className={className} onClick={onClick} />
+					)}
+					{showRibbon && <StatusRibbon credential={credential} />}
 				</>
 			)}
 		</>

--- a/src/components/Credentials/CredentialInfo.js
+++ b/src/components/Credentials/CredentialInfo.js
@@ -4,7 +4,7 @@ import { AiFillCalendar } from 'react-icons/ai';
 import { RiPassExpiredFill } from 'react-icons/ri';
 import { MdTitle, MdGrade, MdOutlineNumbers } from 'react-icons/md';
 import { GiLevelEndFlag } from 'react-icons/gi';
-import { formatDate } from '../../functions/DateFormat';
+import { formatDateTime } from '../../functions/DateFormat';
 import { parseCredential } from '../../functions/parseCredential';
 
 const getFieldIcon = (fieldName) => {
@@ -71,7 +71,7 @@ const CredentialInfo = ({ credential, mainClassName = "text-xs sm:text-sm md:tex
 				<tbody className="divide-y-4 divide-transparent">
 					{parsedCredential && (
 						<>
-							{renderRow('expdate', 'Expiration', formatDate(parsedCredential.expirationDate))}
+							{renderRow('expdate', 'Expiration', formatDateTime(parsedCredential.expirationDate))}
 							{renderRow('familyName', 'Family Name', parsedCredential.credentialSubject.familyName)}
 							{renderRow('firstName', 'First Name', parsedCredential.credentialSubject.firstName)}
 							{renderRow('id', 'Personal ID', parsedCredential.credentialSubject.personalIdentifier)}

--- a/src/components/Credentials/RenderSvgTemplate.js
+++ b/src/components/Credentials/RenderSvgTemplate.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import jsonpointer from 'jsonpointer';
+import { formatDate } from '../../functions/DateFormat';
 
 const RenderSvgTemplate = ({ credential, onSvgGenerated }) => {
 	const [svgContent, setSvgContent] = useState(null);
@@ -27,9 +28,13 @@ const RenderSvgTemplate = ({ credential, onSvgGenerated }) => {
 	useEffect(() => {
 		if (svgContent) {
 			const regex = /{{([^}]+)}}/g;
-
+			const dateRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/; // Matches ISO date format
 			const replacedSvgText = svgContent.replace(regex, (match, content) => {
 				const res = jsonpointer.get(credential, content.trim());
+				// Check if the resolved value is a date and format it
+				if (typeof res === 'string' && dateRegex.test(res)) {
+					return formatDate(res);
+				}
 				return res !== undefined ? res : match;
 			});
 			const dataUri = `data:image/svg+xml;utf8,${encodeURIComponent(replacedSvgText)}`;

--- a/src/components/Credentials/RenderSvgTemplate.js
+++ b/src/components/Credentials/RenderSvgTemplate.js
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react';
+import jsonpointer from 'jsonpointer';
+
+const RenderSvgTemplate = ({ credential, onSvgGenerated }) => {
+	const [svgContent, setSvgContent] = useState(null);
+
+	useEffect(() => {
+		const fetchSvgContent = async () => {
+			try {
+				const response = await fetch(credential.renderMethod.id);
+				if (!response.ok) {
+					throw new Error(`Failed to fetch SVG from ${credential.renderMethod.id}`);
+				}
+
+				const svgText = await response.text();
+				setSvgContent(svgText);
+			} catch (error) {
+				console.error(error);
+			}
+		};
+
+		if (credential.renderMethod.id) {
+			fetchSvgContent();
+		}
+	}, [credential.renderMethod.id]);
+
+	useEffect(() => {
+		if (svgContent) {
+			const regex = /{{([^}]+)}}/g;
+
+			const replacedSvgText = svgContent.replace(regex, (match, content) => {
+				const res = jsonpointer.get(credential, content.trim());
+				return res !== undefined ? res : match;
+			});
+			const dataUri = `data:image/svg+xml;utf8,${encodeURIComponent(replacedSvgText)}`;
+			onSvgGenerated(dataUri);
+		}
+	}, [svgContent, credential, onSvgGenerated]);
+
+	return null; // No need to render anything, we're just generating the SVG
+};
+
+export default RenderSvgTemplate;

--- a/src/functions/DateFormat.js
+++ b/src/functions/DateFormat.js
@@ -1,11 +1,19 @@
-export function formatDate(dateString) {
+export function formatDateTime(dateTimeString) {
 	const options = {
 		year: 'numeric',
-		month: 'long',
-		day: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
 		hour: '2-digit',
 		minute: '2-digit',
 		second: '2-digit',
+	};
+	return new Date(dateTimeString).toLocaleString(undefined, options);
+};
+export function formatDate(dateString) {
+	const options = {
+		year: 'numeric',
+		month: '2-digit',
+		day: 'numeric',
 	};
 	return new Date(dateString).toLocaleString(undefined, options);
 };

--- a/src/pages/History/History.js
+++ b/src/pages/History/History.js
@@ -10,7 +10,7 @@ import "slick-carousel/slick/slick-theme.css";
 import SessionContext from '../../context/SessionContext';
 
 import CredentialInfo from '../../components/Credentials/CredentialInfo';
-import { formatDate } from '../../functions/DateFormat';
+import { formatDateTime } from '../../functions/DateFormat';
 import { base64url } from 'jose';
 import { CredentialImage } from '../../components/Credentials/CredentialImage';
 import { H1 } from '../../components/Heading';
@@ -105,7 +105,7 @@ const History = () => {
 								onClick={() => handleHistoryItemClick(item)}
 							>
 								<div className="font-bold">{item.audience}</div>
-								<div>{formatDate(new Date(item.issuanceDate * 1000).toISOString())}</div>
+								<div>{formatDateTime(new Date(item.issuanceDate * 1000).toISOString())}</div>
 							</button>
 						))}
 					</div>

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -8,7 +8,7 @@ import SessionContext from '../../context/SessionContext';
 
 import { UserData, WebauthnCredential } from '../../api/types';
 import { compareBy, toBase64Url } from '../../util';
-import { formatDate } from '../../functions/DateFormat';
+import { formatDateTime } from '../../functions/DateFormat';
 import type { WebauthnPrfEncryptionKeyInfo, WrappedKeyInfo } from '../../services/keystore';
 import { isPrfKeyV2, serializePrivateData } from '../../services/keystore';
 
@@ -581,13 +581,13 @@ const WebauthnCredentialItem = ({
 					<span className="font-semibold">
 						{t('pageSettings.passkeyItem.created')}:&nbsp;
 					</span>
-					{formatDate(credential.createTime)}
+					{formatDateTime(credential.createTime)}
 				</p>
 				<p className='dark:text-white'>
 					<span className="font-semibold">
 						{t('pageSettings.passkeyItem.lastUsed')}:&nbsp;
 					</span>
-					{formatDate(credential.lastUseTime)}</p>
+					{formatDateTime(credential.lastUseTime)}</p>
 				<p className='dark:text-white'>
 					<span className="font-semibold">
 						{t('pageSettings.passkeyItem.canEncrypt')}:&nbsp;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7821,6 +7821,11 @@ jsonpointer@^5.0.0:
   resolved "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz"
   integrity sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==
 
+jsonpointer@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.1.tgz#2110e0af0900fd37467b5907ecd13a7884a1b559"
+  integrity sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==
+
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.3.5:
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz#4766bd05a8e2a11af222becd19e15575e52a853a"


### PR DESCRIPTION
- Replace PNG cards with dynamically  SVG cards if template exist.
- The SVG cards now render actual user data by replacing the placeholder keys with corresponding values.

Related with : https://github.com/wwWallet/wallet-ecosystem/pull/86