### PR TITLE
Improve Metadata Fetching and Caching for `.well-known`, Issuer, and Verifier Data

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -44,7 +44,7 @@ const events: EventTarget = new EventTarget();
 export interface BackendApi {
 	del(path: string): Promise<AxiosResponse>,
 	get(path: string): Promise<AxiosResponse>,
-	getExternalEntity(path: string): Promise<AxiosResponse>,
+	getExternalEntity(path: string, options?: { appToken?: string }, forceIndexDB?: boolean): Promise<AxiosResponse>,
 	post(path: string, body: object): Promise<AxiosResponse>,
 
 	getSession(): SessionState,
@@ -129,7 +129,7 @@ export function useApi(isOnline: boolean = true): BackendApi {
 		};
 	}
 
-	async function getWithLocalDbKey(path: string, dbKey: string, options?: { appToken?: string }): Promise<AxiosResponse> {
+	async function getWithLocalDbKey(path: string, dbKey: string, options?: { appToken?: string }, forceIndexDB: boolean = false): Promise<AxiosResponse> {
 		// console.log(`Get: ${path} ${isOnline ? 'online' : 'offline'} mode ${isOnline}`);
 
 		// Offline case
@@ -139,6 +139,12 @@ export function useApi(isOnline: boolean = true): BackendApi {
 			} as AxiosResponse;
 		}
 
+		if (forceIndexDB) {
+			const data = await getItem(path, dbKey);
+			if (data) {
+				return { data } as AxiosResponse;
+			}
+		}
 		// Online case
 		const respBackend = await axios.get(
 			`${walletBackendUrl}${path}`,
@@ -155,8 +161,8 @@ export function useApi(isOnline: boolean = true): BackendApi {
 		return getWithLocalDbKey(path, sessionState?.uuid || userUuid, options);
 	}
 
-	async function getExternalEntity(path: string, options?: { appToken?: string }): Promise<AxiosResponse> {
-		return getWithLocalDbKey(path, path, options);
+	async function getExternalEntity(path: string, options?: { appToken?: string }, force: boolean = false): Promise<AxiosResponse> {
+		return getWithLocalDbKey(path, path, options, force);
 	}
 
 	async function fetchInitialData(appToken: string, userUuid: string): Promise<void> {
@@ -164,8 +170,8 @@ export function useApi(isOnline: boolean = true): BackendApi {
 			await get('/storage/vc', userUuid, { appToken });
 			await get('/storage/vp', userUuid, { appToken });
 			await get('/user/session/account-info', userUuid, { appToken });
-			await getExternalEntity('/issuer/all', { appToken });
-			await getExternalEntity('/verifier/all', { appToken });
+			await getExternalEntity('/issuer/all', { appToken }, false);  // forceIndexDB = true for these calls
+			await getExternalEntity('/verifier/all', { appToken }, false);
 
 		} catch (error) {
 			console.error('Failed to perform get requests', error);
@@ -336,7 +342,7 @@ export function useApi(isOnline: boolean = true): BackendApi {
 
 	async function getAllVerifiers(): Promise<Verifier[]> {
 		try {
-			const result = await getExternalEntity('/verifier/all');
+			const result = await getExternalEntity('/verifier/all', undefined, true);
 			const verifiers = result.data;
 			console.log("verifiers = ", verifiers)
 			return verifiers;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -256,6 +256,7 @@ export function useApi(isOnline: boolean = true): BackendApi {
 		if (isOnline) {
 			await fetchInitialData(response.data.appToken, response.data.uuid).catch((error) => console.error('Error in performGetRequests', error));
 		}
+		dispatchEvent(new CustomEvent("login"));
 	}
 
 	async function login(username: string, password: string, keystore: LocalStorageKeystore): Promise<Result<void, any>> {

--- a/src/context/ContainerContext.tsx
+++ b/src/context/ContainerContext.tsx
@@ -65,7 +65,7 @@ export const ContainerContextProvider = ({ children }) => {
 
 			try {
 				const cont = new DIContainer();
-				const issuerResponse = await api.getExternalEntity('/issuer/all')
+				const issuerResponse = await api.getExternalEntity('/issuer/all',undefined,true);
 				const trustedCredentialIssuers = issuerResponse.data;
 
 				const userResponse = await api.getExternalEntity('/user/session/account-info')

--- a/src/context/ContainerContext.tsx
+++ b/src/context/ContainerContext.tsx
@@ -68,7 +68,7 @@ export const ContainerContextProvider = ({ children }) => {
 				const issuerResponse = await api.getExternalEntity('/issuer/all',undefined,true);
 				const trustedCredentialIssuers = issuerResponse.data;
 
-				const userResponse = await api.getExternalEntity('/user/session/account-info')
+				const userResponse = await api.get('/user/session/account-info')
 				const userData = userResponse.data;
 
 				cont.register<IHttpProxy>('HttpProxy', HttpProxy);

--- a/src/context/ContainerContext.tsx
+++ b/src/context/ContainerContext.tsx
@@ -93,7 +93,7 @@ export const ContainerContextProvider = ({ children }) => {
 							return { error: "Failed to parse sdjwt" };
 						}
 
-						const { metadata } = await cont.resolve<IOpenID4VCIHelper>('OpenID4VCIHelper').getCredentialIssuerMetadata(isOnline,result.beautifiedForm.iss);
+						const { metadata } = await cont.resolve<IOpenID4VCIHelper>('OpenID4VCIHelper').getCredentialIssuerMetadata(isOnline,result.beautifiedForm.iss, true);
 						const credentialConfigurationSupportedObj: CredentialConfigurationSupported | undefined = Object.values(metadata.credential_configurations_supported)
 							.filter((x: any) => x?.vct && result.beautifiedForm?.vct && x.vct === result.beautifiedForm?.vct)
 						[0];
@@ -225,8 +225,8 @@ export const ContainerContextProvider = ({ children }) => {
 
 				let clientConfigs: ClientConfig[] = await Promise.all(trustedCredentialIssuers.map(async (credentialIssuer) => {
 					const [authorizationServerMetadata, credentialIssuerMetadata] = await Promise.all([
-						openID4VCIHelper.getAuthorizationServerMetadata(isOnline,credentialIssuer.credentialIssuerIdentifier).catch((err) => null),
-						openID4VCIHelper.getCredentialIssuerMetadata(isOnline,credentialIssuer.credentialIssuerIdentifier).catch((err) => null),
+						openID4VCIHelper.getAuthorizationServerMetadata(isOnline,credentialIssuer.credentialIssuerIdentifier, true).catch((err) => null),
+						openID4VCIHelper.getCredentialIssuerMetadata(isOnline,credentialIssuer.credentialIssuerIdentifier, true).catch((err) => null),
 					]);
 					if (!authorizationServerMetadata || !credentialIssuerMetadata) {
 						console.error("Either authorizationServerMetadata or credentialIssuerMetadata could not be loaded");

--- a/src/indexedDB.ts
+++ b/src/indexedDB.ts
@@ -42,6 +42,9 @@ const storeNameMapping: { [key: string]: string } = {
 };
 
 function getMappedStoreName(storeName: string): string {
+	if (storeName.includes('well-known')) {
+		return 'externalEntities';
+	}
 	const mappedStoreName = storeNameMapping[storeName];
 	if (!mappedStoreName) {
 		throw new Error(`Store name ${storeName} does not exist in the mapping.`);

--- a/src/lib/interfaces/IOpenID4VCIHelper.ts
+++ b/src/lib/interfaces/IOpenID4VCIHelper.ts
@@ -7,7 +7,7 @@ export interface IOpenID4VCIHelper {
 	 * @param credentialIssuerIdentifier
 	 * @throws
 	 */
-	getAuthorizationServerMetadata(isOnline: boolean, credentialIssuerIdentifier: string): Promise<{ authzServeMetadata: OpenidAuthorizationServerMetadata }>;
+	getAuthorizationServerMetadata(isOnline: boolean, credentialIssuerIdentifier: string, forceIndexDB: boolean): Promise<{ authzServeMetadata: OpenidAuthorizationServerMetadata }>;
 
 
 	/**
@@ -15,5 +15,5 @@ export interface IOpenID4VCIHelper {
 	 * @param credentialIssuerIdentifier
 	 * @throws
 	 */
-	getCredentialIssuerMetadata(isOnline: boolean, credentialIssuerIdentifier: string): Promise<{ metadata: OpenidCredentialIssuerMetadata }>;
+	getCredentialIssuerMetadata(isOnline: boolean, credentialIssuerIdentifier: string, forceIndexDB: boolean): Promise<{ metadata: OpenidCredentialIssuerMetadata }>;
 }

--- a/src/lib/interfaces/IOpenID4VCIHelper.ts
+++ b/src/lib/interfaces/IOpenID4VCIHelper.ts
@@ -7,7 +7,7 @@ export interface IOpenID4VCIHelper {
 	 * @param credentialIssuerIdentifier
 	 * @throws
 	 */
-	getAuthorizationServerMetadata(credentialIssuerIdentifier: string): Promise<{ authzServeMetadata: OpenidAuthorizationServerMetadata }>;
+	getAuthorizationServerMetadata(isOnline: boolean, credentialIssuerIdentifier: string): Promise<{ authzServeMetadata: OpenidAuthorizationServerMetadata }>;
 
 
 	/**
@@ -15,5 +15,5 @@ export interface IOpenID4VCIHelper {
 	 * @param credentialIssuerIdentifier
 	 * @throws
 	 */
-	getCredentialIssuerMetadata(credentialIssuerIdentifier: string): Promise<{ metadata: OpenidCredentialIssuerMetadata }>;
+	getCredentialIssuerMetadata(isOnline: boolean, credentialIssuerIdentifier: string): Promise<{ metadata: OpenidCredentialIssuerMetadata }>;
 }

--- a/src/lib/services/OpenID4VCIHelper.ts
+++ b/src/lib/services/OpenID4VCIHelper.ts
@@ -11,15 +11,15 @@ export class OpenID4VCIHelper implements IOpenID4VCIHelper {
 		private httpProxy: IHttpProxy
 	) { }
 
-	async getAuthorizationServerMetadata(isOnline: boolean, credentialIssuerIdentifier: string): Promise<{ authzServeMetadata: OpenidAuthorizationServerMetadata }> {
+	async getAuthorizationServerMetadata(isOnline: boolean, credentialIssuerIdentifier: string, forceIndexDB: boolean = false): Promise<{ authzServeMetadata: OpenidAuthorizationServerMetadata }> {
 
 		let pathAuthorizationServer = `${credentialIssuerIdentifier}/.well-known/oauth-authorization-server`;
 		let response = null;
 		// Online case
-		if (!isOnline) {
+		if (!isOnline || forceIndexDB) {
 			const authzServeMetadata = await getItem(pathAuthorizationServer, pathAuthorizationServer);
 			if (authzServeMetadata) {
-				return { authzServeMetadata };
+				return authzServeMetadata;
 			}
 		}
 
@@ -39,10 +39,10 @@ export class OpenID4VCIHelper implements IOpenID4VCIHelper {
 
 			let pathConfiguration = `${credentialIssuerIdentifier}/.well-known/openid-configuration`;
 			// Online case
-			if (!isOnline) {
+			if (!isOnline || forceIndexDB) {
 				const authzServeMetadata = await getItem(pathConfiguration, pathConfiguration);
 				if (authzServeMetadata) {
-					return { authzServeMetadata };
+					return authzServeMetadata;
 				}
 			}
 
@@ -61,14 +61,14 @@ export class OpenID4VCIHelper implements IOpenID4VCIHelper {
 		}
 	}
 
-	async getCredentialIssuerMetadata(isOnline: boolean, credentialIssuerIdentifier: string): Promise<{ metadata: OpenidCredentialIssuerMetadata }> {
+	async getCredentialIssuerMetadata(isOnline: boolean, credentialIssuerIdentifier: string, forceIndexDB: boolean = false): Promise<{ metadata: OpenidCredentialIssuerMetadata }> {
 
 		let pathCredentialIssuer = `${credentialIssuerIdentifier}/.well-known/openid-credential-issuer`;
 		// Online case
-		if (!isOnline) {
+		if (!isOnline || forceIndexDB) {
 			const metadata = await getItem(pathCredentialIssuer, pathCredentialIssuer);
 			if (metadata) {
-				return { metadata };
+				return metadata;
 			}
 		}
 

--- a/src/lib/services/OpenID4VCIHelper.ts
+++ b/src/lib/services/OpenID4VCIHelper.ts
@@ -4,86 +4,64 @@ import { OpenidAuthorizationServerMetadata, OpenidAuthorizationServerMetadataSch
 import { OpenidCredentialIssuerMetadata, OpenidCredentialIssuerMetadataSchema } from "../schemas/OpenidCredentialIssuerMetadataSchema";
 import { addItem, getItem } from '../../indexedDB';
 
-
 export class OpenID4VCIHelper implements IOpenID4VCIHelper {
+	constructor(private httpProxy: IHttpProxy) { }
 
-	constructor(
-		private httpProxy: IHttpProxy
-	) { }
-
-	async getAuthorizationServerMetadata(isOnline: boolean, credentialIssuerIdentifier: string, forceIndexDB: boolean = false): Promise<{ authzServeMetadata: OpenidAuthorizationServerMetadata }> {
-
-		let pathAuthorizationServer = `${credentialIssuerIdentifier}/.well-known/oauth-authorization-server`;
-		let response = null;
-		// Online case
+	private async fetchAndCache<T>(path: string, schema: any, isOnline: boolean, forceIndexDB: boolean): Promise<T> {
 		if (!isOnline || forceIndexDB) {
-			const authzServeMetadata = await getItem(pathAuthorizationServer, pathAuthorizationServer);
-			if (authzServeMetadata) {
-				return authzServeMetadata;
-			}
+			const cachedData = await getItem(path, path);
+			if (cachedData) return cachedData;
 		}
 
+		// Fetch from network if online
 		try {
-			response = await this.httpProxy.get(pathAuthorizationServer, {});
-			if (!response) {
-				throw new Error("Couldn't get response");
-			}
-			const authzServeMetadata = OpenidAuthorizationServerMetadataSchema.parse(response.data);
-			await addItem(pathAuthorizationServer, pathAuthorizationServer, { authzServeMetadata });
-			return { authzServeMetadata };
-		}
-		catch (err) {
-		}
+			const response = await this.httpProxy.get(path, {});
+			if (!response) throw new Error("Couldn't get response");
 
-		if (response == null) {
-
-			let pathConfiguration = `${credentialIssuerIdentifier}/.well-known/openid-configuration`;
-			// Online case
-			if (!isOnline || forceIndexDB) {
-				const authzServeMetadata = await getItem(pathConfiguration, pathConfiguration);
-				if (authzServeMetadata) {
-					return authzServeMetadata;
-				}
-			}
-
-			try {
-				response = await this.httpProxy.get(pathConfiguration, {});
-				if (!response) {
-					throw new Error("Couldn't get response");
-				}
-				const authzServeMetadata = OpenidAuthorizationServerMetadataSchema.parse(response.data);
-				await addItem(pathConfiguration, pathConfiguration, { authzServeMetadata });
-				return { authzServeMetadata };
-			} catch (err) {
-				console.error(err);
-				throw new Error("Couldn't get authorization server metadata");
-			}
+			const parsedData = schema.parse(response.data);
+			await addItem(path, path, parsedData);  // Cache the fetched data
+			return parsedData;
+		} catch (err) {
+			console.error(`Error fetching from ${path}:`, err);
+			throw new Error(`Couldn't get data from ${path}`);
 		}
 	}
 
-	async getCredentialIssuerMetadata(isOnline: boolean, credentialIssuerIdentifier: string, forceIndexDB: boolean = false): Promise<{ metadata: OpenidCredentialIssuerMetadata }> {
-
-		let pathCredentialIssuer = `${credentialIssuerIdentifier}/.well-known/openid-credential-issuer`;
-		// Online case
-		if (!isOnline || forceIndexDB) {
-			const metadata = await getItem(pathCredentialIssuer, pathCredentialIssuer);
-			if (metadata) {
-				return metadata;
-			}
-		}
+	// Fetches authorization server metadata with fallback
+	async getAuthorizationServerMetadata(isOnline: boolean, credentialIssuerIdentifier: string, forceIndexDB: boolean = false): Promise<{ authzServeMetadata: OpenidAuthorizationServerMetadata }> {
+		const pathAuthorizationServer = `${credentialIssuerIdentifier}/.well-known/oauth-authorization-server`;
+		const pathConfiguration = `${credentialIssuerIdentifier}/.well-known/openid-configuration`;
 
 		try {
-			const response = await this.httpProxy.get(pathCredentialIssuer, {});
-			if (!response) {
-				throw new Error("Couldn't get response");
-			}
-			const metadata = OpenidCredentialIssuerMetadataSchema.parse(response.data);
-			await addItem(pathCredentialIssuer, pathCredentialIssuer, { metadata });
-			return { metadata };
+			const authzServeMetadata = await this.fetchAndCache<OpenidAuthorizationServerMetadata>(
+				pathAuthorizationServer,
+				OpenidAuthorizationServerMetadataSchema,
+				isOnline,
+				forceIndexDB
+			);
+			return { authzServeMetadata };
+		} catch {
+			// Fallback to openid-configuration if oauth-authorization-server fetch fails
+			const authzServeMetadata = await this.fetchAndCache<OpenidAuthorizationServerMetadata>(
+				pathConfiguration,
+				OpenidAuthorizationServerMetadataSchema,
+				isOnline,
+				forceIndexDB
+			);
+			return { authzServeMetadata };
 		}
-		catch (err) {
-			console.error(err);
-			throw new Error("Couldn't get Credential Issuer Metadata");
-		}
+	}
+
+	// Fetches credential issuer metadata
+	async getCredentialIssuerMetadata(isOnline: boolean, credentialIssuerIdentifier: string, forceIndexDB: boolean = false): Promise<{ metadata: OpenidCredentialIssuerMetadata }> {
+		const pathCredentialIssuer = `${credentialIssuerIdentifier}/.well-known/openid-credential-issuer`;
+
+		const metadata = await this.fetchAndCache<OpenidCredentialIssuerMetadata>(
+			pathCredentialIssuer,
+			OpenidCredentialIssuerMetadataSchema,
+			isOnline,
+			forceIndexDB
+		);
+		return { metadata };
 	}
 }

--- a/src/lib/services/OpenID4VCIHelper.ts
+++ b/src/lib/services/OpenID4VCIHelper.ts
@@ -2,6 +2,7 @@ import { IHttpProxy } from "../interfaces/IHttpProxy";
 import { IOpenID4VCIHelper } from "../interfaces/IOpenID4VCIHelper";
 import { OpenidAuthorizationServerMetadata, OpenidAuthorizationServerMetadataSchema } from "../schemas/OpenidAuthorizationServerMetadataSchema";
 import { OpenidCredentialIssuerMetadata, OpenidCredentialIssuerMetadataSchema } from "../schemas/OpenidCredentialIssuerMetadataSchema";
+import { addItem, getItem } from '../../indexedDB';
 
 
 export class OpenID4VCIHelper implements IOpenID4VCIHelper {
@@ -10,50 +11,79 @@ export class OpenID4VCIHelper implements IOpenID4VCIHelper {
 		private httpProxy: IHttpProxy
 	) { }
 
+	async getAuthorizationServerMetadata(isOnline: boolean, credentialIssuerIdentifier: string): Promise<{ authzServeMetadata: OpenidAuthorizationServerMetadata }> {
 
-	async getAuthorizationServerMetadata(credentialIssuerIdentifier: string): Promise<{ authzServeMetadata: OpenidAuthorizationServerMetadata }> {
+		let pathAuthorizationServer = `${credentialIssuerIdentifier}/.well-known/oauth-authorization-server`;
 		let response = null;
+		// Online case
+		if (!isOnline) {
+			const authzServeMetadata = await getItem(pathAuthorizationServer, pathAuthorizationServer);
+			if (authzServeMetadata) {
+				return { authzServeMetadata };
+			}
+		}
+
 		try {
-			response = await this.httpProxy.get(`${credentialIssuerIdentifier}/.well-known/oauth-authorization-server`, {});
+			response = await this.httpProxy.get(pathAuthorizationServer, {});
 			if (!response) {
 				throw new Error("Couldn't get response");
 			}
 			const authzServeMetadata = OpenidAuthorizationServerMetadataSchema.parse(response.data);
+			await addItem(pathAuthorizationServer, pathAuthorizationServer, { authzServeMetadata });
 			return { authzServeMetadata };
 		}
-		catch(err) {
+		catch (err) {
 		}
 
 		if (response == null) {
+
+			let pathConfiguration = `${credentialIssuerIdentifier}/.well-known/openid-configuration`;
+			// Online case
+			if (!isOnline) {
+				const authzServeMetadata = await getItem(pathConfiguration, pathConfiguration);
+				if (authzServeMetadata) {
+					return { authzServeMetadata };
+				}
+			}
+
 			try {
-				response = await this.httpProxy.get(`${credentialIssuerIdentifier}/.well-known/openid-configuration`, {});
+				response = await this.httpProxy.get(pathConfiguration, {});
 				if (!response) {
 					throw new Error("Couldn't get response");
 				}
 				const authzServeMetadata = OpenidAuthorizationServerMetadataSchema.parse(response.data);
+				await addItem(pathConfiguration, pathConfiguration, { authzServeMetadata });
 				return { authzServeMetadata };
-			}
-			catch(err) {
+			} catch (err) {
 				console.error(err);
 				throw new Error("Couldn't get authorization server metadata");
 			}
 		}
 	}
 
-	async getCredentialIssuerMetadata(credentialIssuerIdentifier: string): Promise<{ metadata: OpenidCredentialIssuerMetadata }> {
+	async getCredentialIssuerMetadata(isOnline: boolean, credentialIssuerIdentifier: string): Promise<{ metadata: OpenidCredentialIssuerMetadata }> {
+
+		let pathCredentialIssuer = `${credentialIssuerIdentifier}/.well-known/openid-credential-issuer`;
+		// Online case
+		if (!isOnline) {
+			const metadata = await getItem(pathCredentialIssuer, pathCredentialIssuer);
+			if (metadata) {
+				return { metadata };
+			}
+		}
+
 		try {
-			const response = await this.httpProxy.get(`${credentialIssuerIdentifier}/.well-known/openid-credential-issuer`, {});
+			const response = await this.httpProxy.get(pathCredentialIssuer, {});
 			if (!response) {
 				throw new Error("Couldn't get response");
 			}
 			const metadata = OpenidCredentialIssuerMetadataSchema.parse(response.data);
+			await addItem(pathCredentialIssuer, pathCredentialIssuer, { metadata });
 			return { metadata };
 		}
-		catch(err) {
+		catch (err) {
 			console.error(err);
 			throw new Error("Couldn't get Credential Issuer Metadata");
 		}
-
 	}
-
 }

--- a/src/pages/AddCredentials/AddCredentials.js
+++ b/src/pages/AddCredentials/AddCredentials.js
@@ -28,7 +28,7 @@ const Issuers = () => {
 				let fetchedIssuers = response.data;
 				fetchedIssuers = await Promise.all(fetchedIssuers.map(async (issuer) => {
 					try {
-						const metadata = (await container.openID4VCIHelper.getCredentialIssuerMetadata(issuer.credentialIssuerIdentifier)).metadata;
+						const metadata = (await container.openID4VCIHelper.getCredentialIssuerMetadata(isOnline,issuer.credentialIssuerIdentifier)).metadata;
 						return {
 							...issuer,
 							selectedDisplay: metadata?.display?.filter((display) => display.locale === 'en-US')[0] ? metadata.display.filter((display) => display.locale === 'en-US')[0] : null,
@@ -52,7 +52,7 @@ const Issuers = () => {
 		if (container) {
 			fetchIssuers();
 		}
-	}, [api, container]);
+	}, [api, container, isOnline]);
 
 	const handleIssuerClick = async (credentialIssuerIdentifier) => {
 		const clickedIssuer = issuers.find((issuer) => issuer.credentialIssuerIdentifier === credentialIssuerIdentifier);

--- a/src/pages/AddCredentials/AddCredentials.js
+++ b/src/pages/AddCredentials/AddCredentials.js
@@ -28,7 +28,7 @@ const Issuers = () => {
 				let fetchedIssuers = response.data;
 				fetchedIssuers = await Promise.all(fetchedIssuers.map(async (issuer) => {
 					try {
-						const metadata = (await container.openID4VCIHelper.getCredentialIssuerMetadata(isOnline,issuer.credentialIssuerIdentifier)).metadata;
+						const metadata = (await container.openID4VCIHelper.getCredentialIssuerMetadata(isOnline,issuer.credentialIssuerIdentifier,true)).metadata;
 						return {
 							...issuer,
 							selectedDisplay: metadata?.display?.filter((display) => display.locale === 'en-US')[0] ? metadata.display.filter((display) => display.locale === 'en-US')[0] : null,

--- a/src/pages/AddCredentials/AddCredentials.js
+++ b/src/pages/AddCredentials/AddCredentials.js
@@ -24,7 +24,7 @@ const Issuers = () => {
 	useEffect(() => {
 		const fetchIssuers = async () => {
 			try {
-				const response = await api.getExternalEntity('/issuer/all');
+				const response = await api.getExternalEntity('/issuer/all',undefined, true);
 				let fetchedIssuers = response.data;
 				fetchedIssuers = await Promise.all(fetchedIssuers.map(async (issuer) => {
 					try {


### PR DESCRIPTION
This PR enhances metadata fetching and caching processes, with a focus on `.well-known`, issuer, and verifier data retrieval, improving both offline capabilities and request efficiency:

- **Caching for `.well-known` Requests**: Introduces caching for `.well-known` paths in IndexedDB, allowing offline access to authorization and credential issuer metadata and reducing unnecessary network requests.
- **Prioritized IndexedDB Fetching**: Adds a parameter in `getExternalEntity` and in `.well-known` fetches to prioritize retrieving data from IndexedDB where applicable except on login/signup.

These updates optimize performance, especially in low-connectivity situations, and enhance metadata availability for a smoother user experience.