### PR TITLE
Fix comment syntax in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,7 @@ indent_style = tab
 [{package.json,tsconfig.json,.vscode/settings.json}]
 indent_style = space
 
-[*.{yml,yaml}] # YAML does not allow tab indentation
+# YAML does not allow tab indentation
+[*.{yml,yaml}]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
Without this change, my Emacs editorconfig integration fails to read the file with the following error:

```
⛔ Warning (editorconfig): Failed to get properties, styles will not be applied: (editorconfig-error "Error from editorconfig-get-properties-function: (error \"Error while reading config file: <redacted>/wallet-ecosystem/wallet-frontend/.editorconfig:14:
    [*.{yml,yaml}] # YAML does not allow tab indentation
\")")
```

`editorconfig-checker` doesn't seem to have a problem with it, so maybe it's specific to the Emacs integration. Anyway, moving the comment doesn't hurt.