### PR TITLE
Show sync popup only when sync param is 'fail' and not synced

### DIFF
--- a/src/hocs/UriHandler.tsx
+++ b/src/hocs/UriHandler.tsx
@@ -190,7 +190,7 @@ export const UriHandler = ({ children }) => {
 
 	useEffect(() => {
 		const params = new URLSearchParams(window.location.search);
-		if (params.get('sync') === 'fail' || synced === false) {
+		if (params.get('sync') === 'fail' && synced === false) {
 			setTextSyncPopup({description: 'syncPopup.description' });
 			setSyncPopup(true);
 		}


### PR DESCRIPTION
Only display the sync popup when both the sync URL parameter is 'fail' and synced is false.