### PR TITLE
Enhance Language Filtering and Deduplicate Entries on Add Credentials Page

### DIFF
--- a/src/hooks/useFilterItemByLang.js
+++ b/src/hooks/useFilterItemByLang.js
@@ -1,0 +1,21 @@
+// hooks/useFilterItemByLang.js
+
+import { useTranslation } from 'react-i18next';
+import { getLanguage } from '@/i18n';
+
+const useFilterItemByLang = () => {
+	const { i18n } = useTranslation();
+	const language = i18n.language;
+	const fallbackLang = i18n.options.fallbackLng;
+
+	const filterItemByLang = (arrayOfItems, langFieldName = 'lang') => {
+		let item = arrayOfItems.find(a => getLanguage(a[langFieldName]) === language) ||
+			arrayOfItems.find(a => getLanguage(a[langFieldName]) === fallbackLang);
+
+		return item || arrayOfItems[0] || {};
+	};
+
+	return filterItemByLang;
+};
+
+export default useFilterItemByLang;

--- a/src/pages/AddCredentials/AddCredentials.jsx
+++ b/src/pages/AddCredentials/AddCredentials.jsx
@@ -119,14 +119,14 @@ const Issuers = () => {
 			}
 		};
 
-		if (openID4VCIHelper) {
+		if (openID4VCIHelper && openID4VCI) {
 			console.log("Fetching issuers...")
 			fetchIssuers();
 		}
-	}, [api, isOnline, openID4VCIHelper]);
+	}, [api, isOnline, openID4VCIHelper, openID4VCI]);
 
 	const handleCredentialConfigurationClick = async (credentialConfigurationIdWithCredentialIssuerIdentifier) => {
-		const [credentialConfigurationId, credentialIssuerIdentifier] = credentialConfigurationIdWithCredentialIssuerIdentifier.split('-');
+    const [credentialConfigurationId] = credentialConfigurationIdWithCredentialIssuerIdentifier.split('-');
 		const clickedCredentialConfiguration = credentialConfigurations.find((conf) => conf.credentialConfigurationId === credentialConfigurationId);
 		if (clickedCredentialConfiguration) {
 			setSelectedCredentialConfiguration(clickedCredentialConfiguration);

--- a/src/pages/AddCredentials/AddCredentials.jsx
+++ b/src/pages/AddCredentials/AddCredentials.jsx
@@ -45,7 +45,7 @@ const Issuers = () => {
 
 	const getSelectedIssuerDisplay = () => {
 		const selectedIssuer = getSelectedIssuer();
-		console.log("Selected issuer " , selectedIssuer)
+		console.log("Selected issuer ", selectedIssuer)
 
 		if (selectedIssuer) {
 			const selectedDisplayBasedOnLang = selectedIssuer.display.filter((d) => d.locale === 'en-US')[0];
@@ -99,7 +99,7 @@ const Issuers = () => {
 
 							setCredentialConfigurations((currentArray) => {
 								const credentialConfigurationExists = currentArray.some(({ credentialConfigurationId, credentialIssuerIdentifier, credentialConfiguration }) =>
-									credentialConfigurationId === key
+									credentialConfigurationId === key && credentialIssuerIdentifier === metadata.credential_issuer
 								);
 								if (!credentialConfigurationExists) {
 									return [...currentArray, credentialConfiguration];
@@ -188,7 +188,7 @@ const Issuers = () => {
 					loading={loading}
 					onClose={handleCancel}
 					handleContinue={handleContinue}
-					popupTitle={`${t('pageAddCredentials.popup.title')} ${ getSelectedIssuerDisplay()?.name ?? "Unknown"}`}
+					popupTitle={`${t('pageAddCredentials.popup.title')} ${getSelectedIssuerDisplay()?.name ?? "Unknown"}`}
 					popupMessage={t('pageAddCredentials.popup.message', { issuerName: getSelectedIssuerDisplay()?.name ?? "Unknown" })}
 				/>
 			)}

--- a/src/pages/AddCredentials/AddCredentials.jsx
+++ b/src/pages/AddCredentials/AddCredentials.jsx
@@ -126,7 +126,7 @@ const Issuers = () => {
 	}, [api, isOnline, openID4VCIHelper, openID4VCI]);
 
 	const handleCredentialConfigurationClick = async (credentialConfigurationIdWithCredentialIssuerIdentifier) => {
-    const [credentialConfigurationId] = credentialConfigurationIdWithCredentialIssuerIdentifier.split('-');
+		const [credentialConfigurationId] = credentialConfigurationIdWithCredentialIssuerIdentifier.split('-');
 		const clickedCredentialConfiguration = credentialConfigurations.find((conf) => conf.credentialConfigurationId === credentialConfigurationId);
 		if (clickedCredentialConfiguration) {
 			setSelectedCredentialConfiguration(clickedCredentialConfiguration);

--- a/src/pages/AddCredentials/AddCredentials.jsx
+++ b/src/pages/AddCredentials/AddCredentials.jsx
@@ -9,6 +9,7 @@ import PageDescription from '../../components/Shared/PageDescription';
 import QueryableList from '../../components/QueryableList';
 import { useOpenID4VCIHelper } from '../../lib/services/OpenID4VCIHelper';
 import OpenID4VCIContext from '@/context/OpenID4VCIContext';
+import useFilterItemByLang from '@/hooks/useFilterItemByLang';
 
 const Issuers = () => {
 	const { isOnline } = useContext(StatusContext);
@@ -25,6 +26,7 @@ const Issuers = () => {
 	const { openID4VCI } = useContext(OpenID4VCIContext);
 
 	const { t } = useTranslation();
+	const filterItemByLang = useFilterItemByLang();
 
 	const getSelectedIssuer = () => {
 		if (selectedCredentialConfiguration) {
@@ -35,7 +37,7 @@ const Issuers = () => {
 	}
 
 	const getIssuerDisplayMetadata = (issuerMetadata) => {
-		const selectedDisplayBasedOnLang = issuerMetadata.display.filter((d) => d.locale === 'en-US')[0];
+		const selectedDisplayBasedOnLang = filterItemByLang(issuerMetadata.display, 'locale')
 		if (selectedDisplayBasedOnLang) {
 			const { name, logo } = selectedDisplayBasedOnLang;
 			return { name, logo };
@@ -48,7 +50,7 @@ const Issuers = () => {
 		console.log("Selected issuer ", selectedIssuer)
 
 		if (selectedIssuer) {
-			const selectedDisplayBasedOnLang = selectedIssuer.display.filter((d) => d.locale === 'en-US')[0];
+			const selectedDisplayBasedOnLang = filterItemByLang(selectedIssuer.display, 'locale')
 			if (selectedDisplayBasedOnLang) {
 				const { name, logo } = selectedDisplayBasedOnLang;
 				return { name, logo };
@@ -89,7 +91,7 @@ const Issuers = () => {
 
 							const credentialConfiguration = {
 								identifierField: `${key}-${metadata.credential_issuer}`,
-								credentialConfigurationDisplayName: `${config?.display?.filter((d) => d.locale === 'en-US')[0]?.name} (${getIssuerDisplayMetadata(metadata)?.name})` ?? key,
+								credentialConfigurationDisplayName: `${filterItemByLang(config?.display, 'locale').name} (${getIssuerDisplayMetadata(metadata)?.name})` ?? key,
 
 								credentialConfigurationId: key,
 								credentialIssuerIdentifier: metadata.credential_issuer,


### PR DESCRIPTION
This pull request introduces the `useFilterItemByLang` custom hook, which enhance handling of multilingual display elements.

**Key Changes:**
- **Custom Hook Implementation:** Implemented `useFilterItemByLang` to dynamically select display items based on the current language and a fallback language.
- **Duplicate Checking:** Fix logic to identify and remove duplicate entries based on both `credentialConfigurationId` and `credential_issuer`.
- **Lint Fixes:** Addressed minor lint warnings that improve code readability and maintain consistency with our coding standards.

These changes aim to refine user interactions by presenting information in the preferred language and simplifying the interface on the Add Credentials page.