### PR TITLE
Prefetch issuer logos and handle fallback on failed fetch

### DIFF
--- a/src/components/QueryableList/EntityListItem.tsx
+++ b/src/components/QueryableList/EntityListItem.tsx
@@ -19,7 +19,7 @@ const DisplayNode = ({ primaryData, secondaryData, searchQuery }: EntityListItem
 		const url = primaryData?.logo?.uri;
 		if (typeof url === 'string' && url.trim() !== '') {
 			proxy.get(url, {}, { useCache: true }).then(res => {
-				if (typeof res?.data === 'string') {
+				if (typeof res?.data === 'string' && res.status === 200) {
 					setPrimaryLogoSrc(res.data);
 				}
 			});
@@ -31,7 +31,7 @@ const DisplayNode = ({ primaryData, secondaryData, searchQuery }: EntityListItem
 		const url = secondaryData?.logo?.uri;
 		if (typeof url === 'string' && url.trim() !== '') {
 			proxy.get(url, {}, { useCache: true }).then(res => {
-				if (typeof res?.data === 'string') {
+				if (typeof res?.data === 'string' && res.status === 200) {
 					setSecondaryImageSrc(res.data);
 				}
 			});

--- a/src/lib/services/OpenID4VCIHelper.ts
+++ b/src/lib/services/OpenID4VCIHelper.ts
@@ -186,14 +186,16 @@ export function useOpenID4VCIHelper(): IOpenID4VCIHelper {
 					}
 				}
 
-				// Fetch logos
-				for (const uri of logoUris) {
-					try {
-						await httpProxy.get(uri, {}, { useCache: shouldUseCache });
-					} catch (err) {
-						console.error(`Failed to fetch logo from ${uri}`, err);
+				// Fetch logos in background (non-blocking)
+				void (async () => {
+					for (const uri of logoUris) {
+						try {
+							await httpProxy.get(uri, {}, { useCache: shouldUseCache });
+						} catch (err) {
+							console.error(`Failed to fetch logo from ${uri}`, err);
+						}
 					}
-				}
+				})();
 
 				if (r.mdoc_iacas_uri) {
 					try {


### PR DESCRIPTION
This PR introduces improvements to logo handling for issuers:

- Logos are now prefetched in the background during issuer metadata initialization.
- The `DisplayNode` component now gracefully handles failed logo fetches by checking if the proxy response returns status 200. If not, it falls back to showing the issuer's initials instead of a broken image.
