### PR TITLE
Optimize Image Caching Strategy for PNG, JPEG, SVG, and WebP Formats

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -32,14 +32,22 @@ registerRoute(
 );
 
 registerRoute(
-	({ url }) => url.pathname.endsWith(".png"),
+	({ url }) =>
+		url.pathname.endsWith(".png") ||
+		url.pathname.endsWith(".jpg") ||
+		url.pathname.endsWith(".jpeg") ||
+		url.pathname.endsWith(".svg") ||
+		url.pathname.endsWith(".webp"),
 	new StaleWhileRevalidate({
 		cacheName: "images",
 		plugins: [
-			new ExpirationPlugin({ maxEntries: 50 }),
+			new ExpirationPlugin({
+				maxEntries: 200,
+			}),
 		],
 	})
 );
+
 
 self.addEventListener('install', (event) => {
 	self.skipWaiting();


### PR DESCRIPTION
This PR improves the service worker's caching strategy by adding support for multiple image formats (PNG, JPEG, SVG, and WebP) in a unified cache. The caching strategy uses `StaleWhileRevalidate` with an entry limit of 200 images, allowing images to be served from the cache while fetching updates in the background. 