### PR TITLE
Ensure correct nesting by sorting display claims by path depth

### DIFF
--- a/src/components/Credentials/CredentialInfo.jsx
+++ b/src/components/Credentials/CredentialInfo.jsx
@@ -134,6 +134,9 @@ const CredentialInfo = ({ parsedCredential, mainClassName = "text-sm lg:text-bas
 
 	const expandedDisplayClaims = expandDisplayClaims(filteredClaims, signedClaims);
 
+	// Ensure parents come before children to prevent overwrite issues
+	expandedDisplayClaims.sort((a, b) => a.path.length - b.path.length);
+
 	expandedDisplayClaims.forEach(claim => {
 		if (!Array.isArray(claim.path)) return;
 		if (!Array.isArray(claim.display)) return;


### PR DESCRIPTION
This PR fixes a rendering issue in the `CredentialInfo` component where child claims were being processed before their parent claims, leading to incorrect or missing nesting in the display structure.

To resolve this, the `expandedDisplayClaims` array is now sorted by the depth of each claim's path before building the nested structure. This ensures parent claims are added first, allowing child claims to nest correctly regardless of their original order in the metadata.
