### PR TITLE
Fix JS warning on settings page

### DIFF
--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -882,7 +882,7 @@ const Settings = () => {
 										defaultValue={userData.settings.openidRefreshTokenMaxAgeInSeconds}
 										onChange={(e) => handleTokenMaxAgeChange(e.target.value)}
 										disabled={!isOnline}
-										title={!isOnline && t("common.offlineTitle")}
+										title={!isOnline ? t("common.offlineTitle") : undefined}
 
 									>
 										<option value="0">{t('pageSettings.rememberIssuer.options.none')}</option>


### PR DESCRIPTION
This fixes the warning:
```
Warning: Received `false` for a non-boolean attribute `title`.
```

![image](https://github.com/user-attachments/assets/71f983d2-4ea1-40b9-b6d0-978ff397e4e2)
