### PR TITLE
Update issuer endpoint in fetchInitialData

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -164,7 +164,7 @@ export function useApi(isOnline: boolean = true): BackendApi {
 			await get('/storage/vc', userUuid, { appToken });
 			await get('/storage/vp', userUuid, { appToken });
 			await get('/user/session/account-info', userUuid, { appToken });
-			await getExternalEntity('/legal_person/issuers/all', { appToken });
+			await getExternalEntity('/issuer/all', { appToken });
 			await getExternalEntity('/verifier/all', { appToken });
 
 		} catch (error) {


### PR DESCRIPTION
This PR updates the `fetchInitialData` function by changing the API endpoint from `legal_person/issuers/all` to `issuer/all` when fetching issuer data. This ensures the function aligns with the updated backend endpoint for retrieving issuer information.