### PR TITLE
Set maximumFileSizeToCacheInBytes in vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,9 @@ export default defineConfig({
 			filename: 'service-worker.js', // Custom service worker (MUST exist in `src/`)
 			strategies: 'injectManifest', // Uses `src/service-worker.js` for caching
 			manifest: false, // Vite will use `public/manifest.json` automatically
+			injectManifest: {
+				maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
+			},
 		}),
 
 	],


### PR DESCRIPTION
This change was required in order for build-images directive to complete without failure on the ecosystem.js script of wallet-ecosystem