### PR TITLE
Fix session state issues

### DIFF
--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -25,18 +25,18 @@ export const SessionContextProvider = ({ children }) => {
 	const api = useApi(isOnline);
 	const keystore = useLocalStorageKeystore();
 
+	const logout = async () => {
+		// Clear URL parameters
+		sessionStorage.setItem('freshLogin', 'true');
+		api.clearSession();
+		await keystore.close();
+	};
+
 	const value: SessionContextValue = {
 		api,
 		isLoggedIn: api.isLoggedIn() && keystore.isOpen(),
 		keystore,
-		logout: async () => {
-
-			// Clear URL parameters
-			sessionStorage.setItem('freshLogin', 'true');
-			api.clearSession();
-			await keystore.close();
-
-		},
+		logout,
 	};
 
 	return (

--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext } from 'react';
 
 import StatusContext from './StatusContext';
 import { BackendApi, useApi } from '../api';
-import { useLocalStorageKeystore } from '../services/LocalStorageKeystore';
+import { KeystoreEvent, useLocalStorageKeystore } from '../services/LocalStorageKeystore';
 import type { LocalStorageKeystore } from '../services/LocalStorageKeystore';
 
 
@@ -23,7 +23,8 @@ const SessionContext: React.Context<SessionContextValue> = createContext({
 export const SessionContextProvider = ({ children }) => {
 	const { isOnline } = useContext(StatusContext);
 	const api = useApi(isOnline);
-	const keystore = useLocalStorageKeystore();
+	const keystoreEvents = new EventTarget();
+	const keystore = useLocalStorageKeystore(keystoreEvents);
 
 	const logout = async () => {
 		// Clear URL parameters
@@ -31,6 +32,8 @@ export const SessionContextProvider = ({ children }) => {
 		api.clearSession();
 		await keystore.close();
 	};
+
+	keystoreEvents.addEventListener(KeystoreEvent.Close, logout, { once: true });
 
 	const value: SessionContextValue = {
 		api,

--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -34,6 +34,7 @@ export const SessionContextProvider = ({ children }) => {
 	};
 
 	keystoreEvents.addEventListener(KeystoreEvent.Close, logout, { once: true });
+	keystoreEvents.addEventListener(KeystoreEvent.CloseTabLocal, api.clearSession, { once: true });
 
 	const value: SessionContextValue = {
 		api,

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -181,9 +181,6 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 		{ exportedMainKey, privateData }: UnlockSuccess,
 		user: CachedUser | UserData | null,
 	): Promise<void> => {
-		setMainKey(exportedMainKey);
-		setPrivateData(privateData);
-
 		if (user) {
 			const userHandleB64u = ("prfKeys" in user
 				? user.userHandleB64u
@@ -199,13 +196,21 @@ export function useLocalStorageKeystore(): LocalStorageKeystore {
 			);
 
 			setUserHandleB64u(userHandleB64u);
+
+			// This must happen before setPrivateData in order to prevent the
+			// useEffect updating cachedUsers from corrupting cache entries for other
+			// users logged in in other tabs.
 			setGlobalUserHandleB64u(userHandleB64u);
+
 			setCachedUsers((cachedUsers) => {
 				// Move most recently used user to front of list
 				const otherUsers = (cachedUsers || []).filter((cu) => cu.userHandleB64u !== newUser.userHandleB64u);
 				return [newUser, ...otherUsers];
 			});
 		}
+
+		setMainKey(exportedMainKey);
+		setPrivateData(privateData);
 	};
 
 	const init = async (


### PR DESCRIPTION
Fixes part of #474: log out whenever `api` and `keystore` are not both logged in. This fixes the issue with `sessionStorage` attributes from the `api` module remaining after the idle logout enforced by the keystore.