### PR TITLE
Hotfix: Force Reload When New Content is Available to Resolve ChunkLoadError

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -60,9 +60,7 @@ self.addEventListener('activate', (event) => {
 
 			return self.clients.matchAll().then((clients) => {
 				clients.forEach((client) => {
-					client.postMessage({
-						type: 'NEW_CONTENT_AVAILABLE',
-					});
+					client.navigate(client.url);
 				});
 			});
 		})


### PR DESCRIPTION
This PR introduces a hotfix to address the issue where users encounter a white screen due to missing JavaScript chunk files after a new deployment. The error occurs when the app tries to load a chunk that no longer exists on the server, resulting in ChunkLoadError and Uncaught SyntaxError: Unexpected token '<' in the browser console.