### PR TITLE
Fix: Prevent unnecessary rerender when login with null location.search

### DIFF
--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -222,7 +222,7 @@ const WebauthnSignupLogin = ({
 	const [prfRetryAccepted, setPrfRetryAccepted] = useState(false);
 	const navigate = useNavigate();
 	const location = useLocation();
-	const from = location.search;
+	const from = location.search || '/';
 
 	const { t } = useTranslation();
 	const [retrySignupFrom, setRetrySignupFrom] = useState(null);
@@ -564,7 +564,7 @@ const Auth = () => {
 	const { t } = useTranslation();
 	const location = useLocation();
 
-	const from = location.search;
+	const from = location.search || '/';
 
 	const [error, setError] = useState<React.ReactNode>('');
 	const [webauthnError, setWebauthnError] = useState<React.ReactNode>('');

--- a/src/pages/Login/LoginState.js
+++ b/src/pages/Login/LoginState.js
@@ -20,7 +20,7 @@ const WebauthnLogin = ({
 	const [error, setError] = useState('');
 	const navigate = useNavigate();
 	const location = useLocation();
-	const from = location.search;
+	const from = location.search || '/';
 	const { t } = useTranslation();
 
 	const [isSubmitting, setIsSubmitting] = useState(false);
@@ -104,7 +104,7 @@ const LoginState = () => {
 	const location = useLocation();
 
 	const cachedUsers = keystore.getCachedUsers();
-	const from = location.search;
+	const from = location.search || '/';
 
 	const getfilteredUser = () => {
 		const queryParams = new URLSearchParams(from);


### PR DESCRIPTION
This PR addresses an issue (come after  #498) where the application was causing unnecessary rerenders upon user login/signup when location.search was null. The root cause was due to the assignment const from = location.search; which evaluated to null, triggering rerenders.

The fix updates this assignment to:
`const from = location.search || '/';
`
This ensures that when `location.search` is `null`, it defaults to` '/'`, preventing unnecessary rerenders and improving login/signup flow stability.