### PR TITLE
Define backCameraIndex for Reliable Back Camera Detection in QR Code Scanner

### DIFF
--- a/src/components/QRCodeScanner/QRCodeScanner.js
+++ b/src/components/QRCodeScanner/QRCodeScanner.js
@@ -93,7 +93,7 @@ const QRScanner = ({ onClose }) => {
 
 					setDevices(filteredDevices);
 
-					filteredDevices.findIndex(devices =>
+					const backCameraIndex = filteredDevices.findIndex(devices =>
 						devices.device.deviceId === bestBackCamera.device.deviceId);
 
 					if (backCameraIndex !== -1) {


### PR DESCRIPTION
This commit addresses a missing definition for `backCameraIndex` in `QRCodeScanner.js` following the recent refactor #440 that utilizes `facingMode` to reliably detect the back camera on iOS devices.