### PR TITLE
Fix redirect popup list of credentials, when no locale matches

### DIFF
--- a/src/components/Popups/RedirectPopup.js
+++ b/src/components/Popups/RedirectPopup.js
@@ -52,7 +52,7 @@ const RedirectPopup = ({ loading, availableCredentialConfigurations, onClose, ha
 							aria-label={`Option ${credentialConfigurationId}`}
 						/>
 						<label for={"radio-" + index} class="ms-2 text-sm font-medium text-gray-900 dark:text-gray-300">
-							{(availableCredentialConfigurations[credentialConfigurationId]?.display ? availableCredentialConfigurations[credentialConfigurationId]?.display.filter((d) => d.locale === locale)[0].name : null) ?? credentialConfigurationId}
+							{(availableCredentialConfigurations[credentialConfigurationId]?.display ? availableCredentialConfigurations[credentialConfigurationId]?.display.filter((d) => d.locale === locale)[0]?.name : null) ?? credentialConfigurationId}
 						</label>
 					</div>
 				)


### PR DESCRIPTION
It is possible that an credention configuration has display with a list of locales but none matches. 

Resulting into `availableCredentialConfigurations[credentialConfigurationId]?.display.filter((d) => d.locale === locale)[0]` being undefined.