### PR TITLE
Issuer metatada fetching errors

### DIFF
--- a/src/context/ContainerContext.tsx
+++ b/src/context/ContainerContext.tsx
@@ -103,12 +103,14 @@ export const ContainerContextProvider = ({ children }) => {
 						if ('error' in result) {
 							return { error: "Failed to parse sdjwt" };
 						}
-
-						const { metadata } = await cont.resolve<IOpenID4VCIHelper>('OpenID4VCIHelper').getCredentialIssuerMetadata(isOnline, result.beautifiedForm.iss, shouldUseCache);
-						const credentialConfigurationSupportedObj: CredentialConfigurationSupported | undefined = Object.values(metadata.credential_configurations_supported)
-							.filter((x: any) => x?.vct && result.beautifiedForm?.vct && x.vct === result.beautifiedForm?.vct)
-						[0];
-
+						let credentialConfigurationSupportedObj = null;
+						const metadataResponse = await cont.resolve<IOpenID4VCIHelper>('OpenID4VCIHelper').getCredentialIssuerMetadata(isOnline, result.beautifiedForm.iss, shouldUseCache);
+						if (metadataResponse) {
+							const { metadata } = metadataResponse;
+							credentialConfigurationSupportedObj = Object.values(metadata.credential_configurations_supported)
+								.filter((x: any) => x?.vct && result.beautifiedForm?.vct && x.vct === result.beautifiedForm?.vct)
+							[0];
+						}
 						const credentialHeader = JSON.parse(new TextDecoder().decode(fromBase64(rawCredential.split('.')[0] as string)));
 
 						const credentialImageSvgTemplateURL = credentialHeader?.vctm?.display &&

--- a/src/lib/interfaces/IOpenID4VCIHelper.ts
+++ b/src/lib/interfaces/IOpenID4VCIHelper.ts
@@ -7,7 +7,7 @@ export interface IOpenID4VCIHelper {
 	 * @param credentialIssuerIdentifier
 	 * @throws
 	 */
-	getAuthorizationServerMetadata(isOnline: boolean, credentialIssuerIdentifier: string, forceIndexDB: boolean): Promise<{ authzServeMetadata: OpenidAuthorizationServerMetadata }>;
+	getAuthorizationServerMetadata(isOnline: boolean, credentialIssuerIdentifier: string, forceIndexDB: boolean): Promise<{ authzServeMetadata: OpenidAuthorizationServerMetadata } | null>;
 
 
 	/**
@@ -15,5 +15,5 @@ export interface IOpenID4VCIHelper {
 	 * @param credentialIssuerIdentifier
 	 * @throws
 	 */
-	getCredentialIssuerMetadata(isOnline: boolean, credentialIssuerIdentifier: string, forceIndexDB: boolean): Promise<{ metadata: OpenidCredentialIssuerMetadata }>;
+	getCredentialIssuerMetadata(isOnline: boolean, credentialIssuerIdentifier: string, forceIndexDB: boolean): Promise<{ metadata: OpenidCredentialIssuerMetadata } | null>;
 }

--- a/src/lib/services/OpenID4VCIHelper.ts
+++ b/src/lib/services/OpenID4VCIHelper.ts
@@ -28,7 +28,7 @@ export class OpenID4VCIHelper implements IOpenID4VCIHelper {
 	}
 
 	// Fetches authorization server metadata with fallback
-	async getAuthorizationServerMetadata(isOnline: boolean, credentialIssuerIdentifier: string, forceIndexDB: boolean = false): Promise<{ authzServeMetadata: OpenidAuthorizationServerMetadata }> {
+	async getAuthorizationServerMetadata(isOnline: boolean, credentialIssuerIdentifier: string, forceIndexDB: boolean = false): Promise<{ authzServeMetadata: OpenidAuthorizationServerMetadata } | null> {
 		const pathAuthorizationServer = `${credentialIssuerIdentifier}/.well-known/oauth-authorization-server`;
 		const pathConfiguration = `${credentialIssuerIdentifier}/.well-known/openid-configuration`;
 
@@ -47,21 +47,32 @@ export class OpenID4VCIHelper implements IOpenID4VCIHelper {
 				OpenidAuthorizationServerMetadataSchema,
 				isOnline,
 				forceIndexDB
-			);
+			).catch(() => null);
+
+			if (!authzServeMetadata) {
+				return null;
+			}
 			return { authzServeMetadata };
 		}
 	}
 
 	// Fetches credential issuer metadata
-	async getCredentialIssuerMetadata(isOnline: boolean, credentialIssuerIdentifier: string, forceIndexDB: boolean = false): Promise<{ metadata: OpenidCredentialIssuerMetadata }> {
+	async getCredentialIssuerMetadata(isOnline: boolean, credentialIssuerIdentifier: string, forceIndexDB: boolean = false): Promise<{ metadata: OpenidCredentialIssuerMetadata } | null> {
 		const pathCredentialIssuer = `${credentialIssuerIdentifier}/.well-known/openid-credential-issuer`;
 
-		const metadata = await this.fetchAndCache<OpenidCredentialIssuerMetadata>(
-			pathCredentialIssuer,
-			OpenidCredentialIssuerMetadataSchema,
-			isOnline,
-			forceIndexDB
-		);
-		return { metadata };
+		try {
+			const metadata = await this.fetchAndCache<OpenidCredentialIssuerMetadata>(
+				pathCredentialIssuer,
+				OpenidCredentialIssuerMetadataSchema,
+				isOnline,
+				forceIndexDB
+			);
+			return { metadata };
+		}
+		catch(err) {
+			console.error(err);
+			return null;
+		}
+
 	}
 }


### PR DESCRIPTION
Handle errors when metadata cannot be fetched for a specific issuer through the OpenID4VCIHelper dependency.

These  errors appeared when the issuer who issued a credential stored in the wallet is not anymore available to serve the metadata