### PR TITLE
Converted .apply to iterations in the function utils.toBase64()

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -7,7 +7,14 @@ function toU8(b: BufferSource) {
 }
 
 export function toBase64(binary: BufferSource): string {
-	return btoa(String.fromCharCode.apply(String, toU8(binary)));
+	const uint8Array = toU8(binary);
+	const chunkSize = 0x8000; // 32KB
+	let result = '';
+	for (let i = 0; i < uint8Array.length; i += chunkSize) {
+		const chunk = uint8Array.subarray(i, i + chunkSize);
+		result += String.fromCharCode(...chunk);
+	}
+	return btoa(result);
 }
 
 export function toBase64Url(binary: BufferSource): string {


### PR DESCRIPTION
Even though .apply was returning correct results, after extending the size of the privateData column a change in the toBase64 is required to support larger inputs even though the performance might be reduced for small inputs.