### PR TITLE
Adjust height units to dvh for improved responsiveness on mobile browsers

### DIFF
--- a/src/components/Auth/LoginLayout.tsx
+++ b/src/components/Auth/LoginLayout.tsx
@@ -9,8 +9,8 @@ export default function LoginLayout({ children, heading }: { children: React.Rea
 	const { t } = useTranslation();
 	return (
 		<section className="bg-gray-100 dark:bg-gray-900 h-full">
-			<div className='h-max min-h-screen'>
-				<div className="flex flex-col items-center justify-center px-6 py-8 mx-auto min-h-[95vh]">
+			<div className='h-max min-h-dvh'>
+				<div className="flex flex-col items-center justify-center px-6 py-8 mx-auto min-h-dvh">
 					<a href="/" className="flex justify-center mb-6 text-2xl font-semibold text-gray-900 dark:text-white">
 						<img className="w-40" src={logo} alt="logo" />
 					</a>

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -9,7 +9,7 @@ const Layout = ({ children }) => {
 	const toggleSidebar = () => setIsOpen(!isOpen);
 
 	return (
-		<div className="flex justify-end min-h-screen flex-col md:flex-row bg-gray-100 dark:bg-gray-900">
+		<div className="flex justify-end min-h-dvh flex-col md:flex-row bg-gray-100 dark:bg-gray-900">
 			<Sidebar isOpen={isOpen} toggle={toggleSidebar} />
 
 			{/* Header */}

--- a/src/components/Layout/Navigation/Sidebar.js
+++ b/src/components/Layout/Navigation/Sidebar.js
@@ -56,8 +56,8 @@ const Sidebar = ({ isOpen, toggle }) => {
 	return (
 		<div
 			className={`${isOpen && screenType !== 'desktop'
-				? 'w-full flex flex-col justify-between fixed h-screen z-30 bg-primary dark:bg-primary-hover text-white p-4 pb-24 md:pb-0 overflow-y-auto'
-				: 'hidden w-auto md:flex md:flex-col justify-between sticky top-0 bg-primary dark:bg-primary-hover w-auto text-white h-screen py-10 px-10 overflow-y-auto'
+				? 'w-full flex flex-col justify-between fixed h-dvh z-30 bg-primary dark:bg-primary-hover text-white p-4 pb-24 md:pb-0 overflow-y-auto'
+				: 'hidden w-auto md:flex md:flex-col justify-between sticky top-0 bg-primary dark:bg-primary-hover w-auto text-white h-dvh py-10 px-10 overflow-y-auto'
 
 				}`}
 		>

--- a/src/components/Shared/Spinner.js
+++ b/src/components/Shared/Spinner.js
@@ -11,7 +11,7 @@ function Spinner() {
 	}, []);
 
 	return (
-		<div className="flex justify-center items-center h-screen" role="status" aria-live="polite">
+		<div className="flex justify-center items-center h-dvh" role="status" aria-live="polite">
 			<div className="relative h-40 w-40">
 				<div className={`absolute rounded-full h-40 w-40 border-t-4 border-b-4 border-main-blue ${imageLoaded ? 'animate-spin' : ''}`}></div>
 				<div className={`absolute inset-0 flex items-center justify-center ${!imageLoaded && 'opacity-0'}`}>

--- a/src/pages/NotFound/NotFound.js
+++ b/src/pages/NotFound/NotFound.js
@@ -15,7 +15,7 @@ const NotFound = () => {
 
 	return (
 		<section className="bg-gray-100 dark:bg-gray-900">
-			<div className="flex flex-col items-center justify-center px-6 py-8 mx-auto h-screen pb-20">
+			<div className="flex flex-col items-center justify-center px-6 py-8 mx-auto min-h-dvh">
 				<a href="/" className="flex items-center mb-6 text-2xl font-semibold text-gray-900 dark:text-white">
 					<img className="w-20" src={logo} alt="logo" />
 				</a>


### PR DESCRIPTION
This PR updates basically `h-screen` and `min-h-screen` classes to use `dvh` units, enhancing layout stability across devices by addressing layout shifts caused by browser UI elements, such as address bars on mobile. 
