### PR TITLE
Fix Incorrect Prop Passed to CredentialInfo Component

### DIFF
--- a/src/components/History/HistoryDetailContent.jsx
+++ b/src/components/History/HistoryDetailContent.jsx
@@ -70,7 +70,7 @@ const HistoryDetailContent = ({ historyItem }) => {
 			{/* Render details of the currently selected credential */}
 			{vcEntities[currentSlide - 1] && (
 				<div className={`pt-5 ${screenType !== 'mobile' ? 'overflow-y-auto items-center custom-scrollbar max-h-[30vh]' : ''} `}>
-					<CredentialInfo parsedCredential={vcEntities[currentSlide - 1]} />
+					<CredentialInfo parsedCredential={vcEntities[currentSlide - 1].parsedCredential} />
 				</div>
 			)}
 		</div>


### PR DESCRIPTION
## Overview
This PR addresses an issue where the incorrect prop was being passed to the `CredentialInfo` component within the `HistoryDetailContent` component. Previously, the entire VC entity was mistakenly passed instead of just the parsed credential data.

## Changes
- Updated the `CredentialInfo` component call to pass `vcEntities[currentSlide - 1].parsedCredential` instead of the entire VC entity.
