### PR TITLE
Enhance ParsedCredential with metadataDocuments Integration

### DIFF
--- a/lib/core/src/credential-parsers/SDJWTVCParser.ts
+++ b/lib/core/src/credential-parsers/SDJWTVCParser.ts
@@ -87,12 +87,12 @@ export function SDJWTVCParser(args: { context: Context, httpClient: HttpClient }
 			const parsedClaims: Record<string, unknown> | null = await (async () => {
 				try {
 					return await SdJwt.fromCompact<Record<string, unknown>, any>(rawCredential)
-					.withHasher(hasherAndAlgorithm)
-					.getPrettyClaims()
-					.then((signedClaims) => signedClaims)
-					.catch(() => null);
+						.withHasher(hasherAndAlgorithm)
+						.getPrettyClaims()
+						.then((signedClaims) => signedClaims)
+						.catch(() => null);
 				}
-				catch(err) {
+				catch (err) {
 					return null;
 				}
 
@@ -145,6 +145,8 @@ export function SDJWTVCParser(args: { context: Context, httpClient: HttpClient }
 					metadata: {
 						credential: {
 							format: VerifiableCredentialFormat.VC_SDJWT,
+							// @ts-ignore
+							metadataDocuments: [getSdJwtMetadataResult.credentialMetadata],
 							image: {
 								dataUri: dataUri ?? "",
 							},

--- a/lib/core/src/types.ts
+++ b/lib/core/src/types.ts
@@ -18,7 +18,14 @@ export type Result<T, E> = { success: true; value: T } | { success: false; error
 export type ParsedCredential = {
 	metadata: {
 		credential: {
-			format: VerifiableCredentialFormat,
+			format: VerifiableCredentialFormat.VC_SDJWT,
+			name: string,
+			metadataDocuments: Record<string, unknown>[],
+			image: {
+				dataUri: string;
+			},
+		} | {
+			format: VerifiableCredentialFormat.MSO_MDOC,
 			name: string,
 			image: {
 				dataUri: string;


### PR DESCRIPTION
This PR introduces the inclusion of `metadataDocuments` within the `ParsedCredential` structure.
