### PR TITLE
Fix stale route in NewCredentialNotification

### DIFF
--- a/src/components/Notifications/NewCredentialNotification.jsx
+++ b/src/components/Notifications/NewCredentialNotification.jsx
@@ -39,7 +39,7 @@ const NewCredentialNotification = ({ notification, clearNotification }) => {
 	}, [notification, clearNotification]);
 
 	useEffect(() => {
-		if (notification && location.pathname === '/') {
+		if (notification && window.location.pathname === '/') {
 			showToast();
 		}
 	}, [notification, location, showToast]);


### PR DESCRIPTION
Replaces location by useLocation with window.location to ensure correct path check after redirects.







