### PR TITLE
Add Null Check for vcEntity Before Accessing isExpired

### DIFF
--- a/src/components/Credentials/CredentialLayout.jsx
+++ b/src/components/Credentials/CredentialLayout.jsx
@@ -112,7 +112,7 @@ const CredentialLayout = ({ children, title = null }) => {
 
 				{screenType === 'mobile' && (
 					<>
-						{vcEntity.isExpired && (
+						{vcEntity && vcEntity.isExpired && (
 							<div className="bg-orange-100 mx-2 p-2 shadow-lg text-sm rounded-lg mb-4 flex items-center">
 								<div className="mr-2 text-orange-500">
 									<FaExclamationTriangle size={18} />

--- a/src/components/Credentials/ExpiredRibbon.jsx
+++ b/src/components/Credentials/ExpiredRibbon.jsx
@@ -7,7 +7,7 @@ const ExpiredRibbon = ({ vcEntity }) => {
 
 	return (
 		<>
-			{vcEntity.isExpired &&
+			{vcEntity && vcEntity.isExpired &&
 				<div className={`absolute bottom-0 right-0 text-white text-xs py-1 px-3 rounded-tl-lg rounded-br-2xl border-t border-l border-white ${vcEntity.isExpired ? 'bg-red-600' : 'bg-green-500'}`}>
 					{t('expiredRibbon.expired')}
 				</div>


### PR DESCRIPTION
## Overview
This PR introduces a safeguard check to ensure that `vcEntity` is defined before attempting to access its `isExpired` property. This change prevents potential runtime errors in scenarios where `vcEntity` might be undefined or null.

## Changes
- Updated the condition to include a check for `vcEntity` before accessing `vcEntity.isExpired`.
