### PR TITLE
Fix always being directed to the first issuer in the issuers list for a given credential, even if a different issuer was selected

### DIFF
--- a/src/pages/AddCredentials/AddCredentials.jsx
+++ b/src/pages/AddCredentials/AddCredentials.jsx
@@ -138,8 +138,8 @@ const AddCredentials = () => {
 	}, [api, isOnline, openID4VCIHelper, openID4VCI, filterItemByLang]);
 
 	const handleCredentialConfigurationClick = async (credentialConfigurationIdWithCredentialIssuerIdentifier) => {
-		const [credentialConfigurationId] = JSON.parse(credentialConfigurationIdWithCredentialIssuerIdentifier);
-		const clickedCredentialConfiguration = credentialConfigurations.find((conf) => conf.credentialConfigurationId === credentialConfigurationId);
+		const [credentialConfigurationId, credentialIssuerIdentifier] = JSON.parse(credentialConfigurationIdWithCredentialIssuerIdentifier);
+		const clickedCredentialConfiguration = credentialConfigurations.find((conf) => conf.credentialConfigurationId === credentialConfigurationId && conf.credentialIssuerIdentifier === credentialIssuerIdentifier);
 		if (clickedCredentialConfiguration) {
 			setSelectedCredentialConfiguration(clickedCredentialConfiguration);
 			setShowRedirectPopup(true);


### PR DESCRIPTION
Solves #660 by filtering the credential configurations list by issuer identifier as well as the current credential id.