### PR TITLE
Memoize useFilterItemByLang to Prevent Unnecessary Effect Executions

### DIFF
--- a/src/hooks/useFilterItemByLang.js
+++ b/src/hooks/useFilterItemByLang.js
@@ -1,5 +1,6 @@
 // hooks/useFilterItemByLang.js
 
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getLanguage } from '@/i18n';
 
@@ -8,7 +9,7 @@ const useFilterItemByLang = () => {
 	const language = i18n.language;
 	const fallbackLang = i18n.options.fallbackLng;
 
-	const filterItemByLang = (arrayOfItems, langFieldName = 'lang') => {
+	const filterItemByLang = useCallback((arrayOfItems, langFieldName = 'lang') => {
 
 		if (!Array.isArray(arrayOfItems) || arrayOfItems.length === 0) {
 			return {};
@@ -18,7 +19,7 @@ const useFilterItemByLang = () => {
 			arrayOfItems.find(a => getLanguage(a[langFieldName]) === fallbackLang);
 
 		return item || arrayOfItems[0] || {};
-	};
+	}, [language, fallbackLang]);
 
 	return filterItemByLang;
 };


### PR DESCRIPTION
Memoizes the function returned by useFilterItemByLang to avoid unnecessary effect executions when the language has not changed.