### PR TITLE
Include "kid" of the keypair on the generated proof for the credential request

### DIFF
--- a/src/services/keystore.ts
+++ b/src/services/keystore.ts
@@ -1182,7 +1182,7 @@ export async function generateOpenid4vciProofs(
 			.setProtectedHeader({
 				alg: keypair.alg,
 				typ: "openid4vci-proof+jwt",
-				jwk: { ...keypair.publicKey, key_ops: ['verify'] } as JWK,
+				jwk: { ...keypair.publicKey, kid: keypair.kid, key_ops: ['verify'] } as JWK,
 			})
 			.sign(privateKey);
 		return jws;
@@ -1266,7 +1266,7 @@ export async function generateDeviceResponse([privateData, mainKey]: [PrivateDat
 	const deviceResponseMDoc = await DeviceResponse.from(mdocCredential)
 		.usingPresentationDefinition(presentationDefinition)
 		.usingSessionTranscriptBytes(sessionTranscriptBytes)
-		.authenticateWithSignature({ ...privateKeyJwk, alg } as JWK, alg as SupportedAlgs)
+		.authenticateWithSignature({ ...privateKeyJwk, alg, kid } as JWK, alg as SupportedAlgs)
 		.sign();
 	return { deviceResponseMDoc };
 }
@@ -1293,7 +1293,7 @@ export async function generateDeviceResponseWithProximity([privateData, mainKey]
 	const deviceResponseMDoc = await DeviceResponse.from(mdocCredential)
 		.usingPresentationDefinition(presentationDefinition)
 		.usingSessionTranscriptBytes(sessionTranscriptBytes)
-		.authenticateWithSignature({ ...privateKeyJwk, alg } as JWK, alg as SupportedAlgs)
+		.authenticateWithSignature({ ...privateKeyJwk, alg, kid } as JWK, alg as SupportedAlgs)
 		.sign();
 	return { deviceResponseMDoc };
 }


### PR DESCRIPTION
This PR solves the problem where "kid" in the DeviceSignature of the MdocResponse was ending up as "undefined" due to auth0/mdl library bug.

> Note: The issue needs to be raised on the auth0/mdl library public repository