### PR TITLE
MDoc Proximity: Hotfix for presentation history storage

### DIFF
--- a/src/lib/services/MdocAppCommunication.ts
+++ b/src/lib/services/MdocAppCommunication.ts
@@ -25,14 +25,18 @@ export function useMdocAppCommunication(): IMdocAppCommunication {
 
 	const storeVerifiablePresentation = useCallback(
 		async (presentation: string, presentationSubmission: any, identifiersOfIncludedCredentials: string[], audience: string) => {
-			await api.post('/storage/vp', {
-				presentationIdentifier: generateRandomIdentifier(32),
-				presentation,
-				presentationSubmission,
-				includedVerifiableCredentialIdentifiers: identifiersOfIncludedCredentials,
-				audience,
-				issuanceDate: new Date().toISOString(),
-			});
+			try {
+				await api.post('/storage/vp', {
+					presentationIdentifier: generateRandomIdentifier(32),
+					presentation,
+					presentationSubmission,
+					includedVerifiableCredentialIdentifiers: identifiersOfIncludedCredentials,
+					audience,
+					issuanceDate: new Date().toISOString(),
+				});
+			} catch(e) {
+				console.log("Failed to reach server: Presentation history not stored");
+			}
 		},
 		[api]
 	);


### PR DESCRIPTION
When offline, the mdoc proximity flow completes without informing the user due to an unhandled exception when trying to post the history on the server. This PR handles the exception and as a result the success page is rendered properly.