### PR TITLE
Use --no-open in start-docker to prevent Vite from trying to open browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "scripts": {
     "start": "vite",
-    "start-docker": "npx vite",
+    "start-docker": "npx vite --no-open",
     "build": "vite build",
     "preview": "vite preview",
     "test": "VITE_CJS_IGNORE_WARNING=true vitest run",


### PR DESCRIPTION
Suppresses this error when run in the Docker ecosystem:

```
wallet-frontend | Error: spawn xdg-open ENOENT
wallet-frontend |     at ChildProcess._handle.onexit (node:internal/child_process:285:19)
wallet-frontend |     at onErrorNT (node:internal/child_process:483:16)
wallet-frontend |     at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
```