### PR TITLE
Gracefully Handle Missing Credentials When Batch ID Not Found

### DIFF
--- a/src/context/CredentialsContextProvider.tsx
+++ b/src/context/CredentialsContextProvider.tsx
@@ -173,7 +173,7 @@ export const CredentialsContextProvider = ({ children }) => {
 				}
 				return prev;
 			});
-			credentialNumber.current = storedCredentials.length;
+			credentialNumber.current = storedCredentials?.length;
 
 		} catch (error) {
 			console.error('Failed to fetch data', error);

--- a/src/hooks/useFetchPresentations.js
+++ b/src/hooks/useFetchPresentations.js
@@ -18,7 +18,7 @@ const useFetchPresentations = (keystore, batchId = null, transactionId = null) =
 				let presentations = await keystore.getAllPresentations();
 
 				if (batchId) {
-					const credentials = await keystore.getAllCredentials();
+					const credentials = await keystore.getAllCredentials() || [];
 					const instances = credentials.filter((credential) => credential.batchId === parseInt(batchId));
 					const credentialsIds = instances.map((instance) => instance.credentialId);
 

--- a/src/hooks/useVcEntity.js
+++ b/src/hooks/useVcEntity.js
@@ -16,12 +16,12 @@ export const useVcEntity = (fetchVcData, vcEntityList, batchId) => {
 				setVcEntity(vcEntity);
 			} else {
 				const vcEntityList = await fetchVcData(parseInt(batchId));
-				setVcEntity(vcEntityList[0]);
+				setVcEntity(vcEntityList?.[0]);
 
 			}
 		} catch (err) {
 			console.error('Error fetching VC entity:', err);
-			setVcEntity(null); // Clear the state on error
+			setVcEntity(undefined); // Clear the state on error
 		}
 	}, [fetchVcData, vcEntityList, batchId]);
 

--- a/src/pages/Home/Credential.jsx
+++ b/src/pages/Home/Credential.jsx
@@ -49,6 +49,12 @@ const Credential = () => {
 	const { vcEntityList, fetchVcData } = useContext(CredentialsContext);
 	const vcEntity = useVcEntity(fetchVcData, vcEntityList, batchId);
 
+	useEffect(() => {
+		if (vcEntity === undefined) {
+			navigate(`/${window.location.search}`, { replace: true });
+		}
+	}, [vcEntity]);
+
 	const credentialName = useCredentialName(
 		vcEntity?.parsedCredential?.metadata?.credential?.name,
 		vcEntity?.batchId,


### PR DESCRIPTION
- When navigating to `credential/{batchId}`, if no credentials are found for the given batch ID, the user is now redirected to the home page.
- Added null-safe checks (using `?.length`) when handling credential lists to prevent errors if credentials are null.