### PR TITLE
Fix TypeError: Handle Null or Undefined `vc_list` in `getData` Function

### DIFF
--- a/src/context/CredentialsContext.js
+++ b/src/context/CredentialsContext.js
@@ -69,7 +69,7 @@ export const CredentialsProvider = ({ children }) => {
 		try {
 			const userId = api.getSession().uuid;
 			const previousVcList = await getItem("vc", userId);
-			const previousSize = previousVcList.vc_list.length;
+			const previousSize = previousVcList?.vc_list.length;
 			const vcEntityList = await fetchVcData();
 			setVcEntityList(vcEntityList);
 


### PR DESCRIPTION
This PR addresses an issue where the `getData` function would throw a `TypeError` when trying to access the `vc_list` property of a `null` or `undefined` value. 