### PR TITLE
Separate Display Logic for Issuers with Multiple Credential Configurations

### DIFF
--- a/src/components/Popups/RedirectPopup.jsx
+++ b/src/components/Popups/RedirectPopup.jsx
@@ -4,26 +4,8 @@ import { useTranslation } from 'react-i18next';
 import Button from '../Buttons/Button';
 import PopupLayout from './PopupLayout';
 
-const RedirectPopup = ({ loading, availableCredentialConfigurations, onClose, handleContinue, popupTitle, popupMessage }) => {
+const RedirectPopup = ({ loading, onClose, handleContinue, popupTitle, popupMessage }) => {
 	const { t } = useTranslation();
-
-	const locale = 'en-US';
-
-	const [selectedConfiguration, setSelectedConfiguration] = useState(null);
-
-	const configurationsCount = availableCredentialConfigurations ? Object.keys(availableCredentialConfigurations).length : 0;
-
-	useEffect(() => {
-		if (availableCredentialConfigurations) {
-			setSelectedConfiguration(Object.keys(availableCredentialConfigurations)[0])
-		}
-	}, [availableCredentialConfigurations, setSelectedConfiguration])
-
-	const handleOptionChange = (event) => {
-		if (availableCredentialConfigurations) {
-			setSelectedConfiguration(event.target.value);
-		}
-	};
 
 	return (
 		<PopupLayout isOpen={true} onClose={onClose} loading={loading}>
@@ -36,31 +18,11 @@ const RedirectPopup = ({ loading, availableCredentialConfigurations, onClose, ha
 				{popupMessage}
 			</p>
 
-			{configurationsCount > 1 && Object.keys(availableCredentialConfigurations).map((credentialConfigurationId, index) => {
-				return (
-					<div key={credentialConfigurationId} className="flex items-center mb-4">
-						<input
-							id={"radio-" + index}
-							onChange={handleOptionChange}
-							type="radio"
-							value={credentialConfigurationId}
-							name="default-radio"
-							className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
-							checked={selectedConfiguration === credentialConfigurationId}
-							aria-label={`Option ${credentialConfigurationId}`}
-						/>
-						<label htmlFor={"radio-" + index} className="ms-2 text-sm font-medium text-gray-900 dark:text-gray-300">
-							{(availableCredentialConfigurations[credentialConfigurationId]?.display ? availableCredentialConfigurations[credentialConfigurationId]?.display.filter((d) => d.locale === locale)[0]?.name : null) ?? credentialConfigurationId}
-						</label>
-					</div>
-				)
-			})}
-
 			<div className="flex justify-end space-x-2 pt-4">
 				<Button variant="cancel" onClick={onClose}>
 					{t('common.cancel')}
 				</Button>
-				<Button variant="primary" onClick={() => handleContinue(selectedConfiguration)}>
+				<Button variant="primary" onClick={() => handleContinue()}>
 					{t('common.continue')}
 				</Button>
 			</div>

--- a/src/lib/interfaces/IOpenID4VCI.ts
+++ b/src/lib/interfaces/IOpenID4VCI.ts
@@ -2,6 +2,7 @@ import { CredentialConfigurationSupported } from "../schemas/CredentialConfigura
 
 export interface IOpenID4VCI {
 	handleCredentialOffer(credentialOfferURL: string): Promise<{ credentialIssuer: string, selectedCredentialConfigurationId: string; issuer_state?: string }>;
+	getAvailableCredentialConfigurations(credentialIssuerIdentifier: string): Promise<Record<string, CredentialConfigurationSupported>>;
 	generateAuthorizationRequest(credentialIssuerIdentifier: string, credentialConfigurationId: string, issuer_state?: string): Promise<{ url?: string }>;
 	handleAuthorizationResponse(url: string, dpopNonceHeader?: string): Promise<void>;
 }

--- a/src/lib/interfaces/IOpenID4VCI.ts
+++ b/src/lib/interfaces/IOpenID4VCI.ts
@@ -2,7 +2,6 @@ import { CredentialConfigurationSupported } from "../schemas/CredentialConfigura
 
 export interface IOpenID4VCI {
 	handleCredentialOffer(credentialOfferURL: string): Promise<{ credentialIssuer: string, selectedCredentialConfigurationId: string; issuer_state?: string }>;
-	getAvailableCredentialConfigurations(credentialIssuerIdentifier: string): Promise<Record<string, CredentialConfigurationSupported>>;
 	generateAuthorizationRequest(credentialIssuerIdentifier: string, credentialConfigurationId: string, issuer_state?: string): Promise<{ url?: string }>;
 	handleAuthorizationResponse(url: string, dpopNonceHeader?: string): Promise<void>;
 }

--- a/src/lib/services/OpenID4VCI/OpenID4VCI.ts
+++ b/src/lib/services/OpenID4VCI/OpenID4VCI.ts
@@ -383,6 +383,20 @@ export function useOpenID4VCI({ errorCallback }: { errorCallback: (title: string
 		[httpProxy, openID4VCIHelper]
 	);
 
+	const getAvailableCredentialConfigurations = useCallback(
+		async (credentialIssuerIdentifier: string): Promise<Record<string, CredentialConfigurationSupported>> => {
+			console.log('getAvailableCredentialConfigurations')
+			const [credentialIssuerMetadata] = await Promise.all([
+				openID4VCIHelper.getCredentialIssuerMetadata(credentialIssuerIdentifier)
+			]);
+			if (!credentialIssuerMetadata.metadata?.credential_configurations_supported) {
+				throw new Error("Credential configuration supported not found")
+			}
+			return credentialIssuerMetadata.metadata?.credential_configurations_supported;
+		},
+		[openID4VCIHelper]
+	);
+
 	const generateAuthorizationRequest = useCallback(
 		async (credentialIssuerIdentifier: string, credentialConfigurationId: string, issuer_state?: string) => {
 			console.log('generateAuthorizationRequest')
@@ -453,11 +467,13 @@ export function useOpenID4VCI({ errorCallback }: { errorCallback: (title: string
 	return useMemo(() => {
 		return {
 			generateAuthorizationRequest,
+			getAvailableCredentialConfigurations,
 			handleCredentialOffer,
 			handleAuthorizationResponse
 		}
 	}, [
 		generateAuthorizationRequest,
+		getAvailableCredentialConfigurations,
 		handleCredentialOffer,
 		handleAuthorizationResponse
 	]);

--- a/src/lib/services/OpenID4VCI/OpenID4VCI.ts
+++ b/src/lib/services/OpenID4VCI/OpenID4VCI.ts
@@ -383,20 +383,6 @@ export function useOpenID4VCI({ errorCallback }: { errorCallback: (title: string
 		[httpProxy, openID4VCIHelper]
 	);
 
-	const getAvailableCredentialConfigurations = useCallback(
-		async (credentialIssuerIdentifier: string): Promise<Record<string, CredentialConfigurationSupported>> => {
-			console.log('getAvailableCredentialConfigurations')
-			const [credentialIssuerMetadata] = await Promise.all([
-				openID4VCIHelper.getCredentialIssuerMetadata(credentialIssuerIdentifier)
-			]);
-			if (!credentialIssuerMetadata.metadata?.credential_configurations_supported) {
-				throw new Error("Credential configuration supported not found")
-			}
-			return credentialIssuerMetadata.metadata?.credential_configurations_supported;
-		},
-		[openID4VCIHelper]
-	);
-
 	const generateAuthorizationRequest = useCallback(
 		async (credentialIssuerIdentifier: string, credentialConfigurationId: string, issuer_state?: string) => {
 			console.log('generateAuthorizationRequest')
@@ -467,13 +453,11 @@ export function useOpenID4VCI({ errorCallback }: { errorCallback: (title: string
 	return useMemo(() => {
 		return {
 			generateAuthorizationRequest,
-			getAvailableCredentialConfigurations,
 			handleCredentialOffer,
 			handleAuthorizationResponse
 		}
 	}, [
 		generateAuthorizationRequest,
-		getAvailableCredentialConfigurations,
 		handleCredentialOffer,
 		handleAuthorizationResponse
 	]);

--- a/src/pages/AddCredentials/AddCredentials.jsx
+++ b/src/pages/AddCredentials/AddCredentials.jsx
@@ -17,7 +17,6 @@ const Issuers = () => {
 	const [showRedirectPopup, setShowRedirectPopup] = useState(false);
 	const [selectedIssuer, setSelectedIssuer] = useState(null);
 	const [loading, setLoading] = useState(false);
-	// const [availableCredentialConfigurations, setAvailableCredentialConfigurations] = useState(null);
 
 	const openID4VCIHelper = useOpenID4VCIHelper();
 	const { openID4VCI } = useContext(OpenID4VCIContext);
@@ -25,7 +24,6 @@ const Issuers = () => {
 	const { t } = useTranslation();
 
 	useEffect(() => {
-		console.log("Starting to fetch issuers",openID4VCIHelper);
 		const fetchIssuers = async () => {
 			try {
 				const response = await api.getExternalEntity('/issuer/all', undefined, true);

--- a/src/pages/AddCredentials/AddCredentials.jsx
+++ b/src/pages/AddCredentials/AddCredentials.jsx
@@ -44,7 +44,7 @@ const Issuers = () => {
 								newIssuerList.push(issuerWithConfig);
 							}
 						});
-						setIssuers(newIssuerList)
+						setIssuers([...newIssuerList]);
 					}
 					catch (err) {
 						console.error(err);

--- a/src/pages/AddCredentials/AddCredentials.jsx
+++ b/src/pages/AddCredentials/AddCredentials.jsx
@@ -28,7 +28,6 @@ const Issuers = () => {
 			try {
 				const response = await api.getExternalEntity('/issuer/all', undefined, true);
 				let fetchedIssuers = response.data;
-				const newIssuerList = [];
 				fetchedIssuers.map(async (issuer) => {
 					try {
 						const metadata = (await openID4VCIHelper.getCredentialIssuerMetadata(issuer.credentialIssuerIdentifier)).metadata;
@@ -46,9 +45,21 @@ const Issuers = () => {
 									id: issuer.id,
 									configId: config.vct,
 									selectedDisplayName: metadata.display.filter((display) => display.locale === 'en-US')[0].name || null,
+									credentialIssuerMetadata: metadata,
 								};
+
 								if (issuerWithConfig.visible) {
-									newIssuerList.push(issuerWithConfig);
+									setIssuers((currentArray) => {
+										const issuerExists = currentArray.some((iss) =>
+											iss.credentialIssuerMetadata.credential_issuer === issuerWithConfig.credentialIssuerMetadata.credential_issuer &&
+											iss.configId === issuerWithConfig.configId
+										);
+
+										if (!issuerExists) {
+											return [...currentArray, issuerWithConfig];
+										}
+										return currentArray;
+									});
 								}
 							} else {
 								const issuerWithConfig = {
@@ -56,13 +67,25 @@ const Issuers = () => {
 									id: `${issuer.id}-${config.vct}`,
 									configId: config.vct,
 									selectedDisplayName: `${metadata.display.filter((display) => display.locale === 'en-US')[0].name} - ${config.display.filter((display) => display.locale === 'en-US')[0].name}` || null,
+									credentialIssuerMetadata: metadata,
 								};
+
 								if (issuerWithConfig.visible) {
-									newIssuerList.push(issuerWithConfig);
+									setIssuers((currentArray) => {
+										const issuerExists = currentArray.some((iss) =>
+											iss.credentialIssuerMetadata.credential_issuer === issuerWithConfig.credentialIssuerMetadata.credential_issuer &&
+											iss.configId === issuerWithConfig.configId
+										);
+
+										if (!issuerExists) {
+											return [...currentArray, issuerWithConfig];
+										}
+										return currentArray;
+									});
 								}
 							}
 						});
-						setIssuers([...newIssuerList]);
+
 					}
 					catch (err) {
 						console.error(err);

--- a/src/pages/AddCredentials/AddCredentials.jsx
+++ b/src/pages/AddCredentials/AddCredentials.jsx
@@ -32,10 +32,12 @@ const Issuers = () => {
 				fetchedIssuers.map(async (issuer) => {
 					try {
 						const metadata = (await openID4VCIHelper.getCredentialIssuerMetadata(issuer.credentialIssuerIdentifier)).metadata;
-						const configsLength = Object.keys(metadata.credential_configurations_supported).length;
+						const configs = await openID4VCI.getAvailableCredentialConfigurations(issuer.credentialIssuerIdentifier);
 
-						Object.keys(metadata.credential_configurations_supported).forEach(key => {
-							const config = metadata.credential_configurations_supported[key];
+						const configsLength = Object.keys(configs).length;
+
+						Object.keys(configs).forEach(key => {
+							const config = configs[key];
 
 							// Check if only one configuration supported
 							if (configsLength === 1) {
@@ -71,7 +73,6 @@ const Issuers = () => {
 				console.error('Error fetching issuers:', error);
 			}
 		};
-
 
 		if (openID4VCIHelper) {
 			console.log("Fetching issuers...")

--- a/src/pages/AddCredentials/AddCredentials.jsx
+++ b/src/pages/AddCredentials/AddCredentials.jsx
@@ -32,16 +32,32 @@ const Issuers = () => {
 				fetchedIssuers.map(async (issuer) => {
 					try {
 						const metadata = (await openID4VCIHelper.getCredentialIssuerMetadata(issuer.credentialIssuerIdentifier)).metadata;
+						const configsLength = Object.keys(metadata.credential_configurations_supported).length;
+
 						Object.keys(metadata.credential_configurations_supported).forEach(key => {
 							const config = metadata.credential_configurations_supported[key];
-							const issuerWithConfig = {
-								...issuer,
-								id: `${issuer.id}-${config.vct}`,
-								configId: config.vct,
-								selectedDisplayName: `${metadata.display.filter((display) => display.locale === 'en-US')[0].name} - ${config.display.filter((display) => display.locale === 'en-US')[0].name}` || null,
-							};
-							if (issuerWithConfig.visible) {
-								newIssuerList.push(issuerWithConfig);
+
+							// Check if only one configuration supported
+							if (configsLength === 1) {
+								const issuerWithConfig = {
+									...issuer,
+									id: issuer.id,
+									configId: config.vct,
+									selectedDisplayName: metadata.display.filter((display) => display.locale === 'en-US')[0].name || null,
+								};
+								if (issuerWithConfig.visible) {
+									newIssuerList.push(issuerWithConfig);
+								}
+							} else {
+								const issuerWithConfig = {
+									...issuer,
+									id: `${issuer.id}-${config.vct}`,
+									configId: config.vct,
+									selectedDisplayName: `${metadata.display.filter((display) => display.locale === 'en-US')[0].name} - ${config.display.filter((display) => display.locale === 'en-US')[0].name}` || null,
+								};
+								if (issuerWithConfig.visible) {
+									newIssuerList.push(issuerWithConfig);
+								}
 							}
 						});
 						setIssuers([...newIssuerList]);
@@ -56,6 +72,7 @@ const Issuers = () => {
 			}
 		};
 
+
 		if (openID4VCIHelper) {
 			console.log("Fetching issuers...")
 			fetchIssuers();
@@ -69,7 +86,7 @@ const Issuers = () => {
 			setShowRedirectPopup(true);
 		}
 	};
- 
+
 	const handleCancel = () => {
 		setShowRedirectPopup(false);
 		setSelectedIssuer(null);


### PR DESCRIPTION
This PR updates the UI logic to distinguish issuers based on the number of supported credential configurations. Changes are aimed at improving clarity and usability:

- Single Configuration Display: Issuers with one configuration show a straightforward ID and name.
- Multiple Configurations Display: Issuers with multiple configurations append the type to the ID and adjust the display name to include specific configuration details.
