### PR TITLE
Optimize Initial Data Fetching and Add Missing Credential Issuer Metadata Retrieval

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,6 +10,7 @@ import { useEffect } from 'react';
 import { UseStorageHandle, useClearStorages, useLocalStorage, useSessionStorage } from '../hooks/useStorage';
 import { addItem, getItem } from '../indexedDB';
 import { loginWebAuthnBeginOffline } from './LocalAuthentication';
+import { useOpenID4VCIHelper } from '@/lib/services/OpenID4VCIHelper';
 
 const walletBackendUrl = config.BACKEND_URL;
 
@@ -94,6 +95,8 @@ export function useApi(isOnline: boolean = true): BackendApi {
 	 */
 	const [privateDataEtag, setPrivateDataEtag] = useLocalStorage<string | null>("privateDataEtag", null);
 
+	const openID4VCIHelper = useOpenID4VCIHelper();
+
 	function getAppToken(): string | null {
 		return appToken;
 	}
@@ -170,8 +173,14 @@ export function useApi(isOnline: boolean = true): BackendApi {
 			await get('/storage/vp', userUuid, { appToken });
 			await get('/user/session/account-info', userUuid, { appToken });
 			await getExternalEntity('/verifier/all', { appToken }, false);
-			await getExternalEntity('/issuer/all', { appToken }, false);
-
+			const response = await getExternalEntity('/issuer/all', { appToken }, false);
+			response.data.forEach(async (issuer) => {
+				try {
+					await openID4VCIHelper.getCredentialIssuerMetadata(issuer.credentialIssuerIdentifier);
+				} catch (err) {
+					console.error(err);
+				}
+			});
 		} catch (error) {
 			console.error('Failed to perform get requests', error);
 		}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -169,8 +169,8 @@ export function useApi(isOnline: boolean = true): BackendApi {
 
 	async function fetchInitialData(appToken: string, userUuid: string): Promise<void> {
 		try {
-			await get('/storage/vc', userUuid, { appToken });
-			await get('/storage/vp', userUuid, { appToken });
+			// get('/storage/vc') on home page ('/')
+			// get('/storage/vp') on home page ('/')
 			await get('/user/session/account-info', userUuid, { appToken });
 			await getExternalEntity('/verifier/all', { appToken }, false);
 			const response = await getExternalEntity('/issuer/all', { appToken }, false);


### PR DESCRIPTION
## Summary
This PR optimizes the data fetching strategy during the initial load by removing redundant calls to fetch VC and VP, which are already adequately handled on the home page upon login or signup. Additionally, it introduces the fetching of missing credential issuer metadata, ensuring comprehensive data availability and integrity from the start.

## Changes
- **Removal of Redundant Data Fetching**: The calls to `get('/storage/vc')` and `get('/storage/vp')` have been removed from the `fetchInitialData` function as these are already being called on the home page (`/`). This change eliminates unnecessary network requests during the initial data loading phase, thereby improving the loading performance and reducing data redundancy.
- **Addition of Credential Issuer Metadata Retrieval**: Implemented a new feature in the `fetchInitialData` function to fetch credential issuer metadata for each issuer obtained from `getExternalEntity('/issuer/all')`. This ensures that all relevant metadata about issuers is readily available, filling a previously existing gap in our data fetching logic.
