### PR TITLE
Clear History on Logout and Redirect to Home

### DIFF
--- a/src/components/Auth/PrivateRoute.tsx
+++ b/src/components/Auth/PrivateRoute.tsx
@@ -242,6 +242,12 @@ const PrivateRoute = ({ children }: { children?: React.ReactNode }): React.React
 	};
 
 	if (!isLoggedIn) {
+		const freshLogin = sessionStorage.getItem('freshLogin');
+		if (freshLogin) {
+			sessionStorage.removeItem('freshLogin');
+			window.history.replaceState(null, '', '/');
+			return <Navigate to="/login" replace />;
+		}
 		if (state && userExistsInCache(state)) {
 			return <Navigate to="/login-state" state={{ from: location }} replace />;
 		} else {

--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -17,7 +17,7 @@ const SessionContext: React.Context<SessionContextValue> = createContext({
 	api: undefined,
 	isLoggedIn: false,
 	keystore: undefined,
-	logout: async () => {},
+	logout: async () => { },
 });
 
 export const SessionContextProvider = ({ children }) => {
@@ -32,8 +32,7 @@ export const SessionContextProvider = ({ children }) => {
 		logout: async () => {
 
 			// Clear URL parameters
-			window.history.replaceState(null, '', '/');
-
+			sessionStorage.setItem('freshLogin', 'true');
 			api.clearSession();
 			await keystore.close();
 


### PR DESCRIPTION
Fixes issue #371 where users were redirected to the previous page after logging out and logging back in. 
This update clears the navigation history during logout and ensures users are redirected to the home page after logging in.
