### PR TITLE
Register and log in with WebAuthn without back-end

### DIFF
--- a/src/context/CredentialsContext.js
+++ b/src/context/CredentialsContext.js
@@ -12,7 +12,7 @@ export const CredentialsProvider = ({ children }) => {
 
 	const fetchVcData = useCallback(async () => {
 		const response = await api.get('/storage/vc');
-		const fetchedVcList = response.data.vc_list;
+		const fetchedVcList = response.data?.vc_list || [];
 
 		const vcEntityList = await Promise.all(fetchedVcList.map(async vcEntity => {
 			return { ...vcEntity };
@@ -45,7 +45,7 @@ export const CredentialsProvider = ({ children }) => {
 			attempts += 1;
 			const userId = api.getSession().uuid;
 			const previousVcList = await getItem("vc", userId);
-			const previousSize = previousVcList.vc_list.length;
+			const previousSize = previousVcList?.vc_list.length || 0;
 
 			const vcEntityList = await fetchVcData();
 
@@ -68,7 +68,7 @@ export const CredentialsProvider = ({ children }) => {
 		try {
 			const userId = api.getSession().uuid;
 			const previousVcList = await getItem("vc", userId);
-			const previousSize = previousVcList.vc_list.length;
+			const previousSize = previousVcList?.vc_list.length || 0;
 			const vcEntityList = await fetchVcData();
 			setVcEntityList(vcEntityList);
 

--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -9,6 +9,7 @@ import type { LocalStorageKeystore } from '../services/LocalStorageKeystore';
 type SessionContextValue = {
 	api: BackendApi,
 	isLoggedIn: boolean,
+	isStandAlone: boolean,
 	keystore: LocalStorageKeystore,
 	logout: () => Promise<void>,
 };
@@ -16,18 +17,20 @@ type SessionContextValue = {
 const SessionContext: React.Context<SessionContextValue> = createContext({
 	api: undefined,
 	isLoggedIn: false,
+	isStandAlone: false,
 	keystore: undefined,
 	logout: async () => {},
 });
 
 export const SessionContextProvider = ({ children }) => {
-	const { isOnline } = useContext(StatusContext);
-	const api = useApi(isOnline);
+	const { isOnline, isStandAlone } = useContext(StatusContext);
+	const api = useApi(isOnline, isStandAlone);
 	const keystore = useLocalStorageKeystore();
 
 	const value: SessionContextValue = {
 		api,
-		isLoggedIn: api.isLoggedIn() && keystore.isOpen(),
+		isLoggedIn: api.isLoggedIn() && (isStandAlone || keystore.isOpen()),
+		isStandAlone,
 		keystore,
 		logout: async () => {
 

--- a/src/context/StatusContext.tsx
+++ b/src/context/StatusContext.tsx
@@ -3,12 +3,14 @@ import React, { useEffect, createContext, useState } from 'react';
 interface StatusContextValue {
 	isOnline: boolean;
 	updateAvailable: boolean;
+	isStandAlone: boolean;
 }
 
 
 const StatusContext: React.Context<StatusContextValue> = createContext({
 	isOnline: null,
 	updateAvailable: false,
+	isStandAlone: false,
 });
 
 function getOnlineStatus(): boolean {
@@ -17,6 +19,7 @@ function getOnlineStatus(): boolean {
 
 export const StatusProvider = ({ children }: { children: React.ReactNode }) => {
 	const [isOnline, setIsOnline] = useState(getOnlineStatus);
+	const [isStandAlone] = useState(!process.env.REACT_APP_WALLET_BACKEND_URL || !process.env.REACT_APP_WS_URL);
 	const [updateAvailable, setUpdateAvailable] = useState(false);
 	const updateOnlineStatus = () => {
 		setIsOnline(getOnlineStatus());
@@ -49,7 +52,7 @@ export const StatusProvider = ({ children }: { children: React.ReactNode }) => {
 	});
 
 	return (
-		<StatusContext.Provider value={{ isOnline, updateAvailable }}>
+		<StatusContext.Provider value={{ isOnline, updateAvailable, isStandAlone }}>
 			{children}
 		</StatusContext.Provider>
 	);

--- a/src/functions/webauthn.ts
+++ b/src/functions/webauthn.ts
@@ -1,0 +1,70 @@
+import { UserId } from '../api/types';
+import * as config from '../config';
+
+export function getRpId(): string {
+	return config.WEBAUTHN_RPID;
+}
+
+export function makeCreateOptions({
+	challenge,
+	user,
+}: {
+	challenge: ArrayBuffer,
+	prfSalt?: ArrayBuffer,
+	user: {
+		uuid: UserId,
+		name: string,
+		displayName: string,
+		webauthnCredentials?: any[],
+	},
+}) {
+	return {
+		publicKey: {
+			rp: {
+				id: getRpId(),
+				name: 'wwWallet',
+			},
+			user: {
+				id: user.uuid.asUserHandle(),
+				name: user.name,
+				displayName: user.displayName,
+			},
+			challenge: challenge,
+			pubKeyCredParams: [
+				{ type: "public-key", alg: -7 },
+				{ type: "public-key", alg: -8 },
+				{ type: "public-key", alg: -257 },
+			],
+			excludeCredentials: [],
+			authenticatorSelection: {
+				requireResidentKey: true,
+				residentKey: "required",
+				userVerification: "required",
+			},
+			attestation:'direct',
+			extensions: {
+				credProps: true,
+				prf: {},
+			},
+		},
+	};
+}
+
+export function makeGetOptions({
+	challenge,
+	user,
+}: {
+	challenge: ArrayBuffer,
+	user?: {
+		webauthnCredentials: any[],
+	},
+}) {
+	return {
+		publicKey: {
+			rpId: getRpId(),
+			challenge: challenge,
+			allowCredentials: [],
+			userVerification: "required",
+		},
+	};
+}

--- a/src/hooks/useCheckURL.ts
+++ b/src/hooks/useCheckURL.ts
@@ -19,7 +19,7 @@ function useCheckURL(urlToCheck: string): {
 	textMessagePopup: { title: string, description: string };
 	typeMessagePopup: string;
 } {
-	const { api, isLoggedIn, keystore } = useContext(SessionContext);
+	const { api, isLoggedIn, keystore, isStandAlone } = useContext(SessionContext);
 	const { addLoader, removeLoader } = useContext(BackgroundTasksContext);
 	const container = useContext(ContainerContext);
 
@@ -35,7 +35,7 @@ function useCheckURL(urlToCheck: string): {
 
 	async function handle(urlToCheck: string) {
 		const userHandleB64u = keystore.getUserHandleB64u();
-		if (!userHandleB64u) {
+		if (!userHandleB64u && !isStandAlone) {
 			throw new Error("User handle could not be extracted from keystore");
 		}
 		const u = new URL(urlToCheck);

--- a/src/hooks/useFetchPresentations.js
+++ b/src/hooks/useFetchPresentations.js
@@ -9,7 +9,7 @@ const useFetchPresentations = (api, credentialId = "", historyId = "") => {
 			console.log('FetchPresentations');
 			try {
 				const fetchedPresentations = await api.getAllPresentations();
-				let vpListFromApi = fetchedPresentations.vp_list
+				let vpListFromApi = (fetchedPresentations?.vp_list || [])
 					.sort(reverse(compareBy(vp => vp.issuanceDate)))
 					.map((item) => ({
 						id: item.id,

--- a/src/pages/AddCredentials/AddCredentials.js
+++ b/src/pages/AddCredentials/AddCredentials.js
@@ -25,7 +25,7 @@ const Issuers = () => {
 		const fetchIssuers = async () => {
 			try {
 				const response = await api.getExternalEntity('/issuer/all');
-				let fetchedIssuers = response.data;
+				let fetchedIssuers = response.data || [];
 				fetchedIssuers = await Promise.all(fetchedIssuers.map(async (issuer) => {
 					try {
 						const metadata = (await container.openID4VCIHelper.getCredentialIssuerMetadata(issuer.credentialIssuerIdentifier)).metadata;

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -212,7 +212,7 @@ const WebauthnSignupLogin = ({
 	error: React.ReactNode,
 	setError: (error: React.ReactNode) => void,
 }) => {
-	const { isOnline } = useContext(StatusContext);
+	const { isOnline, isStandAlone } = useContext(StatusContext);
 	const { api, keystore } = useContext(SessionContext);
 
 	const [inProgress, setInProgress] = useState(false);
@@ -557,7 +557,7 @@ const WebauthnSignupLogin = ({
 };
 
 const Auth = () => {
-	const { isOnline } = useContext(StatusContext);
+	const { isOnline, isStandAlone } = useContext(StatusContext);
 	const { api, isLoggedIn, keystore } = useContext(SessionContext);
 	const { t } = useTranslation();
 	const location = useLocation();
@@ -636,7 +636,7 @@ const Auth = () => {
 	};
 
 	const toggleForm = () => {
-		if (isOnline || !isLogin) {
+		if (isOnline || isStandAlone || !isLogin) {
 			setIsLogin(!isLogin);
 			setError('');
 			checkForUpdates();
@@ -736,7 +736,7 @@ const Auth = () => {
 						<Button
 							variant="link"
 							onClick={toggleForm}
-							disabled={!isOnline}
+							disabled={!isOnline && !isStandAlone}
 							title={!isOnline && t('common.offlineTitle')}
 						>
 							{isLogin ? t('loginSignup.signUp') : t('loginSignup.login')}


### PR DESCRIPTION
I want to work on the wallet-frontend without a dependency on the backend. These changes allow me to register and login with WebAuthn without a dependency on the back-end I am skipping the keystore, so I guess it is not perfect just yet, but at least this change allows me to iterate quicker.