### PR TITLE
[Meta-PR] Add test for keystore.generateKeypairs

### DIFF
--- a/src/lib/services/OpenID4VCI/CredentialRequest.ts
+++ b/src/lib/services/OpenID4VCI/CredentialRequest.ts
@@ -150,9 +150,10 @@ export function useCredentialRequest() {
 			}
 			else if (proofType === "attestation") {
 				const numberOfKeypairsToGenerate = credentialIssuerMetadata.metadata.batch_credential_issuance?.batch_size ?? 1;
-				const [{ publicKeys }, newPrivateData, keystoreCommit] = await keystore.generateKeypairs(numberOfKeypairsToGenerate);
+				const [{ keypairs }, newPrivateData, keystoreCommit] = await keystore.generateKeypairs(numberOfKeypairsToGenerate);
 				await api.updatePrivateData(newPrivateData);
 				await keystoreCommit();
+				const publicKeys = keypairs.map(kp => kp.publicKey);
 
 				const requestKeyAttestationResponse = await requestKeyAttestation(publicKeys, c_nonce);
 				if (!requestKeyAttestationResponse) {

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -81,7 +81,7 @@ export interface LocalStorageKeystore {
 	]>,
 
 	generateKeypairs(n: number): Promise<[
-		{ publicKeys: JWK[] },
+		{ keypairs: keystore.CredentialKeyPair[] },
 		AsymmetricEncryptedContainer,
 		CommitCallback,
 	]>,
@@ -423,17 +423,17 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 		),
 
 		generateKeypairs: async (n: number): Promise<[
-			{ publicKeys: JWK[] },
+			{ keypairs: keystore.CredentialKeyPair[] },
 			AsymmetricEncryptedContainer,
 			CommitCallback,
 		]> => (
 			await editPrivateData(async (originalContainer) => {
-				const [{ publicKeys }, newContainer] = await keystore.generateKeypairs(
+				const [{ keypairs }, newContainer] = await keystore.generateKeypairs(
 					originalContainer,
 					config.DID_KEY_VERSION,
 					n
 				);
-				return [{ publicKeys }, newContainer];
+				return [{ keypairs }, newContainer];
 			})
 		),
 

--- a/src/services/keystore.ts
+++ b/src/services/keystore.ts
@@ -1189,14 +1189,14 @@ export async function generateKeypairs(
 	container: OpenedContainer,
 	didKeyVersion: DidKeyVersion,
 	numberOfKeyPairs: number = 1
-): Promise<[{ publicKeys: JWK[] }, OpenedContainer]> {
+): Promise<[{ keypairs: CredentialKeyPair[] }, OpenedContainer]> {
 	const deriveKid = async (publicKey: CryptoKey) => {
 		const pubKey = await crypto.subtle.exportKey("jwk", publicKey);
 		const jwkThumbprint = await jose.calculateJwkThumbprint(pubKey as JWK, "sha256");
 		return jwkThumbprint;
 	};
 	const { newPrivateData, keypairs } = await addNewCredentialKeypairs(container, didKeyVersion, deriveKid, numberOfKeyPairs);
-	return [{ publicKeys: keypairs.map(kp => kp.publicKey) }, newPrivateData];
+	return [{ keypairs }, newPrivateData];
 }
 
 export async function generateDeviceResponse([privateData, mainKey]: [PrivateData, CryptoKey], mdocCredential: MDoc, presentationDefinition: any, mdocGeneratedNonce: string, verifierGeneratedNonce: string, clientId: string, responseUri: string): Promise<{ deviceResponseMDoc: MDoc }> {


### PR DESCRIPTION
PR #640 looks good to me, but I figured it could use a test. In making that test, I noticed a potential issue in the `generateKeypairs` signature: it only returns the public keys, but no identifiers for those keys. This was something I needed in the test in order to check afterwards that the returned keys also exist in the keystore storage.