### PR TITLE
Fix presentation frame to support RFC 9535 notation

### DIFF
--- a/src/lib/services/OpenID4VP/OpenID4VP.ts
+++ b/src/lib/services/OpenID4VP/OpenID4VP.ts
@@ -328,8 +328,15 @@ export function useOpenID4VP({ showCredentialSelectionPopup, showStatusPopup, sh
 						// Use the matchAll method to get all matches
 						let matches = [...path.matchAll(/\['(.*?)'\]/g)];
 
-						// Initialize an empty object to build the result
+						// grab any dot-keys before the first bracket
+						let prefix = path.replace(/\['.*$/, '').replace(/^\$\./, '');
 						let current = result;
+						if (prefix) {
+							prefix.split('.').forEach(key => {
+								current[key] = current[key] || {};
+								current = current[key];
+							});
+						}
 
 						// Iterate over each match and build the nested object
 						for (let i = 0; i < matches.length; i++) {


### PR DESCRIPTION
Companion PR https://github.com/wwWallet/wallet-ecosystem/pull/213
Second step of https://github.com/wwWallet/wallet-ecosystem/issues/212 

**Description**
After making the presentation definitions compliant with RFC 9535, i.e. moving from:
```
"path": [
    "$.age_equal_or_over.14"
  ],
```
to 
```
"path": [
      $.age_equal_or_over['14']"
  ]
  ```

the presentation frame needs adjustment so that instead of
```
{ "14": true }
```
it includes:
```
{ age_equal_or_over: { "14": true } }
```

This solves the bug of presenting `age_equal_or_over` as an empty object.

![image](https://github.com/user-attachments/assets/cf91ec41-2d76-4a11-bf60-e3091bd11ab1)

