### PR TITLE
Unify event architecture between api and keystore

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -38,6 +38,9 @@ export type ClearSessionEvent = {};
 export const CLEAR_SESSION_EVENT = 'clearSession';
 export type ApiEventType = typeof CLEAR_SESSION_EVENT;
 const events: EventTarget = new EventTarget();
+export enum ApiEvent {
+	Login = 'api.login',
+}
 
 
 export interface BackendApi {
@@ -256,7 +259,7 @@ export function useApi(isOnline: boolean = true): BackendApi {
 		if (isOnline) {
 			await fetchInitialData(response.data.appToken, response.data.uuid).catch((error) => console.error('Error in performGetRequests', error));
 		}
-		dispatchEvent(new CustomEvent("login"));
+		dispatchEvent(new CustomEvent(ApiEvent.Login));
 	}
 
 	async function login(username: string, password: string, keystore: LocalStorageKeystore): Promise<Result<void, any>> {

--- a/src/components/Auth/PrivateRoute.tsx
+++ b/src/components/Auth/PrivateRoute.tsx
@@ -9,7 +9,7 @@ import { useSessionStorage } from '../../hooks/useStorage';
 import StatusContext from '../../context/StatusContext';
 import SessionContext from '../../context/SessionContext';
 import { ApiEvent } from '../../api';
-import { cleanupEvents } from '../../util';
+import { cleanupListeners } from '../../util';
 
 
 type PrivateRouteContextValue = {
@@ -31,7 +31,7 @@ export function NotificationPermissionWarning(): React.ReactNode {
 	const [isMessageOfflineVisible, setIsMessageOfflineVisible, clearIsMessageOfflineVisible] = useSessionStorage('isMessageOfflineVisible', false);
 
 	useEffect(
-		() => cleanupEvents(signal => {
+		() => cleanupListeners(signal => {
 			sessionEvents.addEventListener(ApiEvent.ClearSession, clearIsMessageNoGrantedVisible, { signal });
 			sessionEvents.addEventListener(ApiEvent.ClearSession, clearIsMessageGrantedVisible, { signal });
 			sessionEvents.addEventListener(ApiEvent.ClearSession, clearIsMessageOfflineVisible, { signal });
@@ -152,7 +152,7 @@ const PrivateRoute = ({ children }: { children?: React.ReactNode }): React.React
 	const [latestIsOnlineStatus, setLatestIsOnlineStatus, clearLatestIsOnlineStatus] = useSessionStorage('latestIsOnlineStatus', null);
 
 	useEffect(
-		() => cleanupEvents(signal => {
+		() => cleanupListeners(signal => {
 			sessionEvents.addEventListener(ApiEvent.ClearSession, () => {
 				clearTokenSentInSession();
 				clearLatestIsOnlineStatus();

--- a/src/context/ContainerContext.tsx
+++ b/src/context/ContainerContext.tsx
@@ -25,6 +25,7 @@ import renderCustomSvgTemplate from "../components/Credentials/RenderCustomSvgTe
 import StatusContext from "./StatusContext";
 import { getSdJwtVcMetadata } from "../lib/utils/getSdJwtVcMetadata";
 import { CredentialBatchHelper } from "../lib/services/CredentialBatchHelper";
+import { ApiEvent } from "../api";
 
 export type ContainerContextValue = {
 	httpProxy: IHttpProxy,
@@ -61,7 +62,7 @@ export const ContainerContextProvider = ({ children }) => {
 			setIsInitialized(false);
 		});
 
-		window.addEventListener('login', (e) => {
+		window.addEventListener(ApiEvent.Login, (e) => {
 			setIsInitialized(false);
 			setShouldUseCache(false)
 		});

--- a/src/context/ContainerContext.tsx
+++ b/src/context/ContainerContext.tsx
@@ -26,7 +26,7 @@ import StatusContext from "./StatusContext";
 import { getSdJwtVcMetadata } from "../lib/utils/getSdJwtVcMetadata";
 import { CredentialBatchHelper } from "../lib/services/CredentialBatchHelper";
 import { ApiEvent } from "../api";
-import { cleanupEvents } from "../util";
+import { cleanupListeners } from "../util";
 
 export type ContainerContextValue = {
 	httpProxy: IHttpProxy,
@@ -55,7 +55,7 @@ export const ContainerContextProvider = ({ children }) => {
 	const [shouldUseCache, setShouldUseCache] = useState(true)
 
 	useEffect(
-		() => cleanupEvents(signal => {
+		() => cleanupListeners(signal => {
 			const onLogin = () => {
 				setIsInitialized(false);
 				setShouldUseCache(false)

--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -4,7 +4,7 @@ import StatusContext from './StatusContext';
 import { BackendApi, useApi } from '../api';
 import { KeystoreEvent, useLocalStorageKeystore } from '../services/LocalStorageKeystore';
 import type { LocalStorageKeystore } from '../services/LocalStorageKeystore';
-import { cleanupEvents } from '../util';
+import { cleanupListeners } from '../util';
 
 
 type SessionContextValue = {
@@ -40,7 +40,7 @@ export const SessionContextProvider = ({ children }) => {
 	);
 
 	useEffect(
-		() => cleanupEvents(signal => {
+		() => cleanupListeners(signal => {
 			events.addEventListener(KeystoreEvent.Close, logout, { once: true, signal });
 			events.addEventListener(KeystoreEvent.CloseTabLocal, api.clearSession, { once: true, signal });
 		}),

--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -1,13 +1,15 @@
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo } from 'react';
 
 import StatusContext from './StatusContext';
 import { BackendApi, useApi } from '../api';
 import { KeystoreEvent, useLocalStorageKeystore } from '../services/LocalStorageKeystore';
 import type { LocalStorageKeystore } from '../services/LocalStorageKeystore';
+import { cleanupEvents } from '../util';
 
 
 type SessionContextValue = {
 	api: BackendApi,
+	events: EventTarget,
 	isLoggedIn: boolean,
 	keystore: LocalStorageKeystore,
 	logout: () => Promise<void>,
@@ -15,6 +17,7 @@ type SessionContextValue = {
 
 const SessionContext: React.Context<SessionContextValue> = createContext({
 	api: undefined,
+	events: undefined,
 	isLoggedIn: false,
 	keystore: undefined,
 	logout: async () => { },
@@ -22,22 +25,31 @@ const SessionContext: React.Context<SessionContextValue> = createContext({
 
 export const SessionContextProvider = ({ children }) => {
 	const { isOnline } = useContext(StatusContext);
-	const api = useApi(isOnline);
-	const keystoreEvents = new EventTarget();
-	const keystore = useLocalStorageKeystore(keystoreEvents);
+	const events = useMemo(() => new EventTarget(), []);
+	const api = useApi(isOnline, events);
+	const keystore = useLocalStorageKeystore(events);
 
-	const logout = async () => {
-		// Clear URL parameters
-		sessionStorage.setItem('freshLogin', 'true');
-		api.clearSession();
-		await keystore.close();
-	};
+	const logout = useCallback(
+		async () => {
+			// Clear URL parameters
+			sessionStorage.setItem('freshLogin', 'true');
+			api.clearSession();
+			await keystore.close();
+		},
+		[api, keystore],
+	);
 
-	keystoreEvents.addEventListener(KeystoreEvent.Close, logout, { once: true });
-	keystoreEvents.addEventListener(KeystoreEvent.CloseTabLocal, api.clearSession, { once: true });
+	useEffect(
+		() => cleanupEvents(signal => {
+			events.addEventListener(KeystoreEvent.Close, logout, { once: true, signal });
+			events.addEventListener(KeystoreEvent.CloseTabLocal, api.clearSession, { once: true, signal });
+		}),
+		[api, events, keystore, logout],
+	);
 
 	const value: SessionContextValue = {
 		api,
+		events,
 		isLoggedIn: api.isLoggedIn() && keystore.isOpen(),
 		keystore,
 		logout,

--- a/src/hooks/useOnUserInactivity.ts
+++ b/src/hooks/useOnUserInactivity.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useResettableTimeout } from './useResettableTimeout';
-import { cleanupEvents, throttle } from '../util';
+import { cleanupListeners, throttle } from '../util';
 
 
 /**
@@ -12,7 +12,7 @@ export function useOnUserInactivity(action: () => void, timeoutMillis: number) {
 	const resetTimeout = useResettableTimeout(action, timeoutMillis);
 
 	useEffect(
-		() => cleanupEvents(signal => {
+		() => cleanupListeners(signal => {
 			// I would have liked to use the User Activation API
 			// (https://developer.mozilla.org/en-US/docs/Web/API/UserActivation/isActive)
 			// for this, but it doesn't appear to provide an event source and the

--- a/src/hooks/useOnUserInactivity.ts
+++ b/src/hooks/useOnUserInactivity.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useResettableTimeout } from './useResettableTimeout';
-import { throttle } from '../util';
+import { cleanupEvents, throttle } from '../util';
 
 
 /**
@@ -12,7 +12,7 @@ export function useOnUserInactivity(action: () => void, timeoutMillis: number) {
 	const resetTimeout = useResettableTimeout(action, timeoutMillis);
 
 	useEffect(
-		() => {
+		() => cleanupEvents(signal => {
 			// I would have liked to use the User Activation API
 			// (https://developer.mozilla.org/en-US/docs/Web/API/UserActivation/isActive)
 			// for this, but it doesn't appear to provide an event source and the
@@ -23,14 +23,9 @@ export function useOnUserInactivity(action: () => void, timeoutMillis: number) {
 			const throttledReset = throttle(resetTimeout, timeoutMillis / 4);
 			const eventTypes = ["keydown", "pointermove", "pointerdown"];
 			for (const eventType of eventTypes) {
-				window.document.addEventListener(eventType, throttledReset, { passive: true });
+				window.document.addEventListener(eventType, throttledReset, { passive: true, signal });
 			}
-			return () => {
-				for (const eventType of eventTypes) {
-					window.document.removeEventListener(eventType, throttledReset);
-				}
-			}
-		},
+		}),
 		[resetTimeout, timeoutMillis],
 	);
 }

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -106,7 +106,7 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 			clearSessionStorage();
 			eventTarget.dispatchEvent(new CustomEvent(KeystoreEvent.CloseTabLocal));
 		},
-		[clearSessionStorage],
+		[clearSessionStorage, eventTarget],
 	);
 
 	const close = useCallback(
@@ -117,7 +117,7 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 			closeTabLocal();
 			eventTarget.dispatchEvent(new CustomEvent(KeystoreEvent.Close));
 		},
-		[closeTabLocal, idb, clearGlobalUserHandleB64u, clearPrivateData],
+		[closeTabLocal, idb, clearGlobalUserHandleB64u, clearPrivateData, eventTarget],
 	);
 
 	useOnUserInactivity(close, config.INACTIVE_LOGOUT_MILLIS);

--- a/src/util.ts
+++ b/src/util.ts
@@ -153,3 +153,35 @@ export function getElementPropValue(
 	}
 	return value;
 }
+
+/**
+	* Create an `AbortController` and call `effect` with its `AbortSignal` as the
+	* `signal` argument, and return a cleanup handler that calls `.abort()` on the
+	* `AbortController`. This removes all event listeners that `effect` added with
+	* the option `{ signal: signal }`. If `effect` returns a cleanup handler, the
+	* wrapped cleanup handler will call that too.
+	*
+	* Example usage:
+	* ```
+	* useEffect(
+	* 	setupEvents(signal => {
+	* 		window.addEventListener('foo', () => console.log('foo'), { signal });
+	* 		return () => console.log('cleanup');
+	* 	}),
+	* 	[],
+	* );
+	* ```
+	*
+	* @see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#signal
+	*/
+export function cleanupEvents(effect: (signal: AbortSignal) => (void | (() => void))): () => void {
+	const abortController = new AbortController();
+	const signal = abortController.signal;
+	const cleanup = effect(signal);
+	return () => {
+		if (cleanup) {
+			cleanup();
+		}
+		abortController.abort();
+	};
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -174,7 +174,7 @@ export function getElementPropValue(
 	*
 	* @see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#signal
 	*/
-export function cleanupEvents(effect: (signal: AbortSignal) => (void | (() => void))): () => void {
+export function cleanupListeners(effect: (signal: AbortSignal) => (void | (() => void))): () => void {
 	const abortController = new AbortController();
 	const signal = abortController.signal;
 	const cleanup = effect(signal);


### PR DESCRIPTION
With #483, the `api` and `LocalStorageKeystore` modules now expose two very different ways of attaching event listeners to these services. This PR aims to unify both APIs under a shared architecture based on the `EventTarget` type available in the JS engine.

As part of that, this also introduces `util.cleanupListeners` to help streamline setting up `useEffect` cleanup handlers to remove stale event listeners. This helper function sets up an `AbortController` and provides its `signal` so that event listeners can be automatically removed using the [`signal` option of `addEventListener`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#signal).