### PR TITLE
Fix logo rendering from URI with support for SVG and data URIs

### DIFF
--- a/src/components/QueryableList/EntityListItem.tsx
+++ b/src/components/QueryableList/EntityListItem.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useHttpProxy } from '@/lib/services/HttpProxy/HttpProxy';
 import { highlightBestSequence } from '@/components/QueryableList/highlightBestSequence';
-
+import { useProxiedImage } from '@/hooks/useProxiedImage'
 type EntityListItemProps = {
 	primaryData: any;
 	secondaryData?: any;
@@ -11,32 +11,8 @@ type EntityListItemProps = {
 const DisplayNode = ({ primaryData, secondaryData, searchQuery }: EntityListItemProps) => {
 	const proxy = useHttpProxy();
 
-	const [primaryLogoSrc, setPrimaryLogoSrc] = useState<string | null>(null);
-	const [secondaryImageSrc, setSecondaryImageSrc] = useState<string | null>(null);
-
-	// Load primary logo
-	useEffect(() => {
-		const url = primaryData?.logo?.uri;
-		if (typeof url === 'string' && url.trim() !== '') {
-			proxy.get(url, {}, { useCache: true }).then(res => {
-				if (typeof res?.data === 'string' && res.status === 200) {
-					setPrimaryLogoSrc(res.data);
-				}
-			});
-		}
-	}, [primaryData?.logo?.uri]);
-
-	// Load secondary logo
-	useEffect(() => {
-		const url = secondaryData?.logo?.uri;
-		if (typeof url === 'string' && url.trim() !== '') {
-			proxy.get(url, {}, { useCache: true }).then(res => {
-				if (typeof res?.data === 'string' && res.status === 200) {
-					setSecondaryImageSrc(res.data);
-				}
-			});
-		}
-	}, [secondaryData?.logo?.uri]);
+	const primaryLogoSrc = useProxiedImage(primaryData?.logo?.uri);
+	const secondaryImageSrc = useProxiedImage(secondaryData?.logo?.uri);
 
 	const hasTextColor = !!primaryData.text_color;
 	const hasBackgroundColor = !!primaryData.background_color;

--- a/src/hooks/useProxiedImage.ts
+++ b/src/hooks/useProxiedImage.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { useHttpProxy } from "@/lib/services/HttpProxy/HttpProxy";
+
+export const useProxiedImage = (uri?: string | null) => {
+	const proxy = useHttpProxy();
+	const [src, setSrc] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (!uri || typeof uri !== "string" || !uri.trim()) {
+			setSrc(null);
+			return;
+		}
+
+		// Handle data URIs directly (e.g. data:image/svg+xml;base64,...)
+		if (uri.startsWith("data:")) {
+			setSrc(uri);
+			return;
+		}
+
+		// Handle HTTPS or HTTP fetch via proxy
+		if (uri.startsWith("http")) {
+			proxy
+				.get(uri, {}, { useCache: true })
+				.then((res) => {
+					if (res.status === 200 && typeof res.data === "string") {
+						const contentType = String(res.headers?.["content-type"] || "");
+
+						if (contentType.includes("svg")) {
+							const svgText = res.data;
+							const encoded = btoa(
+								new TextEncoder()
+									.encode(svgText)
+									.reduce((data, byte) => data + String.fromCharCode(byte), "")
+							);
+							setSrc(`data:image/svg+xml;base64,${encoded}`);
+						} else {
+							setSrc(res.data);
+						}
+					}
+				})
+				.catch(() => setSrc(null));
+		} else {
+			console.warn("Unsupported logo URI scheme:", uri);
+			setSrc(null);
+		}
+	}, [uri, proxy]);
+
+	return src;
+};


### PR DESCRIPTION
This PR improves the handling of logo.uri values provided in issuer metadata by:

- Supporting both https: and data: URI schemes as specified.
- Detecting image/svg+xml responses and converting them to proper base64 data: URIs for safe rendering in <img> tags.

A reusable hook useProxiedImage has been introduced to abstract the logic and ensure consistent usage across components that display logos.