### PR TITLE
Enhance Home Slider State Persistence

### DIFF
--- a/src/context/CredentialsContext.js
+++ b/src/context/CredentialsContext.js
@@ -9,6 +9,7 @@ export const CredentialsProvider = ({ children }) => {
 	const { api } = useContext(SessionContext);
 	const [vcEntityList, setVcEntityList] = useState([]);
 	const [latestCredentials, setLatestCredentials] = useState(new Set());
+	const [currentSlide, setCurrentSlide] = useState(1);
 
 	const fetchVcData = useCallback(async () => {
 		const response = await api.get('/storage/vc');
@@ -93,7 +94,7 @@ export const CredentialsProvider = ({ children }) => {
 	}, [api, fetchVcData, pollForCredentials]);
 
 	return (
-		<CredentialsContext.Provider value={{ vcEntityList, latestCredentials, getData }}>
+		<CredentialsContext.Provider value={{ vcEntityList, latestCredentials, getData, currentSlide, setCurrentSlide }}>
 			{children}
 		</CredentialsContext.Provider>
 	);

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -10,7 +10,6 @@ import CredentialsContext from '../../context/CredentialsContext';
 // Hooks
 import useFetchPresentations from '../../hooks/useFetchPresentations';
 import useScreenType from '../../hooks/useScreenType';
-import { useSessionStorage } from '../../hooks/useStorage';
 
 // Components
 import { H1 } from '../../components/Shared/Heading';
@@ -20,10 +19,9 @@ import HistoryList from '../../components/History/HistoryList';
 import Slider from '../../components/Shared/Slider';
 
 const Home = () => {
-	const { vcEntityList, latestCredentials, getData } = useContext(CredentialsContext);
+	const { vcEntityList, latestCredentials, getData, currentSlide, setCurrentSlide } = useContext(CredentialsContext);
 	const { api } = useContext(SessionContext);
 	const history = useFetchPresentations(api);
-	const [currentSlide, setCurrentSlide,] = api.useClearOnClearSession(useSessionStorage('currentSlide', 1));
 	const screenType = useScreenType();
 
 	const navigate = useNavigate();


### PR DESCRIPTION
This PR enhances the previous solution #410 by changing the slider’s session storage state management from Home to useState into CredentialsContext. This adjustment maintains the current slide index during navigation and allows for a smooth reset on both page reload and user logout.