### PR TITLE
Fix for card flickering on SelectCredentialsPopup

### DIFF
--- a/src/components/Popups/SelectCredentialsPopup.jsx
+++ b/src/components/Popups/SelectCredentialsPopup.jsx
@@ -344,7 +344,7 @@ function SelectCredentialsPopup({ popupState, setPopupState, showPopup, hidePopu
 						</p>
 						<div>
 						</div>
-						<div className={`xm:px-4 px-16 sm:px-24 md:px-8`}>
+						<div className={`xm:px-4 px-16 sm:px-24 md:px-8 ${screenType === 'desktop' && 'max-w-[600px]'}`}>
 							{vcEntities ? (
 								<Slider
 									items={vcEntities}


### PR DESCRIPTION
Fix for https://github.com/wwWallet/wallet-frontend/issues/733

By limiting the max width of the card on desktops, swiper's `onResize` function is not called endlessly, fixing the glitch.