### PR TITLE
Refactor New VC Detection to Use Custom Event Listener

### DIFF
--- a/src/components/Notifications/HandlerNotification.js
+++ b/src/components/Notifications/HandlerNotification.js
@@ -32,7 +32,6 @@ const ToastDisplay = ({ id, notification }) => {
 
 const HandlerNotification = () => {
 	const [notification, setNotification] = useState({ title: '', body: '' });
-	const { getData } = useContext(CredentialsContext);
 
 	const showToast = useCallback(
 		() => toast((t) => <ToastDisplay id={t.id} notification={notification} />),
@@ -52,7 +51,6 @@ const HandlerNotification = () => {
 					title: payload?.notification?.title,
 					body: payload?.notification?.body,
 				});
-				getData();
 			})
 			.catch((err) => {
 				console.log('Failed to receive message:', err);
@@ -63,7 +61,7 @@ const HandlerNotification = () => {
 				messageListener();
 			}
 		};
-	}, [getData]);
+	}, []);
 
 	return (
 			<Toaster />

--- a/src/components/Notifications/HandlerNotification.js
+++ b/src/components/Notifications/HandlerNotification.js
@@ -1,9 +1,8 @@
-import React, { useState, useEffect, useContext, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import toast, { Toaster } from 'react-hot-toast';
 import { onMessageListener } from '../../firebase';
 import { AiOutlineClose } from 'react-icons/ai';
 import logo from '../../assets/images/logo.png';
-import CredentialsContext from '../../context/CredentialsContext';
 
 const ToastDisplay = ({ id, notification }) => {
 	return (

--- a/src/context/CredentialsContext.js
+++ b/src/context/CredentialsContext.js
@@ -11,12 +11,6 @@ export const CredentialsProvider = ({ children }) => {
 	const [latestCredentials, setLatestCredentials] = useState(new Set());
 	const [currentSlide, setCurrentSlide] = useState(1);
 
-	useEffect(() => {
-		window.addEventListener('newCredential', (e) => {
-			getData(true);
-		});
-	}, []);
-
 	const fetchVcData = useCallback(async () => {
 		const response = await api.get('/storage/vc');
 		const fetchedVcList = response.data.vc_list;
@@ -71,7 +65,7 @@ export const CredentialsProvider = ({ children }) => {
 		}, 1000);
 	}, [api, fetchVcData]);
 
-	const getData = useCallback(async (shouldPoll=false) => {
+	const getData = useCallback(async (shouldPoll = false) => {
 		try {
 			const userId = api.getSession().uuid;
 			const previousVcList = await getItem("vc", userId);
@@ -96,8 +90,12 @@ export const CredentialsProvider = ({ children }) => {
 		}
 	}, [api, fetchVcData, pollForCredentials]);
 
+	useEffect(() => {
+		window.addEventListener('newCredential', (e) => {
+			getData(true);
+		});
+	}, [getData]);
 
-	
 	return (
 		<CredentialsContext.Provider value={{ vcEntityList, latestCredentials, getData, currentSlide, setCurrentSlide }}>
 			{children}

--- a/src/lib/services/OpenID4VCIClient.ts
+++ b/src/lib/services/OpenID4VCIClient.ts
@@ -463,6 +463,7 @@ export class OpenID4VCIClient implements IOpenID4VCIClient {
 			credentialConfigurationId: flowState.credentialConfigurationId,
 			credentialIssuerIdentifier: this.config.credentialIssuerIdentifier,
 		});
+		dispatchEvent(new CustomEvent('newCredential'));
 		return;
 
 	}


### PR DESCRIPTION
This PR refactors the way we detect new credentials by switching from notifications and url detection to a CustomEvent listener approach.

**Previously:**
New VC detection relied on notifications as the primary trigger, with a fallback to URL-based detection.
This approach had issues, especially on iOS devices where notifications were not consistently triggering.

**Now:**
We’ve removed the notification-based triggers and instead detect new VCs by listening for a CustomEvent named newCredential. This allows us to handle VC updates more reliably across platforms.
