### PR TITLE
Handle only data messages in service worker to avoid duplicate background notifications

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -20,9 +20,9 @@ const messaging = firebase.messaging();
 
 messaging.onBackgroundMessage(function(payload) {
 	console.log('Received background message ', payload);
-	const notificationTitle = payload.notification.title;
+	const notificationTitle = payload.data.title;
 	const notificationOptions = {
-		body: payload.notification.body,
+		body: payload.data.body,
 		data: { url: '/' },
 	};
 

--- a/src/hooks/useNewCredentialListener.js
+++ b/src/hooks/useNewCredentialListener.js
@@ -23,8 +23,8 @@ const useNewCredentialListener = () => {
 			console.log('Notification received:', payload);
 
 			const newNotification = {
-				title: payload?.notification?.title,
-				body: payload?.notification?.body,
+				title: payload?.data?.title,
+				body: payload?.data?.body,
 			};
 			// Save notification to sessionStorage
 			sessionStorage.setItem('newCredentialNotification', JSON.stringify(newNotification));


### PR DESCRIPTION
Updates the Firebase service worker to display notifications only from data messages.
Prevents duplicate notifications when Browser is closed by avoiding payload.notification.