### PR TITLE
Fix Event Listener for New Credential Updates

### DIFF
--- a/src/context/CredentialsContext.js
+++ b/src/context/CredentialsContext.js
@@ -91,9 +91,13 @@ export const CredentialsProvider = ({ children }) => {
 	}, [api, fetchVcData, pollForCredentials]);
 
 	useEffect(() => {
-		window.addEventListener('newCredential', (e) => {
+		const handleNewCredentialEvent = () => {
 			getData(true);
-		});
+		};
+		window.addEventListener('newCredential', handleNewCredentialEvent);
+		return () => {
+			window.removeEventListener('newCredential', handleNewCredentialEvent);
+		};
 	}, [getData]);
 
 	return (


### PR DESCRIPTION
This PR fixes an issue with the newCredential event listener by adding a proper cleanup function in the useEffect hook. This prevents multiple bindings of the listener and ensures efficient handling of new credential events.