### PR TITLE
Sync dependency injection container with keystore

### DIFF
--- a/src/context/ContainerContext.tsx
+++ b/src/context/ContainerContext.tsx
@@ -49,8 +49,14 @@ export const ContainerContextProvider = ({ children }) => {
 	const [isInitialized, setIsInitialized] = useState(false); // New flag
 
 	useEffect(() => {
+		window.addEventListener('generatedProof', (e) => {
+			setIsInitialized(false);
+		});
+	}, []);
+
+	useEffect(() => {
 		const initialize = async () => {
-			if (isInitialized || !isLoggedIn || !api || container !== null) return;
+			if (isInitialized || !isLoggedIn || !api) return;
 
 			console.log('Initializing container...');
 			setIsInitialized(true);

--- a/src/lib/services/OpenID4VCIClient.ts
+++ b/src/lib/services/OpenID4VCIClient.ts
@@ -359,6 +359,9 @@ export class OpenID4VCIClient implements IOpenID4VCIClient {
 			const generateProofResult = await this.generateNonceProof(c_nonce, this.config.credentialIssuerIdentifier, this.config.clientId);
 			jws = generateProofResult.jws;
 			console.log("proof = ", jws)
+			if (jws) {
+				dispatchEvent(new CustomEvent("generatedProof"));
+			}
 		}
 		catch (err) {
 			console.error(err);


### PR DESCRIPTION
Synchronizes `container` with latest `keystore` using event listener. This PR fixes a case where a desynchronization was caused between the dependency injection container and the `keystore` once the `OpenID4VCIClient` dependency was generating a proof using the `keystore`.