### PR TITLE
Make Pushed Authorization Request optional as per spec

### DIFF
--- a/src/lib/schemas/OpenidAuthorizationServerMetadataSchema.ts
+++ b/src/lib/schemas/OpenidAuthorizationServerMetadataSchema.ts
@@ -4,13 +4,18 @@ export const OpenidAuthorizationServerMetadataSchema = z.object({
 	issuer: z.string(),
 	authorization_endpoint: z.string(),
 	token_endpoint: z.string(),
-	pushed_authorization_request_endpoint: z.string(),
+	pushed_authorization_request_endpoint: z.string().optional(),
+	authorization_challenge_endpoint: z.string().optional(),
 	require_pushed_authorization_requests: z.boolean().optional(),
-	token_endpoint_auth_methods_supported: z.array(z.string()),
+	token_endpoint_auth_methods_supported: z.array(z.string()).optional(),
 	response_types_supported: z.array(z.string()),
-	code_challenge_methods_supported: z.array(z.string()),
+	code_challenge_methods_supported: z.array(z.string()).optional(),
 	dpop_signing_alg_values_supported: z.array(z.string()).optional(),
+}).refine((input: { require_pushed_authorization_requests?: boolean, pushed_authorization_request_endpoint: string }) => {
+	if (input.require_pushed_authorization_requests) {
+    return input.pushed_authorization_request_endpoint && input.pushed_authorization_request_endpoint.length > 0;
+	}
+	return true;
 });
-
 
 export type OpenidAuthorizationServerMetadata = z.infer<typeof OpenidAuthorizationServerMetadataSchema>;


### PR DESCRIPTION
The spec does not require the Pushed Authorization Request (PAR) endpoint to be in the authorization server (AS) metadata, yet the wwwallet crashes if this pushed_authorzation_server_endpoint isn't there.

This change makes it optional. It then initiates either a "normal" oidc flow, if the AS doesn't support the PAR. But intitiates a PAR if the server requires it.

This fixes issue #598.