### PR TITLE
Refactor Login Navigation to Ensure Fresh State After Logout

### DIFF
--- a/src/components/Auth/PrivateRoute.tsx
+++ b/src/components/Auth/PrivateRoute.tsx
@@ -243,16 +243,10 @@ const PrivateRoute = ({ children }: { children?: React.ReactNode }): React.React
 	};
 
 	if (!isLoggedIn) {
-		const freshLogin = sessionStorage.getItem('freshLogin');
-		if (freshLogin) {
-			sessionStorage.removeItem('freshLogin');
-			window.history.replaceState(null, '', '/');
-			return <Navigate to="/login" replace />;
-		}
 		if (state && userExistsInCache(state)) {
-			return <Navigate to="/login-state" state={{ from: location }} replace />;
+			return <Navigate to={`/login-state${window.location.search}`} replace />;
 		} else {
-			return <Navigate to="/login" state={{ from: location }} replace />;
+			return <Navigate to={`/login${window.location.search}`} replace />;
 		}
 	}
 

--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -30,7 +30,7 @@ export const SessionContextProvider = ({ children }) => {
 
 	// Memoize clearSession using useCallback
 	const clearSession = useCallback(async () => {
-		sessionStorage.setItem('freshLogin', 'true');
+		window.history.replaceState({}, '', `${window.location.pathname}`);
 		console.log('Clear Session');
 		api.clearSession();
 	}, [api]);

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -222,7 +222,7 @@ const WebauthnSignupLogin = ({
 	const [prfRetryAccepted, setPrfRetryAccepted] = useState(false);
 	const navigate = useNavigate();
 	const location = useLocation();
-	const from = location.state?.from || '/';
+	const from = location.search;
 
 	const { t } = useTranslation();
 	const [retrySignupFrom, setRetrySignupFrom] = useState(null);
@@ -564,7 +564,7 @@ const Auth = () => {
 	const { t } = useTranslation();
 	const location = useLocation();
 
-	const from = location.state?.from || '/';
+	const from = location.search;
 
 	const [error, setError] = useState<React.ReactNode>('');
 	const [webauthnError, setWebauthnError] = useState<React.ReactNode>('');

--- a/src/pages/Login/LoginState.js
+++ b/src/pages/Login/LoginState.js
@@ -19,7 +19,7 @@ const WebauthnLogin = ({
 	const [error, setError] = useState('');
 	const navigate = useNavigate();
 	const location = useLocation();
-	const from = location.state?.from || '/';
+	const from = location.search;
 	const { t } = useTranslation();
 
 	const [isSubmitting, setIsSubmitting] = useState(false);
@@ -103,7 +103,7 @@ const LoginState = () => {
 	const location = useLocation();
 
 	const cachedUsers = keystore.getCachedUsers();
-	const from = location.state?.from;
+	const from = location.search;
 
 	const getCachedUser = () => {
 		const queryParams = new URLSearchParams(from?.search ?? location.search);


### PR DESCRIPTION
- Removed the use of the `sessionStorage` variable `freshLogin` and updated the behavior to clean `window.history.replaceState` immediately during session cleanup.
- Updated navigation to /login or /login-state to always include the current `window.location.search` parameters, ensuring a consistent and fresh login state after logout.
