### PR TITLE
OID4VCI implementation enhacements

### DIFF
--- a/src/lib/interfaces/IOpenID4VCIClientStateRepository.ts
+++ b/src/lib/interfaces/IOpenID4VCIClientStateRepository.ts
@@ -2,7 +2,7 @@ import { OpenID4VCIClientState } from "../types/OpenID4VCIClientState";
 
 export interface IOpenID4VCIClientStateRepository {
 	getByStateAndUserHandle(state: string, userHandleB64U: string): Promise<OpenID4VCIClientState | null>;
-	getByCredentialConfigurationIdAndUserHandle(credentialConfigurationId: string, userHandleB64U: string): Promise<OpenID4VCIClientState | null>;
+	getByCredentialIssuerIdentifierAndCredentialConfigurationIdAndUserHandle(credentialIssuerIdentifier: string, credentialConfigurationId: string, userHandleB64U: string): Promise<OpenID4VCIClientState | null>;
 	create(s: OpenID4VCIClientState): Promise<void>;
 	updateState(s: OpenID4VCIClientState, userHandleB64U: string): Promise<void>;
 	cleanupExpired(userHandleB64U: string): Promise<void>;

--- a/src/lib/services/OpenID4VCIClient.ts
+++ b/src/lib/services/OpenID4VCIClient.ts
@@ -331,11 +331,11 @@ export class OpenID4VCIClient implements IOpenID4VCIClient {
 	}
 
 	/**
-	 * 
-	 * @param response 
-	 * @param flowState 
-	 * @param cachedProof used in case a failure due to invalid dpop-nonce is caused and the last proof can be re-used.
-	 * @returns 
+	 *
+	 * @param response
+	 * @param flowState
+	 * @param cachedProof cachedProof is used in case a failure due to invalid dpop-nonce is caused and the last proof can be re-used.
+	 * @returns
 	 */
 	private async credentialRequest(response: any, flowState: OpenID4VCIClientState, cachedProof?: string) {
 		const {

--- a/src/lib/services/OpenID4VCIClientStateRepository.ts
+++ b/src/lib/services/OpenID4VCIClientStateRepository.ts
@@ -39,14 +39,14 @@ export class OpenID4VCIClientStateRepository implements IOpenID4VCIClientStateRe
 		return res ? res : null;
 	}
 
-	async getByCredentialConfigurationIdAndUserHandle(credentialConfigurationId: string, userHandleB64U: string): Promise<OpenID4VCIClientState | null> {
+	async getByCredentialIssuerIdentifierAndCredentialConfigurationIdAndUserHandle(credentialIssuer: string, credentialConfigurationId: string, userHandleB64U: string): Promise<OpenID4VCIClientState | null> {
 		const array = JSON.parse(localStorage.getItem(this.key)) as Array<OpenID4VCIClientState>;
-		const res = array.filter((s) => s.credentialConfigurationId === credentialConfigurationId && s.userHandleB64U === userHandleB64U)[0];
+		const res = array.filter((s) => s.credentialIssuerIdentifier === credentialIssuer && s.credentialConfigurationId === credentialConfigurationId && s.userHandleB64U === userHandleB64U)[0];
 		return res ? res : null;
 	}
 
 	async create(s: OpenID4VCIClientState): Promise<void> {
-		const existingState = await this.getByCredentialConfigurationIdAndUserHandle(s.credentialConfigurationId, s.userHandleB64U);
+		const existingState = await this.getByCredentialIssuerIdentifierAndCredentialConfigurationIdAndUserHandle(s.credentialIssuerIdentifier, s.credentialConfigurationId, s.userHandleB64U);
 		if (existingState) { // remove the existing state for this configuration id
 			const array = JSON.parse(localStorage.getItem(this.key)) as Array<OpenID4VCIClientState>;
 			const updatedArray = array.filter((x) => x.credentialConfigurationId !== s.credentialConfigurationId);


### PR DESCRIPTION
This PR includes the following changes:

- DPoP implementation enhacements
- `state` invalidation
- reuse DPoP keys

According to section [RFC9449 - 4.2. DPoP Proof JWT Syntax](https://datatracker.ietf.org/doc/html/rfc9449#section-4.2) the `dpop-nonce` header could also be provided on the resource endpoint, which in our case is the credential endpoint.

> When the authentication server or resource server provides a DPoP-Nonce HTTP header in a response (see Sections [8](https://datatracker.ietf.org/doc/html/rfc9449#ASNonce) and [9](https://datatracker.ietf.org/doc/html/rfc9449#RSNonce)), the DPoP proof MUST also contain the following claim....


This PR also introduces a simple replay prevention mechanism by invalidating the previous oid4vci `state` parameter.