### PR TITLE
Replace fork with upsteam auth0/mdl 2.2.0 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN yarn install && yarn build
 WORKDIR /home/node/app
 # Overwrite wallet-common with the remote master branch
 RUN yarn cache clean -f && yarn add /lib/wallet-common && yarn install
-RUN yarn add https://github.com/wwwallet/mdl.git#deploy
 
 FROM builder-base AS test
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@auth0/mdl": "^2.1.0",
+    "@auth0/mdl": "^2.2.0",
     "@cef-ebsi/key-did-resolver": "^1.1.0",
     "@sd-jwt/core": "^0.10.0",
     "ajv": "^8.17.1",

--- a/src/lib/services/MdocAppCommunication.ts
+++ b/src/lib/services/MdocAppCommunication.ts
@@ -1,6 +1,6 @@
 import { IMdocAppCommunication } from "../interfaces/IMdocAppCommunication";
 import { DataItem, MDoc, parse } from "@auth0/mdl";
-import { cborDecode, cborEncode } from "@auth0/mdl/lib/cbor";
+import { cborDecode, cborEncode, getCborEncodeDecodeOptions, setCborEncodeDecodeOptions } from "@auth0/mdl/lib/cbor";
 import { v4 as uuidv4 } from 'uuid';
 import { encryptMessage, decryptMessage, hexToUint8Array, uint8ArrayToBase64Url, deriveSharedSecret, getKey, uint8ArraytoHexString, getSessionTranscriptBytes, getDeviceEngagement, encryptUint8Array } from "../utils/mdocProtocol";
 import { base64url } from "jose";
@@ -60,6 +60,9 @@ export function useMdocAppCommunication(): IMdocAppCommunication {
 
 		const deviceEngagement = getDeviceEngagement(uuid, publicKeyJWK);
 
+		const options = getCborEncodeDecodeOptions();
+		options.variableMapSize = true;
+		setCborEncodeDecodeOptions(options);
 		const cbor = cborEncode(deviceEngagement);
 
 		deviceEngagementBytesRef.current = DataItem.fromData(deviceEngagement);
@@ -197,6 +200,9 @@ export function useMdocAppCommunication(): IMdocAppCommunication {
 			])],
 			status: 0
 		};
+		const options = getCborEncodeDecodeOptions();
+		options.variableMapSize = true;
+		setCborEncodeDecodeOptions(options);
 		const encoded = cborEncode(m);
 		const mdoc = parse(encoded);
 
@@ -257,6 +263,9 @@ export function useMdocAppCommunication(): IMdocAppCommunication {
 			status: 20
 		}
 
+		const options = getCborEncodeDecodeOptions();
+		options.variableMapSize = true;
+		setCborEncodeDecodeOptions(options);
 		const sessionDataEncoded = cborEncode(sessionData);
 		/* @ts-ignore */
 		const send = await nativeWrapper.bluetoothSendToServer(JSON.stringify([0, ...sessionDataEncoded]));

--- a/src/lib/utils/mdocProtocol.ts
+++ b/src/lib/utils/mdocProtocol.ts
@@ -1,4 +1,4 @@
-import { cborEncode } from "@auth0/mdl/lib/cbor";
+import { cborEncode, getCborEncodeDecodeOptions, setCborEncodeDecodeOptions } from "@auth0/mdl/lib/cbor";
 import { DataItem } from "@auth0/mdl";
 
 export async function createSessionKey(rawPublic: ArrayBuffer, ephemeralKey: CryptoKeyPair) : Promise<CryptoKey> {
@@ -165,11 +165,14 @@ export async function getKey(keyMaterial, salt, info) {
 }
 
 export function getSessionTranscriptBytes(deviceEngagementBytes, eReaderKeyBytes) {
+	const options = getCborEncodeDecodeOptions();
+	options.variableMapSize = true;
+	setCborEncodeDecodeOptions(options);
 	return cborEncode(DataItem.fromData([
 		deviceEngagementBytes, // DeviceEngagementBytes
 		eReaderKeyBytes, // EReaderKeyBytes
 		null,
-	]))
+	]));
 }
 
 export function getDeviceEngagement(uuid: string, publicKeyJWK: JsonWebKey) {

--- a/src/services/keystore.ts
+++ b/src/services/keystore.ts
@@ -1291,7 +1291,7 @@ export async function generateDeviceResponseWithProximity([privateData, mainKey]
 	const privateKeyJwk = await crypto.subtle.exportKey("jwk", privateKey);
 
 	const options = getCborEncodeDecodeOptions();
-  options.variableMapSize = true;
+	options.variableMapSize = true;
 	setCborEncodeDecodeOptions(options);
 
 	const deviceResponseMDoc = await DeviceResponse.from(mdocCredential)

--- a/src/services/keystore.ts
+++ b/src/services/keystore.ts
@@ -10,7 +10,7 @@ import * as config from '../config';
 import type { DidKeyVersion } from '../config';
 import { byteArrayEquals, filterObject, jsonParseTaggedBinary, jsonStringifyTaggedBinary, toBase64Url } from "../util";
 import { SDJwt } from "@sd-jwt/core";
-import { cborEncode, cborDecode, DataItem } from "@auth0/mdl/lib/cbor";
+import { cborEncode, cborDecode, DataItem, getCborEncodeDecodeOptions, setCborEncodeDecodeOptions } from "@auth0/mdl/lib/cbor";
 import { DeviceResponse, MDoc } from "@auth0/mdl";
 import { SupportedAlgs } from "@auth0/mdl/lib/mdoc/model/types";
 import { COSEKeyToJWK } from "cose-kit";
@@ -1289,6 +1289,10 @@ export async function generateDeviceResponseWithProximity([privateData, mainKey]
 	const { alg, did, wrappedPrivateKey } = keypair;
 	const privateKey = await unwrapPrivateKey(wrappedPrivateKey, mainKey, true);
 	const privateKeyJwk = await crypto.subtle.exportKey("jwk", privateKey);
+
+	const options = getCborEncodeDecodeOptions();
+  options.variableMapSize = true;
+	setCborEncodeDecodeOptions(options);
 
 	const deviceResponseMDoc = await DeviceResponse.from(mdocCredential)
 		.usingPresentationDefinition(presentationDefinition)

--- a/tests.Dockerfile
+++ b/tests.Dockerfile
@@ -14,7 +14,6 @@ COPY .env.template .env
 WORKDIR /home/node/app
 
 RUN yarn cache clean -f && yarn add /lib/wallet-common && yarn install
-RUN yarn add https://github.com/wwwallet/mdl.git#deploy
 
 FROM builder-base AS test
 


### PR DESCRIPTION
PR https://github.com/wwWallet/wallet-frontend/pull/596/files replaces upstream `auth0/mdl` with a fork to patch the [incompatibility with ISO 18013-5](https://github.com/auth0-lab/mdl/issues/48) CBOR map structures.

Upstream auth0/mdl released [2.2.0](https://github.com/auth0-lab/mdl/releases/tag/v2.2.0) which supports passing CBOR encoding options that can be utilized to address this. Therefore the fork is no longer needed.