### PR TITLE
Ensure Consistent Slide-Down Effect for New Credentials

### DIFF
--- a/src/context/CredentialsContext.js
+++ b/src/context/CredentialsContext.js
@@ -127,16 +127,6 @@ export const CredentialsProvider = ({ children }) => {
 		}
 	}, [api, fetchVcData, pollForCredentials]);
 
-	useEffect(() => {
-		const handleNewCredentialEvent = () => {
-			getData(true);
-		};
-		window.addEventListener('newCredential', handleNewCredentialEvent);
-		return () => {
-			window.removeEventListener('newCredential', handleNewCredentialEvent);
-		};
-	}, [getData]);
-
 	return (
 		<CredentialsContext.Provider value={{ vcEntityList, latestCredentials, fetchVcData, getData, currentSlide, setCurrentSlide, parseCredential }}>
 			{children}

--- a/src/lib/services/OpenID4VCI/OpenID4VCI.tsx
+++ b/src/lib/services/OpenID4VCI/OpenID4VCI.tsx
@@ -10,6 +10,7 @@ import { useHttpProxy } from '../HttpProxy/HttpProxy';
 import { useOpenID4VCIClientStateRepository } from '../OpenID4VCIClientStateRepository';
 import { useCallback, useContext, useMemo, useEffect, useRef } from 'react';
 import SessionContext from '../../../context/SessionContext';
+import CredentialsContext from '../../../context/CredentialsContext';
 import { useOpenID4VCIPushedAuthorizationRequest } from './OpenID4VCIAuthorizationRequest/OpenID4VCIPushedAuthorizationRequest';
 import { useOpenID4VCIAuthorizationRequestForFirstPartyApplications } from './OpenID4VCIAuthorizationRequest/OpenID4VCIAuthorizationRequestForFirstPartyApplications';
 import { useOpenID4VCIHelper } from '../OpenID4VCIHelper';
@@ -24,6 +25,7 @@ export function useOpenID4VCI({ errorCallback }: { errorCallback: (title: string
 	const httpProxy = useHttpProxy();
 	const openID4VCIClientStateRepository = useOpenID4VCIClientStateRepository();
 	const { api } = useContext(SessionContext);
+	const { getData } = useContext<any>(CredentialsContext);
 
 	const openID4VCIHelper = useOpenID4VCIHelper();
 
@@ -94,10 +96,13 @@ export function useOpenID4VCI({ errorCallback }: { errorCallback: (title: string
 			await api.post('/storage/vc', {
 				credentials: storableCredentials
 			});
+
+			getData(true);
+
 			return;
 
 		},
-		[openID4VCIHelper, api, openID4VCIClientStateRepository, credentialRequestBuilder]
+		[openID4VCIHelper, api, openID4VCIClientStateRepository, credentialRequestBuilder, getData]
 	);
 
 	const requestCredentials = useCallback(


### PR DESCRIPTION
This PR ensures that the slide-down effect is consistently displayed when new credentials are received, regardless of whether they are triggered by a notification or not.

Key updates in this PR:

- Removed the unused newCredentialListener event.
- Call getData with polling mechanism to check for new credentials.