### PR TITLE
Make Pushed Authorization Request optional as per spec

### DIFF
--- a/src/lib/services/OpenID4VCI/OpenID4VCIAuthorizationRequest/OpenID4VCIAuthorizationRequest.ts
+++ b/src/lib/services/OpenID4VCI/OpenID4VCIAuthorizationRequest/OpenID4VCIAuthorizationRequest.ts
@@ -1,0 +1,62 @@
+import { IOpenID4VCIAuthorizationRequest } from "../../../interfaces/IOpenID4VCIAuthorizationRequest";
+import { OpenidAuthorizationServerMetadata } from "../../../schemas/OpenidAuthorizationServerMetadataSchema";
+import pkce from 'pkce-challenge';
+import { OpenidCredentialIssuerMetadata } from "../../../schemas/OpenidCredentialIssuerMetadataSchema";
+import { generateRandomIdentifier } from "../../../utils/generateRandomIdentifier";
+import { OpenID4VCIClientState } from "../../../types/OpenID4VCIClientState";
+import { useHttpProxy } from "../../HttpProxy/HttpProxy";
+import { useOpenID4VCIClientStateRepository } from "../../OpenID4VCIClientStateRepository";
+import { useCallback, useMemo, useContext } from "react";
+import SessionContext from "@/context/SessionContext";
+
+export function useOpenID4VCIAuthorizationRequest(): IOpenID4VCIAuthorizationRequest {
+
+	const httpProxy = useHttpProxy();
+	const openID4VCIClientStateRepository = useOpenID4VCIClientStateRepository();
+	const { keystore } = useContext(SessionContext);
+
+	const generate = useCallback(
+		async (
+			credentialConfigurationId: string,
+			issuer_state: string | undefined,
+			config: {
+				credentialIssuerIdentifier: string;
+				redirectUri: string;
+				clientId: string;
+				authorizationServerMetadata: OpenidAuthorizationServerMetadata;
+				credentialIssuerMetadata: OpenidCredentialIssuerMetadata;
+			}
+		): Promise<{ authorizationRequestURL: string }> => {
+			const userHandleB64u = keystore.getUserHandleB64u();
+
+			const { code_challenge, code_verifier } = await pkce();
+
+			const authorizationURLParams = new URLSearchParams();
+
+			const selectedCredentialConfigurationSupported = config.credentialIssuerMetadata.credential_configurations_supported[credentialConfigurationId];
+			authorizationURLParams.append("scope", selectedCredentialConfigurationSupported.scope);
+			authorizationURLParams.append("response_type", "code");
+			authorizationURLParams.append("client_id", config.clientId);
+			authorizationURLParams.append("code_challenge", code_challenge);
+			authorizationURLParams.append("code_challenge_method", "S256");
+
+			// the purpose of the "id" is to provide the "state" a random factor for unlinkability and to make OpenID4VCIClientState instances unique
+			const state = btoa(JSON.stringify({ userHandleB64u: userHandleB64u, id: generateRandomIdentifier(12) })).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+			authorizationURLParams.append("state", state);
+
+			if (issuer_state) {
+				authorizationURLParams.append("issuer_state", issuer_state);
+			}
+
+			authorizationURLParams.append("redirect_uri", config.redirectUri);
+			const authorizationRequestURL = new URL(config.authorizationServerMetadata.authorization_endpoint);
+			authorizationRequestURL.search = authorizationURLParams.toString();
+			await openID4VCIClientStateRepository.create(new OpenID4VCIClientState(userHandleB64u, config.credentialIssuerIdentifier, state, code_verifier, credentialConfigurationId))
+
+			return { authorizationRequestURL: authorizationRequestURL.toString() };
+		},
+		[httpProxy, openID4VCIClientStateRepository, keystore]
+	);
+
+	return useMemo(() => ({ generate }), [generate]);
+}


### PR DESCRIPTION
The spec does not require the Pushed Authorization Request (PAR) endpoint to be in the authorization server (AS) metadata, yet the wwwallet crashes if this pushed_authorzation_server_endpoint isn't there.

This change makes it optional. It then initiates either a "normal" oidc flow, if the AS doesn't support the PAR. But intitiates a PAR if the server requires it.

This partly fixes issue #598 .

It complements the PR in https://github.com/wwWallet/wallet-common/pull/3

Inside "our own fork" in wip/verify, we have applied a version on some of the older code that we use in our env, this was merged in https://github.com/wwWallet/wallet-frontend/pull/639 - the code was manually ported from the version at main to our version so the patches are different.


---

Some notes on the code quality:

- I chose to duplicate a lot of code from OpenID4VCIPushedAuthorizationRequest in a new OpenID4VCIAuthorizationRequest. This could be DRYd. I chose not to, to keep the intention of this change clear and focused. Please let me know if you want me to DRY up the similarities and shared logic from these two services. And if so, if you want this in this PR, or in a different PR.

- I chose to only use the PAR if it is required - not if it is optional. That makes the "common" authorization request - redirect/GET the common flow, but allows PAR if the AS requires this.  Please let me know if you want a different business logic for this.

- I chose to follow the AS metadata to determine this logic, and not some configuration option. It could be a configuration, but that would mean configuration and server-metadata must be matched and the combination validated runtime - ie. if the config option requires PAR, but the AS doesn't have PAR, this creates a complex validation issue. I opted for the simple version where the AS dictates what we can and should use in interacting with the AS.