### PR TITLE
Fix: Improve Layout Consistency and Text Overflow Handling on Add credential Page

### DIFF
--- a/src/components/QueryableList/EntityListItem.tsx
+++ b/src/components/QueryableList/EntityListItem.tsx
@@ -48,7 +48,7 @@ const DisplayNode = ({ primaryData, secondaryData, searchQuery }: EntityListItem
 			</span>
 
 			{secondaryData && (
-				<span className="flex w-max mt-1 px-2 py-1 text-sm rounded-md items-center gap-2 font-light bg-gray-200 dark:bg-gray-600 whitespace-nowrap">
+				<span className="flex max-w-max mt-1 px-2 py-1 text-sm rounded-md items-center gap-2 font-light bg-gray-200 dark:bg-gray-600 whitespace-nowrap">
 					{secondaryData?.logo?.uri && (
 						<div
 							className="h-5 w-5 flex justify-center items-center rounded-sm shrink-0 border-[0.5px] border-gray-200"
@@ -61,7 +61,9 @@ const DisplayNode = ({ primaryData, secondaryData, searchQuery }: EntityListItem
 							/>
 						</div>
 					)}
-					<span>{highlightBestSequence(secondaryData?.name, searchQuery)}</span>
+					<span className="truncate">
+						{highlightBestSequence(secondaryData?.name, searchQuery)}
+					</span>
 				</span>
 			)}
 		</span>

--- a/src/components/QueryableList/EntityListItem.tsx
+++ b/src/components/QueryableList/EntityListItem.tsx
@@ -44,7 +44,12 @@ const DisplayNode = ({ primaryData, secondaryData, searchQuery }: EntityListItem
 						<p className="font-bold">{primaryData.name?.charAt(0)}</p>
 					)}
 				</div>
-				<span>{highlightBestSequence(primaryData.name, searchQuery)}</span>
+				<span
+					className="line-clamp-2 max-w-full"
+					title={primaryData.name}
+				>
+					{highlightBestSequence(primaryData.name, searchQuery)}
+				</span>
 			</span>
 
 			{secondaryData && (

--- a/src/components/QueryableList/QueryableList.tsx
+++ b/src/components/QueryableList/QueryableList.tsx
@@ -77,7 +77,7 @@ const QueryableList = <T extends object>({
 				<div className="my-2">
 					{recentCredentialConfigurations.length > 0 && recentList.length > 0 && !searchQuery && <H3 heading={t("queryableList.recent")} />}
 					<div
-						className="space-y-2 mb-2 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2"
+						className="mb-2 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2"
 					>
 						{!searchQuery && recentCredentialConfigurations.map((el) => (
 							<Button


### PR DESCRIPTION
This PR addresses multiple UI credential types on the Add credential page to enhance visual consistency and readability across devices.

**Improvements:**

- Fixed mismatched heights of recent credential type boxes for a cleaner grid layout.
- Applied truncation to long issuer names using ellipsis to avoid overflow and layout breakage.
- Added 2-line ellipsis to credential type names to gracefully handle long names without breaking the layout.

