### PR TITLE
Refactor generateOpenid4vciProof to generateOpenid4vciProofs (plural)

### DIFF
--- a/src/context/ContainerContext.tsx
+++ b/src/context/ContainerContext.tsx
@@ -184,7 +184,7 @@ export const ContainerContextProvider = ({ children }) => {
 					cont.resolve<IHttpProxy>('HttpProxy'),
 					cont.resolve<IOpenID4VCIClientStateRepository>('OpenID4VCIClientStateRepository'),
 					async (cNonce: string, audience: string, clientId: string): Promise<{ jws: string }> => {
-						const [{ proof_jwt }, newPrivateData, keystoreCommit] = await keystore.generateOpenid4vciProof(cNonce, audience, clientId);
+						const [{ proof_jwts: [proof_jwt] }, newPrivateData, keystoreCommit] = await keystore.generateOpenid4vciProofs([{ nonce: cNonce, audience, issuer: clientId }]);
 						await api.updatePrivateData(newPrivateData);
 						await keystoreCommit();
 						return { jws: proof_jwt };

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -67,8 +67,8 @@ export interface LocalStorageKeystore {
 	getUserHandleB64u(): string | null,
 
 	signJwtPresentation(nonce: string, audience: string, verifiableCredentials: any[]): Promise<{ vpjwt: string }>,
-	generateOpenid4vciProof(nonce: string, audience: string, issuer: string): Promise<[
-		{ proof_jwt: string },
+	generateOpenid4vciProofs(requests: { nonce: string, audience: string, issuer: string }[]): Promise<[
+		{ proof_jwts: string[] },
 		AsymmetricEncryptedContainer,
 		CommitCallback,
 	]>,
@@ -369,20 +369,27 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 			await keystore.signJwtPresentation(await openPrivateData(), nonce, audience, verifiableCredentials)
 		),
 
-		generateOpenid4vciProof: async (nonce: string, audience: string, issuer: string): Promise<[
-			{ proof_jwt: string },
+		generateOpenid4vciProofs: async (requests: { nonce: string, audience: string, issuer: string }[]): Promise<[
+			{ proof_jwts: string[] },
 			AsymmetricEncryptedContainer,
 			CommitCallback,
 		]> => (
-			await editPrivateData(async (container) =>
-				await keystore.generateOpenid4vciProof(
-					container,
-					config.DID_KEY_VERSION,
-					nonce,
-					audience,
-					issuer
-				),
-			)
+			await editPrivateData(async (originalContainer) => {
+				let container = originalContainer;
+				let proof_jwts = [];
+				for (const { nonce, audience, issuer } of requests) {
+					const [{ proof_jwt }, newContainer] = await keystore.generateOpenid4vciProof(
+						container,
+						config.DID_KEY_VERSION,
+						nonce,
+						audience,
+						issuer
+					);
+					proof_jwts.push(proof_jwt);
+					container = newContainer;
+				}
+				return [{ proof_jwts }, container];
+			})
 		),
 	};
 }

--- a/src/services/SigningRequestHandlers.ts
+++ b/src/services/SigningRequestHandlers.ts
@@ -25,7 +25,7 @@ export function SigningRequestHandlerService(): SigningRequestHandlers {
 		},
 
 		handleGenerateOpenid4vciProofSigningRequest: async (api: BackendApi, socket, keystore, { message_id, audience, nonce, issuer }) => {
-			const [{ proof_jwt }, newPrivateData, keystoreCommit] = await keystore.generateOpenid4vciProof(nonce, audience, issuer)
+			const [{ proof_jwts: [proof_jwt] }, newPrivateData, keystoreCommit] = await keystore.generateOpenid4vciProofs([{ nonce, audience, issuer }])
 			await api.updatePrivateData(newPrivateData);
 			await keystoreCommit();
 			console.log("proof jwt = ", proof_jwt);


### PR DESCRIPTION
In preparation for adding batch issuance, this refactors the `generateOpenid4vciProof` function to take an array of key generation requests and return a corresponding array of results.

When making multiple changes to the keystore, one needs to make sure the second change continues from the state after the first change. This can be subtly difficult to get right within the "tick" architecture of state updates in React hooks. By batching multiple changes together in one "transaction", the keystore can return a single new state that combines all the changes as one, instead of needing to re-synchronize the application state after each change.