### PR TITLE
Refactor Credential Tabs and Improve JSON Viewer Handling for Long Strings

### DIFF
--- a/src/components/Credentials/CredentialTabsPanel.jsx
+++ b/src/components/Credentials/CredentialTabsPanel.jsx
@@ -1,0 +1,21 @@
+import React, { useState } from "react";
+import CredentialTabs from "../../components/Credentials/CredentialTabs";
+
+const CredentialTabsPanel = ({ tabs, defaultTab = 0 }) => {
+	const [activeTab, setActiveTab] = useState(defaultTab);
+
+	return (
+		<>
+			<CredentialTabs
+				tabs={tabs}
+				activeTab={activeTab}
+				onTabChange={setActiveTab}
+			/>
+			<div className="py-2">
+				{tabs[activeTab].component}
+			</div>
+		</>
+	);
+};
+
+export default CredentialTabsPanel;

--- a/src/components/JsonViewer/JsonViewer.jsx
+++ b/src/components/JsonViewer/JsonViewer.jsx
@@ -53,7 +53,7 @@ const JsonViewer = ({ name, value, depth = 0 }) => {
 			: `"${value.slice(0, MAX_STRING_LENGTH)}..."`;
 
 		return (
-			<div className={`${indentClass} break-words`}>
+			<div className={`${indentClass} break-all`}>
 				<span className="text-gray-800 dark:text-white">{name && `"${name}"`}:</span>{' '}
 				<span className={valueClass}>{displayValue}</span>
 				{shouldTruncate && (

--- a/src/pages/Home/Credential.jsx
+++ b/src/pages/Home/Credential.jsx
@@ -17,7 +17,6 @@ import useScreenType from '../../hooks/useScreenType';
 import { useVcEntity } from '../../hooks/useVcEntity';
 
 // Components
-import CredentialTabs from '../../components/Credentials/CredentialTabs';
 import CredentialInfo from '../../components/Credentials/CredentialInfo';
 import CredentialJson from '../../components/Credentials/CredentialJson';
 import HistoryList from '../../components/History/HistoryList';
@@ -27,7 +26,7 @@ import Button from '../../components/Buttons/Button';
 import CredentialLayout from '../../components/Credentials/CredentialLayout';
 import PopupLayout from '../../components/Popups/PopupLayout';
 import CredentialImage from '../../components/Credentials/CredentialImage';
-
+import CredentialTabsPanel from '@/components/Credentials/CredentialTabsPanel';
 
 import { useMdocAppCommunication } from '@/lib/services/MdocAppCommunication';
 
@@ -39,7 +38,6 @@ const Credential = () => {
 	const [showDeletePopup, setShowDeletePopup] = useState(false);
 	const [loading, setLoading] = useState(false);
 	const screenType = useScreenType();
-	const [activeTab, setActiveTab] = useState(0);
 	const { generateEngagementQR, startClient, getMdocRequest, sendMdocResponse, terminateSession } = useMdocAppCommunication();
 	const [showMdocQR, setShowMdocQR] = useState(false);
 	const [mdocQRStatus, setMdocQRStatus] = useState(0); // 0 init; 1 loading; 2 finished;
@@ -160,12 +158,7 @@ const Credential = () => {
 			<>
 				<div className="w-full pt-2 px-2">
 					{screenType !== 'mobile' ? (
-						<>
-							<CredentialTabs tabs={infoTabs} activeTab={activeTab} onTabChange={setActiveTab} />
-							<div className='py-2'>
-								{infoTabs[activeTab].component}
-							</div>
-						</>
+						<CredentialTabsPanel tabs={infoTabs} />
 					) : (
 						<>
 							<Button

--- a/src/pages/Home/Credential.jsx
+++ b/src/pages/Home/Credential.jsx
@@ -132,9 +132,9 @@ const Credential = () => {
 	}, [vcEntity]);
 
 	const infoTabs = [
-		{ label: t('pageCredentials.datasetTitle'), component: <CredentialJson parsedCredential={vcEntity?.parsedCredential} /> },
 		{
-			label: t('pageCredentials.presentationsTitle'), component:
+			label: t('pageCredentials.presentationsTitle'),
+			component:
 				<>
 					{history.length === 0 ? (
 						<p className="text-gray-700 dark:text-white">
@@ -144,6 +144,13 @@ const Credential = () => {
 						<HistoryList history={history} />
 					)}
 				</>
+		},
+		{
+			label: t('pageCredentials.datasetTitle'),
+			component:
+				<CredentialJson
+					parsedCredential={vcEntity?.parsedCredential}
+				/>
 		}
 	];
 


### PR DESCRIPTION
This PR introduces several UI and structure improvements:

- Refactors the credential page by extracting the CredentialTabsPanel component to encapsulate tab state management and rendering, enhancing readability and maintainability.
- Reorders the credential tabs for a more logical and user-friendly navigation experience.
- Fixes a layout issue in JsonViewer by applying the 'break-all' CSS utility, ensuring that long unbreakable string values do not cause parent containers to overflow or expand unexpectedly.
