### PR TITLE
Removed orientation from Web Manifest to avoid Chromium PWA bug

### DIFF
--- a/vite-plugins/manifest.ts
+++ b/vite-plugins/manifest.ts
@@ -65,7 +65,6 @@ export function generateManifest(env): Partial<ManifestOptions> {
 		],
 		"start_url": "/",
 		"display": "standalone",
-		"orientation": "any",
 		"theme_color": "#111827",
 		"description": `${process.env.VITE_STATIC_NAME || 'wwWallet'} enables secure storage and management of verifiable credentials.`,
 		"background_color": "#ffffff",


### PR DESCRIPTION
This fix seems to effectively correct the behavior described in https://github.com/wwWallet/wallet-frontend/issues/519. Looks like `orientation: any` has a weird effect on Chromium, this patch could be reverted when the issue gets fixes on the browser.