### PR TITLE
Update dcql package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "asn1js": "^3.0.5",
     "autoprefixer": "^10.4.14",
     "axios": "^1.4.0",
-    "dcql": "^0.2.22",
+    "dcql": "^0.4.2",
     "wallet-common": "./lib/wallet-common",
     "cose-kit": "^1.7.1",
     "did-resolver": "^4.1.0",

--- a/src/lib/services/OpenID4VP/OpenID4VP.ts
+++ b/src/lib/services/OpenID4VP/OpenID4VP.ts
@@ -219,83 +219,73 @@ export function useOpenID4VP({ showCredentialSelectionPopup, showStatusPopup, sh
 
 		const descriptorPurpose = dcqlJson.credential_sets?.[0]?.purpose || t('selectCredentialPopup.purposeNotSpecified');
 
+		// shape all credentials in the wallet
+		const shapedCredentials: any[] = [];
+		for (const vc of vcList) {
+			let shaped: any = { credential_format: vc.format };
+			try {
+				if (vc.format === VerifiableCredentialFormat.MSO_MDOC) {
+					const credentialBytes = base64url.decode(vc.credential);
+					const issuerSigned = cborDecode(credentialBytes);
+					const [header, _, payload, sig] = issuerSigned.get('issuerAuth') as Array<Uint8Array>;
+					const decodedIssuerAuthPayload = cborDecode(payload);
+					const docType = decodedIssuerAuthPayload.data.get('docType');
+					const envelope = {
+						version: "1.0",
+						documents: [new Map([
+							["docType", docType],
+							["issuerSigned", issuerSigned],
+						])],
+						status: 0,
+					};
+					const mdoc = parse(cborEncode(envelope));
+					const [document] = mdoc.documents;
+
+					const nsName = document.issuerSignedNameSpaces[0];
+					const nsObject = document.getIssuerNameSpace(nsName);
+
+					shaped = {
+						credential_format: vc.format,
+						doctype: docType,
+						namespaces: {
+							[nsName]: nsObject
+						},
+						credentialIdentifier: vc.credentialIdentifier,
+						cryptographic_holder_binding: true
+					};
+				} else {
+					// --- SD-JWT shaping ---
+					const { signedClaims, error } = await parseCredential(vc.credential);
+					if (error) throw error;
+					shaped.vct = signedClaims.vct;
+					shaped.claims = signedClaims;
+					shaped.cryptographic_holder_binding = true;
+					shaped.credentialIdentifier = vc.credentialIdentifier;
+				}
+				shapedCredentials.push(shaped);
+			} catch (e) {
+				console.error('DCQL shaping error for this VC:', e);
+			}
+		}
+
+		const parsedQuery = DcqlQuery.parse(dcqlJson);
+		DcqlQuery.validate(parsedQuery);
+		const result = await DcqlQuery.query(parsedQuery, shapedCredentials);
+
+		// Build the mapping for each credential query
 		const mapping = new Map<string, { credentials: string[]; requestedFields: { name: string; purpose: string }[] }>();
-
 		for (const credReq of dcqlJson.credentials) {
-			const mini = { credential_sets: dcqlJson.credential_sets, credentials: [credReq] };
-			const parsed = DcqlQuery.parse(mini);
-			DcqlQuery.validate(parsed);
-
+			const match = result.credential_matches[credReq.id];
 			const conforming: string[] = [];
-
-			for (const vc of vcList) {
-				if (vc.format !== credReq.format) continue;
-
-				let shaped: any = { credential_format: vc.format };
-
-				try {
-					if (vc.format === VerifiableCredentialFormat.MSO_MDOC) {
-						const credentialBytes = base64url.decode(vc.credential);
-						const issuerSigned = cborDecode(credentialBytes);
-
-						const docType = credReq.meta?.doctype_value!;
-						const envelope = {
-							version: "1.0",
-							documents: [new Map([
-								["docType", docType],
-								["issuerSigned", issuerSigned],
-							])],
-							status: 0,
-						};
-						const mdoc = parse(cborEncode(envelope));
-						const [document] = mdoc.documents;
-
-						const nsName = document.issuerSignedNameSpaces[0];
-						const nsObject = document.getIssuerNameSpace(nsName);
-
-						shaped = {
-							credential_format: vc.format,
-							doctype: docType,
-							namespaces: {
-								[nsName]: nsObject
-							}
-						};
-					} else {
-						const { signedClaims, error } = await parseCredential(vc.credential);
-						if (error) throw error;
-						shaped.vct = signedClaims.vct;
-						if (!credReq.claims || credReq.claims.length === 0) {
-							// No claims specified in dcql_query, include all signed claims
-							shaped.claims = signedClaims;
-						} else {
-							// include only requested claims
-							shaped.claims = {};
-							for (const claim of credReq.claims) {
-								for (const p of claim.path) {
-									const v = p.split('.').reduce((o, k) => o?.[k], signedClaims);
-									if (v !== undefined) {
-										shaped.claims[p] = v;
-										break;
-									}
-								}
-							}
-						}
+			if (match?.success && match.valid_credentials) {
+				for (const vcMatch of match.valid_credentials) {
+					// Use input_credential_index to get the shaped credential
+					const shaped = shapedCredentials[vcMatch.input_credential_index];
+					if (shaped?.credentialIdentifier) {
+						conforming.push(shaped.credentialIdentifier);
 					}
-					const result = await DcqlQuery.query(parsed, [shaped]);
-
-					const match = result.credential_matches[credReq.id];
-					if (match?.success) {
-						conforming.push(vc.credentialIdentifier);
-					}
-				} catch (e) {
-					console.error('DCQL eval error for this VC:', e);
 				}
 			}
-
-			if (conforming.length === 0) {
-				return { error: HandleAuthorizationRequestError.INSUFFICIENT_CREDENTIALS };
-			}
-
 			mapping.set(credReq.id, {
 				credentials: conforming,
 				requestedFields: !credReq.claims || credReq.claims.length === 0
@@ -308,6 +298,10 @@ export function useOpenID4VP({ showCredentialSelectionPopup, showStatusPopup, sh
 			});
 		}
 
+		const allConforming = Array.from(mapping.values()).flatMap(m => m.credentials);
+		if (allConforming.length === 0) {
+			return { error: HandleAuthorizationRequestError.INSUFFICIENT_CREDENTIALS };
+		}
 		return { mapping, descriptorPurpose };
 	}
 
@@ -656,7 +650,6 @@ export function useOpenID4VP({ showCredentialSelectionPopup, showStatusPopup, sh
 				};
 
 				const sdJwt = await SDJwt.fromEncode(vcEntity.credential, hasher);
-				// TODO handle transaction data
 				const presentation = (vcEntity.credential.split("~").length - 1) > 1
 					? await sdJwt.present(frame, hasher)
 					: vcEntity.credential;
@@ -664,6 +657,7 @@ export function useOpenID4VP({ showCredentialSelectionPopup, showStatusPopup, sh
 				const shaped = {
 					credential_format: vcEntity.format,
 					vct: signedClaims.vct,
+					cryptographic_holder_binding: true,
 					claims: !descriptor.claims || descriptor.claims.length === 0
 						? signedClaims // include all claims
 						: Object.fromEntries(
@@ -673,10 +667,10 @@ export function useOpenID4VP({ showCredentialSelectionPopup, showStatusPopup, sh
 						)
 				};
 				const presResult = DcqlPresentationResult.fromDcqlPresentation(
-					{ [selectionKey]: shaped },
+					{ [selectionKey]: [shaped] },
 					{ dcqlQuery: dcql_query }
 				);
-				if (!presResult.valid_matches[selectionKey]?.success) {
+				if (!presResult.credential_matches[selectionKey]?.success) {
 					throw new Error(`Presentation for '${selectionKey}' did not satisfy DCQL`);
 				}
 

--- a/src/lib/services/OpenID4VP/OpenID4VP.ts
+++ b/src/lib/services/OpenID4VP/OpenID4VP.ts
@@ -289,7 +289,7 @@ export function useOpenID4VP({ showCredentialSelectionPopup, showStatusPopup, sh
 			mapping.set(credReq.id, {
 				credentials: conforming,
 				requestedFields: !credReq.claims || credReq.claims.length === 0
-					? [{ name: t('selectCredentialPopup.allClaimsRequested'), purpose: descriptorPurpose, path: ['*'] }]
+					? [{ name: t('selectCredentialPopup.allClaimsRequested'), purpose: descriptorPurpose, path: [null] }]
 					: credReq.claims.map(cl => ({
 						name: cl.id || cl.path.join('.'),
 						purpose: descriptorPurpose,


### PR DESCRIPTION
- Update `dcql` package
- Refactor  DCQL credential matching logic to run the full DCQL query against all shaped wallet credentials at once, instead of per-credential mini queries. This enables correct handling of credential sets and ensures the DCQL engine can validate multi-credential requirements as intended.

