### PR TITLE
Define --max-old-space-size parameter 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY --from=test /home/node/app/package.json /dev/null
 
 COPY . .
 COPY .env.prod .env
-RUN yarn build
+RUN NODE_OPTIONS=--max-old-space-size=3072 yarn build
 
 
 FROM nginx:alpine AS deploy

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig(({ mode }) => {
 				strategies: 'injectManifest', // Uses `src/service-worker.js` for caching
 				manifest: false, // Vite will use `public/manifest.json` automatically
 				injectManifest: {
-					maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
+					maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
 				},
 			}),
 


### PR DESCRIPTION
The increase of max-old-space-size is required for the building procedure in order for a build to successfully complete on MacOS operating system