### PR TITLE
wip: pre-authorized_code flow

### DIFF
--- a/src/components/Credentials/CredentialImage.js
+++ b/src/components/Credentials/CredentialImage.js
@@ -33,8 +33,8 @@ const CredentialImage = ({ credential, className, onClick, showRibbon = true }) 
 						<img src={svgImage} alt={"Credential"} className={className} onClick={onClick} />
 					)}
 				</>
-			) : parsedCredential && parsedCredential.credentialImage.credentialImageURL && (
-				<img src={parsedCredential.credentialImage.credentialImageURL} alt={"Credential"} className={className} onClick={onClick} />
+			) : (
+				<img src={parsedCredential?.credentialImage?.credentialImageURL || 'https://picsum.photos/300/200' } alt={"Credential"} className={className} onClick={onClick} />
 			)}
 
 			{parsedCredential && showRibbon &&

--- a/src/components/Credentials/CredentialInfo.js
+++ b/src/components/Credentials/CredentialInfo.js
@@ -86,6 +86,11 @@ const CredentialInfo = ({ credential, mainClassName = "text-sm lg:text-base w-fu
 							{renderRow('grade', 'Grade', parsedCredential?.grade, screenType)}
 							{renderRow('id', 'Social Security Number', parsedCredential?.ssn, screenType)}
 							{renderRow('id', 'Document Number', parsedCredential?.document_number, screenType)}
+
+							{renderRow('id', 'ID', parsedCredential?.vc?.credentialSubject?.sub)}
+							{renderRow('familyName', 'Family Name', parsedCredential?.vc?.credentialSubject?.family_name)}
+							{renderRow('firstName', 'Given Name', parsedCredential?.vc?.credentialSubject?.given_name)}
+							{renderRow('diplomaTitle', 'Affiliation', parsedCredential?.vc?.credentialSubject?.eduperson_affiliation)}
 						</>
 					)}
 				</tbody>

--- a/src/components/Credentials/CredentialJson.js
+++ b/src/components/Credentials/CredentialJson.js
@@ -10,7 +10,7 @@ const CredentialJson = ({ credential, textAreaRows='10' }) => {
 
 	useEffect(() => {
 		if (container) {
-			container.credentialParserRegistry.parse(credential).then((c) => {
+			container.credentialParserRegistry.parse(credential.vc || credential).then((c) => {
 				if ('error' in c) {
 					return;
 				}

--- a/src/functions/parseSdJwtCredential.ts
+++ b/src/functions/parseSdJwtCredential.ts
@@ -19,6 +19,16 @@ const hasherAndAlgorithm: HasherAndAlgorithm = {
 	algorithm: HasherAlgorithm.Sha256
 }
 
+const parseJwt = (token: string) => {
+	var base64Url = token.split('.')[1];
+	var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+	var jsonPayload = decodeURIComponent(window.atob(base64).split('').map(function(c) {
+			return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+	}).join(''));
+
+	return JSON.parse(jsonPayload);
+}
+
 export const parseSdJwtCredential = async (credential: string | object): Promise<{ beautifiedForm: any; } | { error: string }> => {
 	try {
 		if (typeof credential == 'string') { // is JWT
@@ -31,6 +41,10 @@ export const parseSdJwtCredential = async (credential: string | object): Promise
 					beautifiedForm: parsed
 				}
 
+			}
+
+			return {
+				beautifiedForm: parseJwt(credential),
 			}
 		}
 		return { error: "Could not parse SDJWT credential" };

--- a/src/hooks/useContainer.ts
+++ b/src/hooks/useContainer.ts
@@ -105,9 +105,9 @@ export function useContainer() {
 				else {
 					let credentialImageURL = credentialHeader?.vctm?.display && credentialHeader.vctm.display[0] && credentialHeader.vctm.display[0][defaultLocale] ?
 						credentialHeader.vctm.display[0][defaultLocale]?.rendering?.simple?.logo?.uri
-						: null;
+						: 'https://picsum.photos/300/200';
 
-					if (!credentialImageURL) { // prrovide fallback method through the OpenID credential issuer metadata
+					if (!credentialImageURL) { // provide fallback method through the OpenID credential issuer metadata
 						const { metadata } = await cont.resolve<IOpenID4VCIHelper>('OpenID4VCIHelper').getCredentialIssuerMetadata(result.beautifiedForm.iss);
 						const credentialConfigurationSupportedObj: CredentialConfigurationSupported = Object.values(metadata.credential_configurations_supported)
 							.filter((x: any) => x?.vct && result.beautifiedForm?.vct && x.vct === result.beautifiedForm?.vct)

--- a/src/lib/schemas/vc.ts
+++ b/src/lib/schemas/vc.ts
@@ -1,6 +1,7 @@
 export enum VerifiableCredentialFormat {
 	SD_JWT_VC = "vc+sd-jwt",
 	VC_JWT = "vc_jwt",
+	JWT_VC_JSON = "jwt_vc_json",
 	MSO_MDOC = "mso_mdoc"
 }
 

--- a/src/lib/services/OpenID4VCIHelper.ts
+++ b/src/lib/services/OpenID4VCIHelper.ts
@@ -37,7 +37,7 @@ export class OpenID4VCIHelper implements IOpenID4VCIHelper {
 		}
 		catch(err) {
 			console.error(err);
-			throw new Error("Couldn't get Credential Issuer Metadata");
+			// throw new Error("Couldn't get Credential Issuer Metadata");
 		}
 
 	}

--- a/src/lib/types/StorableCredential.ts
+++ b/src/lib/types/StorableCredential.ts
@@ -4,4 +4,6 @@ export type StorableCredential = {
 	credentialIdentifier: string;
 	format: VerifiableCredentialFormat;
 	credential: string;
+	credentialIssuerIdentifier?: string;
+	credentialConfigurationId?: string;
 };


### PR DESCRIPTION
The intention of this draft PR is to provide a basis for collecting feedback on how to fit the pre-authorized_code flow implementation into the existing architecture of wwwallet. I have commented on the challenges I faced on the files of the PR and summarized my challenges below the video. Some refactoring of the wwwallet architecture may be needed to support pre-authorized_code flow. It is probably best to split the problem up into smaller problems that are easy to solve separately. I may have broken the existing flows in this draft, which needs to be addressed.

**Feature**

As Martin Jørgensen from MBO Beek
I want to save an Academic Base Credential into my wwWallet
In order to prove my affiliation with MBO Beek to other organizations

Given I am logged in as Martin Jørgensen to my Eduwallet account on https://mbob.idp.dev.eduwallet.nl/simplesaml/module.php/profile on my desktop
And I am logged in to my wwWallet account on my smartphone
When I scan the QR code on my Eduwallet profile page with the wwWallet
Then my Academic Base Credential issued by MBO Beek appears in my wwWallet

**Demo of feature in action**

https://github.com/user-attachments/assets/452e3c15-c4d7-4d45-9ede-982d7eb9cfc2

**Challenges**

- `useCheckUrl.ts` acts like a router and contains quite a bit of logic. The pre-authorized_code flow may be easier to integrate if some of the logic is moved to a functional component.
- The application now errors if the credential does not contain a credentialImageSvgTemplateURL or a credentialImageURL, or has no credentialImage at all. Also, the credentialImage can reside under `credential.vc.credentialImage` if the VC has a different format. More flexibility in retrieving the credentialImage as well as a fallback image would be helpful.
- The credential fields to render in the credential info is hardcoded. While it is fine to have hard-baked templates for some credentials, it would be nice to have a default rendering method for any other credentials based on the credential definition that can be found here: https://agent.dev.eduwallet.nl/mbob/.well-known/openid-credential-issuer, e.g. `parsedCredential?.vc?.credentialSubject`
- The `credentialParserRegistry` now only has a parser for the vc+sd-jwt format. It should intelligently parse the jwt_vc_json format if applicable.
- Somehow, `credentialConfigurationId` and `credentialIssuerIdentifier` fields are not stored in the IndexedDB, while they are stored on demo.wwwallet.org. Having the `credentialIssuerIdentifier` would be very helpful for displaying the credential based on credential configuration fetched from the issuer's configuration endpoint.
- With pre-authorized-code flow, the credential can be issued to wwwallet in a simple procedure, with zero configuration, as is required for the other example issuers. This allows us to experiment with any issuer, even when their configuration is not stored in the database of the wallet-backend-server. I don't know how to marry this with the current application architecture for authorization code flow that calls handleCredentialOffer, which is strongly designed toward Authorization, on openID4VCIClients from the container that are constructed based on configured issuers fetched from the database, while I would like to use some of the dependencies that these clients are composed with.
- The subsequent fetches in the pre-authorized code flow implementation can be abstracted out to an OpenId4VC client, but we already have one, so adding more methods to that interface may get confusing. We could refactor to separate clients for pre-authorized code flow and authorization code flow.
- `credential_configurations_supported` is an array of one or more supported formats. A chain pattern may be appropriate for deciding which supported format to use, since this affects subsequent processing of the credential.
- The `cryptographic_binding_methods_supported` of the issuer https://agent.dev.eduwallet.nl/mbob/.well-known/openid-credential-issuer are `["did:jwk", "did:key"]`, so the credential only considered the jwt verified with a `kid` header with the `did` as a value. This means that we should have different ways to construct jwts depending on the `cryptographic_binding_methods_supported` of the issuer.

**Additional notes**

- After scanning the QR code the wwWallet React app flashes 5 times. This UX can be improved by refactoring the components such that fewer re-renders are triggered
- When the URL contains a credential offer, the issuer configuration of all configured issuers are fetched. It could be more efficient to fetch only the issuer configuration from the /well-known/ endpoint of the issuer in the credential offer.
- Indenting with spaces instead of tabs would make the PRs on GitHub easier to read. Github displays tabs as 8 spaces.