### PR TITLE
Unify credential name logic via `useCredentialName` hook

### DIFF
--- a/src/components/Credentials/CredentialGridCard.jsx
+++ b/src/components/Credentials/CredentialGridCard.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import i18n from '@/i18n';
+import { useCredentialName } from '@/hooks/useCredentialName';
+import CredentialImage from './CredentialImage';
+
+const CredentialGridCard = ({ vcEntity, onClick, latestCredentials }) => {
+	const { t } = useTranslation();
+
+	const credentialName = useCredentialName(
+		vcEntity?.parsedCredential?.metadata?.credential?.name,
+		vcEntity?.id,
+		i18n.language
+	);
+
+	return (
+		<button
+			id={`credential-grid-${vcEntity.id}`}
+			className={`relative rounded-xl transition-shadow shadow-md hover:shadow-lg cursor-pointer ${latestCredentials.has(vcEntity.id) ? 'highlight-border fade-in' : ''
+				}`}
+			onClick={() => onClick(vcEntity)}
+			aria-label={credentialName}
+			title={t('pageCredentials.credentialDetailsTitle', {
+				credentialName: credentialName,
+			})}
+		>
+			<CredentialImage
+				vcEntity={vcEntity}
+				vcEntityInstances={vcEntity.instances}
+				parsedCredential={vcEntity.parsedCredential}
+				className={`w-full h-full object-cover rounded-xl ${latestCredentials.has(vcEntity.id) ? 'highlight-filter' : ''
+					}`}
+			/>
+		</button>
+	);
+};
+
+export default CredentialGridCard;

--- a/src/components/Credentials/CredentialImage.jsx
+++ b/src/components/Credentials/CredentialImage.jsx
@@ -4,7 +4,7 @@ import UsagesRibbon from "./UsagesRibbon";
 import DefaultCred from "../../assets/images/cred.png";
 import { CredentialCardSkeleton } from '../Skeletons';
 
-const CredentialImage = ({ vcEntity, className, onClick, showRibbon = true, vcEntityInstances = null, filter = null }) => {
+const CredentialImage = ({ vcEntity, className, onClick, showRibbon = true, vcEntityInstances = null, filter = null, onLoad, }) => {
 	const [imageSrc, setImageSrc] = useState(undefined);
 
 	useEffect(() => {
@@ -14,6 +14,7 @@ const CredentialImage = ({ vcEntity, className, onClick, showRibbon = true, vcEn
 			const imageFn = vcEntity?.parsedCredential?.metadata?.credential?.image?.dataUri;
 			if (!imageFn) {
 				setImageSrc(DefaultCred);
+				onLoad?.();
 				return;
 			}
 
@@ -21,6 +22,7 @@ const CredentialImage = ({ vcEntity, className, onClick, showRibbon = true, vcEn
 				const uri = await (filter !== null ? imageFn(filter) : imageFn());
 				if (isMounted && uri) {
 					setImageSrc(uri);
+					onLoad?.();
 				} else {
 					setImageSrc(DefaultCred);
 				}
@@ -28,6 +30,7 @@ const CredentialImage = ({ vcEntity, className, onClick, showRibbon = true, vcEn
 				console.warn('Failed to load credential image:', error);
 				if (isMounted) {
 					setImageSrc(DefaultCred);
+					onLoad?.();
 				}
 			}
 		}

--- a/src/components/Credentials/CredentialLayout.jsx
+++ b/src/components/Credentials/CredentialLayout.jsx
@@ -17,6 +17,7 @@ import { H1 } from '../Shared/Heading';
 import CredentialImage from './CredentialImage';
 import FullscreenPopup from '../Popups/FullscreenImg';
 import PageDescription from '../Shared/PageDescription';
+import CredentialGridCard from './CredentialGridCard';
 
 const UsageStats = ({ zeroSigCount, sigTotal, screenType, t }) => {
 	if (zeroSigCount === null || sigTotal === null) return null;
@@ -40,11 +41,10 @@ const UsageStats = ({ zeroSigCount, sigTotal, screenType, t }) => {
 	);
 };
 
-const CredentialLayout = ({ children, title = null, displayCredentialInfo = null }) => {
+const CredentialLayout = ({ children, title = null, displayCredentialInfo = null, credentialName = "" }) => {
 	const { credentialId } = useParams();
 	const screenType = useScreenType();
 	const [showFullscreenImgPopup, setShowFullscreenImgPopup] = useState(false);
-	const [credentialFiendlyName, setCredentialFriendlyName] = useState(null);
 	const { t } = useTranslation();
 	const navigate = useNavigate();
 	const [zeroSigCount, setZeroSigCount] = useState(null)
@@ -57,7 +57,6 @@ const CredentialLayout = ({ children, title = null, displayCredentialInfo = null
 		if (vcEntity) {
 			setZeroSigCount(vcEntity.instances.filter(instance => instance.sigCount === 0).length || 0);
 			setSigTotal(vcEntity.instances.length);
-			setCredentialFriendlyName(vcEntity.parsedCredential.metadata.credential.name);
 		}
 	}, [vcEntity]);
 
@@ -72,8 +71,8 @@ const CredentialLayout = ({ children, title = null, displayCredentialInfo = null
 			id="show-full-screen-credential"
 			className="relative rounded-xl xm:rounded-lg w-full overflow-hidden transition-shadow shadow-md hover:shadow-lg cursor-pointer"
 			onClick={onClick}
-			aria-label={ariaLabel ?? credentialFiendlyName}
-			title={title ?? t('pageCredentials.credentialFullScreenTitle', { friendlyName: credentialFiendlyName })}
+			aria-label={ariaLabel ?? credentialName}
+			title={title ?? t('pageCredentials.credentialFullScreenTitle', { friendlyName: credentialName })}
 		>
 			<CredentialImage
 				vcEntity={vcEntity}
@@ -121,7 +120,7 @@ const CredentialLayout = ({ children, title = null, displayCredentialInfo = null
 				</div>
 				{screenType === 'mobile' && (
 					<div className='flex flex-start flex-col gap-1'>
-						<p className='text-xl font-bold text-primary dark:text-white'>{credentialFiendlyName}</p>
+						<p className='text-xl font-bold text-primary dark:text-white'>{credentialName}</p>
 						<UsageStats zeroSigCount={zeroSigCount} sigTotal={sigTotal} screenType={screenType} t={t} />
 
 					</div>
@@ -155,7 +154,7 @@ const CredentialLayout = ({ children, title = null, displayCredentialInfo = null
 				>
 					<FaArrowRight size={20} className="mx-2 text-2xl mb-2 text-primary dark:text-primary-light" />
 
-					<H1 heading={credentialFiendlyName} hr={false} />
+					<H1 heading={credentialName} hr={false} />
 				</H1>
 			) : (
 				<div className='flex'>

--- a/src/components/Credentials/CredentialSlideCard.jsx
+++ b/src/components/Credentials/CredentialSlideCard.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import i18n from '@/i18n';
+import CredentialImage from './CredentialImage';
+import { useCredentialName } from '@/hooks/useCredentialName';
+
+const CredentialSlideCard = ({ vcEntity, isActive, latestCredentials, onClick }) => {
+	const { t } = useTranslation();
+
+	const credentialName = useCredentialName(
+		vcEntity?.parsedCredential?.metadata?.credential?.name,
+		vcEntity?.id,
+		[i18n.language]
+	);
+
+	return (
+		<button
+			id={`credential-slide-${vcEntity.id}`}
+			className={`relative rounded-xl w-full transition-shadow shadow-md hover:shadow-lg cursor-pointer ${latestCredentials.has(vcEntity.id) ? 'fade-in' : ''
+				}`}
+			onClick={() => onClick(vcEntity)}
+			aria-label={credentialName ?? ''}
+			tabIndex={isActive ? 0 : -1}
+			title={t('pageCredentials.credentialFullScreenTitle', {
+				credentialName: credentialName,
+			})}
+		>
+			<CredentialImage
+				vcEntity={vcEntity}
+				vcEntityInstances={vcEntity.instances}
+				showRibbon={isActive}
+				parsedCredential={vcEntity.parsedCredential}
+				className={`w-full h-full object-cover rounded-xl ${latestCredentials.has(vcEntity.id) ? 'highlight-filter' : ''
+					}`}
+			/>
+		</button>
+	);
+};
+
+export default CredentialSlideCard;

--- a/src/components/History/HistoryDetailContent.jsx
+++ b/src/components/History/HistoryDetailContent.jsx
@@ -61,8 +61,6 @@ const HistoryDetailContent = ({ historyItem }) => {
 		<div
 			key={index}
 			className="relative rounded-xl w-full transition-shadow shadow-md hover:shadow-lg"
-			aria-label={vcEntity.parsedCredential.metadata.credential.name}
-			title={vcEntity.parsedCredential.metadata.credential.name}
 		>
 			<CredentialImage vcEntity={vcEntity} showRibbon={false} className="w-full h-full rounded-xl" />
 		</div>

--- a/src/components/Popups/SelectCredentialsPopup.jsx
+++ b/src/components/Popups/SelectCredentialsPopup.jsx
@@ -11,6 +11,69 @@ import CredentialCardSkeleton from '../Skeletons/CredentialCardSkeleton';
 import { CredentialInfoSkeleton } from '../Skeletons';
 import { truncateByWords } from '@/functions/truncateWords';
 import { MdFactCheck } from "react-icons/md";
+import { useCredentialName } from '@/hooks/useCredentialName';
+import i18n from '@/i18n';
+
+const SelectableCredentialSlideCard = ({
+	vcEntity,
+	isActive,
+	isSelected,
+	onClick
+}) => {
+	const { t } = useTranslation();
+	const [imageLoaded, setImageLoaded] = useState(false);
+
+	const credentialName = useCredentialName(
+		vcEntity?.parsedCredential?.metadata?.credential?.name,
+		vcEntity?.id,
+		[i18n.language]
+	);
+
+	return (
+		<button
+			id={`slider-select-credentials-${vcEntity.id}`}
+			className="relative w-full rounded-xl transition-shadow shadow-md hover:shadow-xl cursor-pointer"
+			tabIndex={isActive ? 0 : -1}
+			onClick={() => onClick(vcEntity.credentialIdentifier)}
+			aria-label={credentialName}
+			title={t('selectCredentialPopup.credentialSelectTitle', {
+				friendlyName: credentialName,
+			})}
+		>
+			<CredentialImage
+				vcEntity={vcEntity}
+				vcEntityInstances={vcEntity.instances}
+				key={vcEntity.credentialIdentifier}
+				parsedCredential={vcEntity.parsedCredential}
+				className="w-full object-cover rounded-xl"
+				showRibbon={isActive}
+				onLoad={() => setImageLoaded(true)}
+			/>
+
+			{imageLoaded && (
+				<>
+					<div
+						className={`absolute inset-0 rounded-xl transition-opacity bg-white/50 ${isSelected ? 'opacity-0' : 'opacity-50'
+							}`}
+					/>
+					<div className="absolute bottom-4 right-4 z-60">
+						{isSelected ? (
+							<FaCheckCircle
+								size={30}
+								className="z-50 rounded-full bg-white text-primary dark:text-primary-light"
+							/>
+						) : (
+							<FaRegCircle
+								size={30}
+								className="z-50 rounded-full bg-white/50 text-primary dark:text-primary-light"
+							/>
+						)}
+					</div>
+				</>
+			)}
+		</button>
+	);
+};
 
 const formatTitle = (title) => {
 	if (title) {
@@ -227,36 +290,6 @@ function SelectCredentialsPopup({ popupState, setPopupState, showPopup, hidePopu
 		return null;
 	};
 
-	const renderSlideContent = (vcEntity) => (
-		<button
-			id={`slider-select-credentials-${vcEntity.id}`}
-			key={vcEntity.id}
-			className="relative rounded-xl transition-shadow shadow-md hover:shadow-xl cursor-pointer"
-			tabIndex={currentSlide !== vcEntities.indexOf(vcEntity) + 1 ? -1 : 0}
-			onClick={() => handleClick(vcEntity.credentialIdentifier)}
-			aria-label={`${vcEntity.parsedCredential.metadata.credential.name}`}
-			title={t('selectCredentialPopup.credentialSelectTitle', { friendlyName: vcEntity.parsedCredential.metadata.credential.name })}
-		>
-			<CredentialImage
-				vcEntity={vcEntity}
-				vcEntityInstances={vcEntity.instances}
-				key={vcEntity.credentialIdentifier}
-				parsedCredential={vcEntity.parsedCredential}
-				className="w-full object-cover rounded-xl"
-				showRibbon={currentSlide === vcEntities.indexOf(vcEntity) + 1}
-			/>
-
-			<div className={`absolute inset-0 rounded-xl transition-opacity bg-white/50 ${selectedCredential === vcEntity.credentialIdentifier ? 'opacity-0' : 'opacity-50'}`} />
-			<div className="absolute bottom-4 right-4 z-60">
-				{selectedCredential === vcEntity.credentialIdentifier ? (
-					<FaCheckCircle size={30} className="z-50 rounded-full bg-white text-primary dark:text-primary-light" />
-				) : (
-					<FaRegCircle size={30} className="z-50 rounded-full bg-white/50 text-primary dark:text-primary-light" />
-				)}
-			</div>
-		</button>
-	);
-
 	return (
 		<PopupLayout isOpen={popupState?.isOpen} onClose={onClose} loading={false} fullScreen={screenType !== 'desktop'} padding="p-0" shouldCloseOnOverlayClick={false}>
 			<div className={`${screenType === 'desktop' && 'p-4'}`}>
@@ -392,7 +425,15 @@ function SelectCredentialsPopup({ popupState, setPopupState, showPopup, hidePopu
 							{vcEntities && vcEntities.length ? (
 								<Slider
 									items={vcEntities}
-									renderSlideContent={renderSlideContent}
+									renderSlideContent={(vcEntity, index) => (
+										<SelectableCredentialSlideCard
+											key={vcEntity.id}
+											vcEntity={vcEntity}
+											isActive={currentSlide === index + 1}
+											isSelected={selectedCredential === vcEntity.credentialIdentifier}
+											onClick={handleClick}
+										/>
+									)}
 									onSlideChange={(currentIndex) => setCurrentSlide(currentIndex + 1)}
 								/>
 							) : (

--- a/src/context/CredentialsContextProvider.tsx
+++ b/src/context/CredentialsContextProvider.tsx
@@ -43,7 +43,7 @@ export const CredentialsContextProvider = ({ children }) => {
 		setCredentialEngine(engine);
 	}, [httpProxy, helper, getExternalEntity]);
 
-		useEffect(() => {
+	useEffect(() => {
 		if (httpProxy && helper) {
 			if (prevIsLoggedIn.current === false && isLoggedIn === true) {
 				console.log("[CredentialsContext] Detected login transition, initializing without cache");
@@ -146,15 +146,29 @@ export const CredentialsContextProvider = ({ children }) => {
 		return filteredVcEntityList;
 	}, [get, parseCredential, credentialEngine]);
 
-	const updateVcListAndLatestCredentials = (vcEntityList: ExtendedVcEntity[]) => {
-		setLatestCredentials(new Set(vcEntityList.filter(vc => vc.id === vcEntityList[0].id).map(vc => vc.id)));
+	const updateVcListAndLatestCredentials = useCallback(
+		(newVcEntityList: ExtendedVcEntity[], setLatest: boolean) => {
+			if (setLatest && newVcEntityList.length > 0) {
+				setLatestCredentials(new Set(newVcEntityList.filter(vc => vc.id === newVcEntityList[0].id).map(vc => vc.id)));
 
-		setTimeout(() => {
-			setLatestCredentials(new Set());
-		}, 2000);
+				setTimeout(() => {
+					setLatestCredentials(new Set());
+				}, 2000);
+			}
 
-		setVcEntityList(vcEntityList);
-	};
+			setVcEntityList((prev) => {
+				if (
+					!prev ||
+					prev.length !== newVcEntityList.length ||
+					prev.some((vc, i) => vc.id !== newVcEntityList[i].id)
+				) {
+					return newVcEntityList;
+				}
+				return prev;
+			});
+		},
+		[setVcEntityList, setLatestCredentials]
+	);
 
 	const pollForCredentials = useCallback(() => {
 		if (isPollingActive) {
@@ -174,7 +188,7 @@ export const CredentialsContextProvider = ({ children }) => {
 			if (previousSize < vcEntityList.length) {
 				console.log('Found new credentials, stopping polling');
 				stopPolling();
-				updateVcListAndLatestCredentials(vcEntityList);
+				updateVcListAndLatestCredentials(vcEntityList, true);
 			}
 
 			if (attempts >= 5) {
@@ -191,21 +205,22 @@ export const CredentialsContextProvider = ({ children }) => {
 			const uniqueIdentifiers = new Set(previousVcList?.vc_list.map(vc => vc.credentialIdentifier));
 			const previousSize = uniqueIdentifiers.size;
 
-			const vcEntityList = await fetchVcData();
-			const newCredentialsFound = previousSize < vcEntityList.length;
+			const newVcEntityList = await fetchVcData();
+			const newCredentialsFound = previousSize < newVcEntityList.length;
 
 			if (shouldPoll && !newCredentialsFound) {
 				window.history.replaceState({}, '', `/`);
 				console.log("No new credentials, starting polling");
-				setVcEntityList(vcEntityList);
+				setVcEntityList(newVcEntityList);
+				updateVcListAndLatestCredentials(newVcEntityList, false);
 				pollForCredentials();
 			} else if (newCredentialsFound) {
 				window.history.replaceState({}, '', `/`);
 				stopPolling();
 				console.log("Found new credentials, no need to poll");
-				updateVcListAndLatestCredentials(vcEntityList);
+				updateVcListAndLatestCredentials(newVcEntityList, true);
 			} else {
-				setVcEntityList(vcEntityList);
+				updateVcListAndLatestCredentials(newVcEntityList, false);
 			}
 		} catch (error) {
 			console.error('Failed to fetch data', error);

--- a/src/hooks/useCredentialName.ts
+++ b/src/hooks/useCredentialName.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect, useCallback } from 'react';
+
+export function useCredentialName(
+	credentialNameFn?: (langs?: string[]) => Promise<string | null>,
+	credentialId?: string,
+	preferredLangs: string[] = ['en-US']
+): string | null {
+	const [name, setName] = useState<string | null>(null);
+
+	const fetchName = useCallback(() => {
+		if (!credentialNameFn) return Promise.resolve(null);
+		return credentialNameFn(preferredLangs);
+	}, [credentialNameFn, ...preferredLangs]);
+
+	useEffect(() => {
+		let isMounted = true;
+		fetchName().then((resolvedName) => {
+			if (isMounted) setName(resolvedName ?? null);
+		}).catch(() => {
+			if (isMounted) setName(null);
+		});
+
+		return () => {
+			isMounted = false;
+		};
+	}, [credentialId, fetchName]);
+
+	return name;
+}

--- a/src/pages/Home/Credential.jsx
+++ b/src/pages/Home/Credential.jsx
@@ -4,10 +4,12 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation, Trans } from 'react-i18next';
 import { BsQrCode, BsCheckCircle } from "react-icons/bs";
 import QRCode from "react-qr-code";
+import i18n from '@/i18n';
 
 // Contexts
 import SessionContext from '@/context/SessionContext';
 import CredentialsContext from '@/context/CredentialsContext';
+import { useCredentialName } from '@/hooks/useCredentialName';
 
 // Hooks
 import useFetchPresentations from '../../hooks/useFetchPresentations';
@@ -49,6 +51,12 @@ const Credential = () => {
 
 	const { vcEntityList, fetchVcData } = useContext(CredentialsContext);
 	const vcEntity = useVcEntity(fetchVcData, vcEntityList, credentialId);
+
+	const credentialName = useCredentialName(
+		vcEntity?.parsedCredential?.metadata?.credential?.name,
+		vcEntity?.id,
+		[i18n.language]
+	);
 
 	const handleSureDelete = async () => {
 		setLoading(true);
@@ -140,7 +148,8 @@ const Credential = () => {
 	];
 
 	return (
-		<CredentialLayout title={t('pageCredentials.credentialTitle')} displayCredentialInfo={vcEntity && <CredentialInfo parsedCredential={vcEntity.parsedCredential} />}>
+
+		<CredentialLayout title={t('pageCredentials.credentialTitle')} displayCredentialInfo={vcEntity && <CredentialInfo parsedCredential={vcEntity.parsedCredential} />} credentialName={credentialName ?? ""}>
 			<>
 				<div className="w-full pt-2 px-2">
 					{screenType !== 'mobile' ? (
@@ -172,45 +181,45 @@ const Credential = () => {
 					)}
 				</div>
 				<div className='px-2 w-full'>
-				{shareWithQr && (<Button variant='primary' additionalClassName='w-full my-2' onClick={generateQR}>{<span className='px-1'><BsQrCode/></span>}{t('qrShareMdoc.shareUsingQR')}</Button>)}
+					{shareWithQr && (<Button variant='primary' additionalClassName='w-full my-2' onClick={generateQR}>{<span className='px-1'><BsQrCode /></span>}{t('qrShareMdoc.shareUsingQR')}</Button>)}
 					<PopupLayout fullScreen={true} isOpen={showMdocQR}>
-					<div className="flex items-start justify-between mb-2">
-						<h2 className="text-lg font-bold mb-2 text-primary dark:text-white">
-							{t('qrShareMdoc.shareUsingQR')}
-						</h2>
+						<div className="flex items-start justify-between mb-2">
+							<h2 className="text-lg font-bold mb-2 text-primary dark:text-white">
+								{t('qrShareMdoc.shareUsingQR')}
+							</h2>
 						</div>
 						<hr className="mb-2 border-t border-primary/80 dark:border-white/80" />
 						<span>
-								{mdocQRStatus === -1 && <span className="text-gray-700 italic dark:text-white text-sm mt-2 mb-4">{t('qrShareMdoc.enablePermissions')}</span>}
-								{mdocQRStatus === 0 && <div className='flex items-center justify-center'><QRCode value={mdocQRContent} /></div>}
-								{(mdocQRStatus === 1 || mdocQRStatus === 3) && <span className="text-gray-700 italic dark:text-white text-sm mt-2 mb-4">{t('qrShareMdoc.communicating')}</span>}
-								{mdocQRStatus === 2 && <span className='pb-16'>
-									<p className="text-gray-700 dark:text-white text-sm mt-2 mb-4">
-										{t('qrShareMdoc.nearbyVerifierRequested')}{' '}
-										<strong>
-											{
-												shareWithQrFilter.map(key => key.split("_").map(word => `${word[0].toUpperCase()}${word.slice(1)}`).join(" ")).join(", ")
-											}
-										</strong>
-									</p>
-									<CredentialImage
-										vcEntity={vcEntity}
-										key={vcEntity.credentialIdentifier}
-										parsedCredential={vcEntity.parsedCredential}
-										className="w-full object-cover rounded-xl"
-									/>
-									<div className={`flex flex-wrap justify-center flex flex-row justify-center items-center mb-2 pb-[20px] ${screenType === 'desktop' && 'overflow-y-auto items-center custom-scrollbar max-h-[20vh]'} ${screenType === 'tablet' && 'px-24'}`}>
-										{vcEntity && <CredentialInfo mainClassName={"text-xs w-full"} parsedCredential={vcEntity.parsedCredential}/>}
-									</div>
-									<div className={`flex justify-between pt-4 z-10 ${screenType !== 'desktop' && 'fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 flex px-6 pb-6 flex shadow-2xl rounded-t-lg w-auto'}`}>
-										<Button variant='cancel' onClick={cancelShare}>{t('common.cancel')}</Button>
-										<Button variant='primary' onClick={consentToShare}>{t('qrShareMdoc.send')}</Button>
-									</div>
-									</span>}
-								{mdocQRStatus === 4 && <span className='flex items-center justify-center mt-10'><BsCheckCircle color='green' size={100}/></span>}
-								{![1,2].includes(mdocQRStatus) &&
-									<div className={`flex justify-end pt-4 z-10 ${screenType !== 'desktop' && 'fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 flex px-6 pb-6 flex shadow-2xl rounded-t-lg w-auto'}`}>
-										<Button variant='primary' onClick={() => setShowMdocQR(false)}>{t('messagePopup.close')}</Button>
+							{mdocQRStatus === -1 && <span className="text-gray-700 italic dark:text-white text-sm mt-2 mb-4">{t('qrShareMdoc.enablePermissions')}</span>}
+							{mdocQRStatus === 0 && <div className='flex items-center justify-center'><QRCode value={mdocQRContent} /></div>}
+							{(mdocQRStatus === 1 || mdocQRStatus === 3) && <span className="text-gray-700 italic dark:text-white text-sm mt-2 mb-4">{t('qrShareMdoc.communicating')}</span>}
+							{mdocQRStatus === 2 && <span className='pb-16'>
+								<p className="text-gray-700 dark:text-white text-sm mt-2 mb-4">
+									{t('qrShareMdoc.nearbyVerifierRequested')}{' '}
+									<strong>
+										{
+											shareWithQrFilter.map(key => key.split("_").map(word => `${word[0].toUpperCase()}${word.slice(1)}`).join(" ")).join(", ")
+										}
+									</strong>
+								</p>
+								<CredentialImage
+									vcEntity={vcEntity}
+									key={vcEntity.credentialIdentifier}
+									parsedCredential={vcEntity.parsedCredential}
+									className="w-full object-cover rounded-xl"
+								/>
+								<div className={`flex flex-wrap justify-center flex flex-row justify-center items-center mb-2 pb-[20px] ${screenType === 'desktop' && 'overflow-y-auto items-center custom-scrollbar max-h-[20vh]'} ${screenType === 'tablet' && 'px-24'}`}>
+									{vcEntity && <CredentialInfo mainClassName={"text-xs w-full"} parsedCredential={vcEntity.parsedCredential} />}
+								</div>
+								<div className={`flex justify-between pt-4 z-10 ${screenType !== 'desktop' && 'fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 flex px-6 pb-6 flex shadow-2xl rounded-t-lg w-auto'}`}>
+									<Button variant='cancel' onClick={cancelShare}>{t('common.cancel')}</Button>
+									<Button variant='primary' onClick={consentToShare}>{t('qrShareMdoc.send')}</Button>
+								</div>
+							</span>}
+							{mdocQRStatus === 4 && <span className='flex items-center justify-center mt-10'><BsCheckCircle color='green' size={100} /></span>}
+							{![1, 2].includes(mdocQRStatus) &&
+								<div className={`flex justify-end pt-4 z-10 ${screenType !== 'desktop' && 'fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 flex px-6 pb-6 flex shadow-2xl rounded-t-lg w-auto'}`}>
+									<Button variant='primary' onClick={() => setShowMdocQR(false)}>{t('messagePopup.close')}</Button>
 								</div>}
 						</span>
 					</PopupLayout>
@@ -228,7 +237,7 @@ const Credential = () => {
 						message={
 							<Trans
 								i18nKey="pageCredentials.deletePopupMessage"
-								values={{ credentialName: vcEntity.parsedCredential.metadata.credential.name }}
+								values={{ credentialName }}
 								components={{ strong: <strong />, br: <br /> }}
 							/>
 						}

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -2,6 +2,7 @@
 import React, { useContext, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import i18n from '@/i18n';
 
 // Contexts
 import SessionContext from '@/context/SessionContext';
@@ -18,6 +19,8 @@ import AddCredentialCard from '../../components/Credentials/AddCredentialCard';
 import HistoryList from '../../components/History/HistoryList';
 import Slider from '../../components/Shared/Slider';
 import { CredentialCardSkeleton } from '@/components/Skeletons';
+import CredentialGridCard from '@/components/Credentials/CredentialGridCard';
+import CredentialSlideCard from '@/components/Credentials/CredentialSlideCard';
 
 const Home = () => {
 	const { vcEntityList, latestCredentials, getData, currentSlide, setCurrentSlide } = useContext(CredentialsContext);
@@ -39,26 +42,6 @@ const Home = () => {
 		navigate(`/credential/${vcEntity.credentialIdentifier}`);
 	};
 
-	const renderSlideContent = (vcEntity) => (
-		<button
-			id={`credential-slide-${vcEntity.id}`}
-			key={vcEntity.id}
-			className={`relative rounded-xl w-full transition-shadow shadow-md hover:shadow-lg cursor-pointer ${latestCredentials.has(vcEntity.id) ? 'fade-in' : ''}`}
-			onClick={() => { handleImageClick(vcEntity); }}
-			aria-label={`${vcEntity?.parsedCredential?.metadata?.credential?.name}`}
-			tabIndex={currentSlide !== vcEntityList.indexOf(vcEntity) + 1 ? -1 : 0}
-			title={t('pageCredentials.credentialFullScreenTitle', { friendlyName: vcEntity?.parsedCredential?.metadata?.credential.name })}
-		>
-			<CredentialImage
-				vcEntity={vcEntity}
-				vcEntityInstances={vcEntity.instances}
-				showRibbon={currentSlide === vcEntityList.indexOf(vcEntity) + 1}
-				parsedCredential={vcEntity.parsedCredential}
-				className={`w-full h-full object-cover rounded-xl ${latestCredentials.has(vcEntity.id) ? 'highlight-filter' : ''}`}
-			/>
-		</button>
-	);
-
 	return (
 		<>
 			<div className="sm:px-6 w-full">
@@ -79,7 +62,15 @@ const Home = () => {
 										<div className='xm:px-4 px-12 sm:px-20'>
 											<Slider
 												items={vcEntityList}
-												renderSlideContent={renderSlideContent}
+												renderSlideContent={(vcEntity, index) => (
+													<CredentialSlideCard
+														key={vcEntity.id}
+														vcEntity={vcEntity}
+														isActive={currentSlide === index + 1}
+														latestCredentials={latestCredentials}
+														onClick={handleImageClick}
+													/>
+												)}
 												initialSlide={currentSlide}
 												onSlideChange={(currentIndex) => setCurrentSlide(currentIndex + 1)}
 											/>
@@ -98,21 +89,12 @@ const Home = () => {
 								) : (
 									<div className="grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 md:gap-5 lg:gap-10 lg:grid-cols-2 xl:grid-cols-3">
 										{vcEntityList && vcEntityList.map((vcEntity) => (
-											<button
-												id={`credential-grid-${vcEntity.id}`}
+											<CredentialGridCard
 												key={vcEntity.id}
-												className={`relative rounded-xl transition-shadow shadow-md hover:shadow-lg cursor-pointer ${latestCredentials.has(vcEntity.id) ? 'highlight-border fade-in' : ''}`}
-												onClick={() => handleImageClick(vcEntity)}
-												aria-label={`${vcEntity?.parsedCredential?.metadata?.credential?.name}`}
-												title={t('pageCredentials.credentialDetailsTitle', { friendlyName: vcEntity?.parsedCredential?.metadata?.credential?.name })}
-											>
-												<CredentialImage
-													vcEntity={vcEntity}
-													vcEntityInstances={vcEntity.instances}
-													parsedCredential={vcEntity.parsedCredential}
-													className={`w-full h-full object-cover rounded-xl ${latestCredentials.has(vcEntity.id) ? 'highlight-filter' : ''}`}
-												/>
-											</button>
+												vcEntity={vcEntity}
+												latestCredentials={latestCredentials}
+												onClick={handleImageClick}
+											/>
 										))}
 										<AddCredentialCard onClick={handleAddCredential} />
 									</div>


### PR DESCRIPTION
This PR introduces a set of refactorings and improvements aimed at streamlining credential name resolution and card rendering across the application:

Related PR: https://github.com/wwWallet/wallet-common/pull/33
### Hook Introduction

- Created a new `useCredentialName` hook to centralize and memoize credential name resolution.
- Ensures consistent naming logic across components with support for localized fallback handling.

### Component Updates

- Updated the following components to use `useCredentialName`:
  - `Home`
  - `CredentialLayout`
  - `Credential` page
  - `SelectCredentialsPopup`
  - `HistoryContent`

### UI Improvements

- Extracted `CredentialGridCard` and `CredentialSlideCard` from the `Home` page into reusable components.
- Improved readability and reuse in credential rendering logic.

### Image Load UX

- Updated `CredentialImage` to support an optional `onLoad` callback.
- Enables clean transitions in selection flows (e.g., `SelectCredentialsPopup`) where selection indicators should only appear after the image has loaded.

