### PR TITLE
SD-JWT VC - SVG Rendering Implementation Update

### DIFF
--- a/src/context/ContainerContext.tsx
+++ b/src/context/ContainerContext.tsx
@@ -125,7 +125,7 @@ export const ContainerContextProvider = ({ children }) => {
 							|| credentialConfigurationSupportedObj?.display?.[0]?.description
 							|| "Credential";
 
-						const svgContent = await renderSvgTemplate({ beautifiedForm: result.beautifiedForm, credentialImageSvgTemplateURL: credentialImageSvgTemplateURL });
+						const svgContent = await renderSvgTemplate({ beautifiedForm: result.beautifiedForm, credentialImageSvgTemplateURL: credentialImageSvgTemplateURL,claims:credentialHeader.vctm.claims });
 
 						const simple = credentialHeader?.vctm?.display?.[0]?.[defaultLocale]?.rendering?.simple;
 						const issuerMetadata = credentialConfigurationSupportedObj?.display?.[0];


### PR DESCRIPTION
This PR enhances the SVG rendering functionality for SD-JWT Verifiable Credentials by dynamically mapping `svg_id` placeholders in SVG templates to values in `beautifiedForm` based on path information from `credentialHeader.vctm.claims`. 

Related with:
- https://github.com/wwWallet/wallet-ecosystem/pull/105
- https://github.com/wwWallet/wallet-enterprise/pull/71