### PR TITLE
Fix SVG Render Optional Chaining and Resolve Lint Warnings in Context and Hooks

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,7 +6,7 @@ import { fromBase64Url, jsonParseTaggedBinary, jsonStringifyTaggedBinary, toBase
 import { EncryptedContainer, makeAssertionPrfExtensionInputs, parsePrivateData, serializePrivateData } from '../services/keystore';
 import { CachedUser, LocalStorageKeystore } from '../services/LocalStorageKeystore';
 import { UserData, UserId, Verifier } from './types';
-import { useContext, useEffect } from 'react';
+import { useEffect } from 'react';
 import { UseStorageHandle, useClearStorages, useLocalStorage, useSessionStorage } from '../hooks/useStorage';
 import { addItem, getItem } from '../indexedDB';
 import { loginWebAuthnBeginOffline } from './LocalAuthentication';

--- a/src/context/ContainerContext.tsx
+++ b/src/context/ContainerContext.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useContext, createContext, useRef } from "react";
+import { useEffect, useState, useContext, createContext } from "react";
 import { DIContainer } from "../lib/DIContainer";
 import { IHttpProxy } from "../lib/interfaces/IHttpProxy";
 import { IOpenID4VCIClient } from "../lib/interfaces/IOpenID4VCIClient";
@@ -125,7 +125,7 @@ export const ContainerContextProvider = ({ children }) => {
 							|| credentialConfigurationSupportedObj?.display?.[0]?.description
 							|| "Credential";
 
-						const svgContent = await renderSvgTemplate({ beautifiedForm: result.beautifiedForm, credentialImageSvgTemplateURL: credentialImageSvgTemplateURL,claims:credentialHeader.vctm.claims });
+						const svgContent = await renderSvgTemplate({ beautifiedForm: result.beautifiedForm, credentialImageSvgTemplateURL: credentialImageSvgTemplateURL,claims:credentialHeader?.vctm?.claims });
 
 						const simple = credentialHeader?.vctm?.display?.[0]?.[defaultLocale]?.rendering?.simple;
 						const issuerMetadata = credentialConfigurationSupportedObj?.display?.[0];
@@ -277,7 +277,7 @@ export const ContainerContextProvider = ({ children }) => {
 		};
 
 		initialize();
-	}, [isLoggedIn, api, container, isInitialized, keystore]);
+	}, [isLoggedIn, api, container, isInitialized, keystore, isOnline, shouldUseCache]);
 
 	return (
 		<ContainerContext.Provider value={container}>


### PR DESCRIPTION
This PR addresses the following issues:

1. **SVG Template Rendering Update**: Modified the `renderSvgTemplate` function call to use optional chaining (`?.`) for `credentialHeader.vctm.claims`, preventing errors if `vctm` or `claims` are undefined.
  
2. **Lint Error Fixes**:
   - Removed unused imports `useContext` from `src/api/index.ts` and `useRef` from `src/context/ContainerContext.tsx`.
   - Added missing dependencies `isOnline` and `shouldUseCache` in the `useEffect` dependency array within `ContainerContext.tsx` to satisfy `react-hooks/exhaustive-deps`.
