### PR TITLE
Simplify docker-build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,14 +6,16 @@ on:
   pull_request:
 
 jobs:
-  build-front:
+  build:
+    runs-on: ubuntu-latest
+
     permissions:
       contents: read
-      packages: read
 
-    uses: wwwallet/wallet-ecosystem/.github/workflows/docker-build-push.yml@master
-    secrets: inherit
-    with:
-      image-tag: ghcr.io/wwwallet/wallet-frontend:latest
-      docker-push: false
-      dockerfile-path: ./tests.Dockerfile
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: docker/build-push-action@v6
+      with:
+        push: false
+        file: tests.Dockerfile


### PR DESCRIPTION
This workflow no longer pushes images, so we're not using most of the functionality of `wallet-ecosystem/.github/workflows/docker-build-push.yml`. It's simpler to just inline the steps instead of referencing an external workflow.