### PR TITLE
keep url search params after sync

### DIFF
--- a/src/components/Popups/SyncPopup.jsx
+++ b/src/components/Popups/SyncPopup.jsx
@@ -28,7 +28,10 @@ const WebauthnLogin = ({
 		async (cachedUser) => {
 			const result = await api.loginWebauthn(keystore, async () => false, [], cachedUser);
 			if (result.ok) {
-				navigate(`${window.location.pathname}`, { replace: true });
+				const params = new URLSearchParams(window.location.search);
+				params.delete("user");
+				params.delete('sync')
+				navigate(`${window.location.pathname}?${params.toString()}`, { replace: true });
 			} else {
 				// Using a switch here so the t() argument can be a literal, to ease searching
 				switch (result.val) {

--- a/src/hocs/UriHandler.tsx
+++ b/src/hocs/UriHandler.tsx
@@ -31,7 +31,7 @@ export const UriHandler = ({ children }) => {
 	const [showPinInputPopup, setShowPinInputPopup] = useState<boolean>(false);
 
 	const [showSyncPopup, setSyncPopup] = useState<boolean>(false);
-	const [textSyncPopup, setTextSyncPopup] = useState<{ description: string }>({description: "" });
+	const [textSyncPopup, setTextSyncPopup] = useState<{ description: string }>({ description: "" });
 
 	const [showMessagePopup, setMessagePopup] = useState<boolean>(false);
 	const [textMessagePopup, setTextMessagePopup] = useState<{ title: string, description: string }>({ title: "", description: "" });
@@ -194,8 +194,10 @@ export const UriHandler = ({ children }) => {
 			setSynced(false);
 		}
 		else if (params.get('sync') === 'fail' && synced === false) {
-			setTextSyncPopup({description: 'syncPopup.description' });
+			setTextSyncPopup({ description: 'syncPopup.description' });
 			setSyncPopup(true);
+		} else {
+			setSyncPopup(false);
 		}
 	}, [location, t, synced]);
 


### PR DESCRIPTION
This PR fixes the case where, upon returning to the wallet with query params, we need to sync before processing those params. The params are now preserved and handled after sync.