### PR TITLE
fix: History Detail component preview of presentation

### DIFF
--- a/src/components/History/HistoryDetailContent.jsx
+++ b/src/components/History/HistoryDetailContent.jsx
@@ -32,6 +32,8 @@ const HistoryDetailContent = ({ historyItem }) => {
 						switch (parsedCredential.metadata.credential.format) {
 							case VerifiableCredentialFormat.VC_SDJWT:
 								return credentialEngine.sdJwtVerifier.verify({ rawCredential: credential, opts: {} });
+							case VerifiableCredentialFormat.DC_SDJWT:
+								return credentialEngine.sdJwtVerifier.verify({ rawCredential: credential, opts: {} });
 							case VerifiableCredentialFormat.MSO_MDOC:
 								return credentialEngine.msoMdocVerifier.verify({ rawCredential: credential, opts: {} });
 							default:


### PR DESCRIPTION
Fixed case where a user was presenting a dc+sd-jwt credential and the preview was missing