### PR TITLE
Remove Overflow Scroll from Query List Container

### DIFF
--- a/src/components/QueryableList/QueryableList.tsx
+++ b/src/components/QueryableList/QueryableList.tsx
@@ -108,7 +108,7 @@ const QueryableList = <T extends object>({
 				</p>
 			) : (
 				<div
-					className="max-h-screen-80 overflow-y-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2"
+					className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2"
 					style={{ maxHeight: "80vh" }}
 				>
 					{filteredList.map((el) => (


### PR DESCRIPTION
This PR removes the overflow-y-auto class from the query list container to prevent unnecessary vertical scrolling.