### PR TITLE
Enhance Select Credentials Popup: Improved Display for Requested Claims and UI Microfixes

### DIFF
--- a/src/components/Credentials/CredentialInfo.jsx
+++ b/src/components/Credentials/CredentialInfo.jsx
@@ -110,6 +110,9 @@ const formatClaimValue = (value) => {
 			</div>
 		);
 	}
+	if (typeof value === 'string' && !value.includes(' ') && value.length > 30) {
+		return value.slice(0, 30) + '…';
+	}
 	return formatDate(value, 'date');
 };
 
@@ -282,10 +285,20 @@ const CredentialInfo = ({ parsedCredential, mainClassName = "text-sm lg:text-bas
 							: ''
 							}`}
 					>
-						<div className="font-semibold text-primary dark:text-white w-1/2">
+						<div
+							className={
+								`font-semibold text-primary dark:text-white w-1/2 break-words` +
+								(label && label.length > 20 && !label.includes(' ') ? ' break-all' : '')
+							}
+						>
 							{label}:
 						</div>
-						<div className="text-gray-700 dark:text-white break-words w-1/2 flex justify-between items-start">
+						<div
+							className={
+								`text-gray-700 dark:text-white w-1/2 flex justify-between items-start break-words` +
+								(value && value.length > 20 && !value.includes(' ') ? ' break-all' : '')
+							}
+						>
 							{value}
 							{isRequested && (
 								<IoIosSend

--- a/src/components/Credentials/CredentialInfo.jsx
+++ b/src/components/Credentials/CredentialInfo.jsx
@@ -140,8 +140,18 @@ const CredentialInfo = ({ parsedCredential, mainClassName = "text-sm lg:text-bas
 
 	const filteredClaims = Array.isArray(displayClaims)
 		? displayClaims.filter(c => {
-			const valid = isDisplayClaim(c);
-			return valid;
+			// Always keep if it is a display claim
+			if (isDisplayClaim(c)) return true;
+
+			// If requestedFields exists, also keep if the path is in requestedFields
+			if (requestedFields) {
+				const joined = Array.isArray(c.path) ? c.path.join('.') : '';
+				return requestedFields.some(field =>
+					(Array.isArray(field) ? field.join('.') : field) === joined
+				);
+			}
+
+			return false;
 		})
 		: [];
 
@@ -162,9 +172,44 @@ const CredentialInfo = ({ parsedCredential, mainClassName = "text-sm lg:text-bas
 			requestedFields?.map(p => Array.isArray(p) ? p.join('.') : p)
 		);
 
+	const pathKey = (path) => Array.isArray(path) ? path.join('.') : '';
+
+	const pathToClaimIdx = new Map(
+		expandedDisplayClaims.map((claim, idx) => [pathKey(claim.path), idx])
+	);
+
+	const syntheticClaims = [];
+
+	if (requestedFieldSet && requestedFields) {
+		requestedFields.forEach(field => {
+			const pathArr = Array.isArray(field) ? field : [field];
+			const joined = pathKey(pathArr);
+			const value = getValueByPath(pathArr, signedClaims);
+
+			const claimIdx = pathToClaimIdx.get(joined);
+
+			if (claimIdx !== undefined) {
+				const claim = expandedDisplayClaims[claimIdx];
+				if (!claim.display || !claim.display.some(d => d.label)) {
+					expandedDisplayClaims[claimIdx] = {
+						...claim,
+						display: [{ lang: 'en', label: joined, description: '' }]
+					};
+				}
+			} else if (value !== undefined) {
+				syntheticClaims.push({
+					path: pathArr,
+					display: [{ lang: 'en', label: joined, description: '' }]
+				});
+			}
+		});
+	}
+
+	const claimsWithDisplay = [...expandedDisplayClaims, ...syntheticClaims];
+
 	const visibleClaims =
 		requestedDisplay === "hide" && requestedFieldSet
-			? expandedDisplayClaims.filter(claim => {
+			? claimsWithDisplay.filter(claim => {
 				const joinedPath = claim.path?.join('.');
 				if (!joinedPath) return false;
 
@@ -178,8 +223,7 @@ const CredentialInfo = ({ parsedCredential, mainClassName = "text-sm lg:text-bas
 					req.startsWith(joinedPath + '.')
 				);
 			})
-			: expandedDisplayClaims;
-
+			: claimsWithDisplay;
 
 	visibleClaims.forEach(claim => {
 		if (!Array.isArray(claim.path)) return;

--- a/src/components/Popups/SelectCredentialsPopup.jsx
+++ b/src/components/Popups/SelectCredentialsPopup.jsx
@@ -364,7 +364,7 @@ function SelectCredentialsPopup({ popupState, setPopupState, showPopup, hidePopu
 												</span>
 											</div>
 											<p className="text-sm text-gray-700 font-normal dark:text-white list-disc ml-4">
-												{fields[0] !== '' ? (
+												{!fields[0].path[0] ? (
 													<span>
 														{t('selectCredentialPopup.allClaimsRequested')}
 													</span>

--- a/src/components/Popups/SelectCredentialsPopup.jsx
+++ b/src/components/Popups/SelectCredentialsPopup.jsx
@@ -165,8 +165,6 @@ function SelectCredentialsPopup({ popupState, setPopupState, showPopup, hidePopu
 	const [currentIndex, setCurrentIndex] = useState(0);
 	const [currentSelectionMap, setCurrentSelectionMap] = useState({});
 	const [showFullPurpose, setShowFullPurpose] = useState(false);
-	const [showAllPreviewFields, setShowAllPreviewFields] = useState({});
-
 	const [selectedCredential, setSelectedCredential] = useState(null);
 	const screenType = useScreenType();
 	const [currentSlide, setCurrentSlide] = useState(1);
@@ -351,11 +349,6 @@ function SelectCredentialsPopup({ popupState, setPopupState, showPopup, hidePopu
 									{t('selectCredentialPopup.requestedCredentialsFieldsTitle')}
 								</p>
 								{Object.entries(requestedFieldsPerCredential).map(([descriptorId, fields]) => {
-									const paths = fields.map(f =>
-										Array.isArray(f.path) ? f.path.join('.') : f.path
-									);
-									const showAll = showAllPreviewFields[descriptorId];
-
 									return (
 										<div key={descriptorId} className="my">
 											<div className="flex flex-row gap-1 text-sm text-gray-700 dark:text-white my-1">
@@ -370,40 +363,17 @@ function SelectCredentialsPopup({ popupState, setPopupState, showPopup, hidePopu
 													{descriptorId}
 												</span>
 											</div>
-											<ul className="text-sm text-gray-700 font-normal dark:text-white list-disc ml-5">
-												{!paths[0] ? (
-													<li className="my-1 px-1">
-														<span >
-															{t('selectCredentialPopup.allClaimsRequested')}
-														</span>
-													</li>
+											<p className="text-sm text-gray-700 font-normal dark:text-white list-disc ml-4">
+												{fields[0] !== '' ? (
+													<span>
+														{t('selectCredentialPopup.allClaimsRequested')}
+													</span>
 												) : (
-
-													(showAll ? paths : paths.slice(0, 2)).map((path, i) => (
-														<li key={i} className="my-1 bg-gray-100 dark:bg-gray-600 px-1 rounded border border-gray-400 max-w-max">
-															<span
-																title={path}
-																className="break-all"
-															>
-																{path}
-															</span>
-														</li>
-													))
+													<span>
+														{t('selectCredentialPopup.specificClaimsRequested')}
+													</span>
 												)}
-											</ul>
-											{paths.length > 2 && (
-												<button
-													onClick={() =>
-														setShowAllPreviewFields(prev => ({
-															...prev,
-															[descriptorId]: !prev[descriptorId]
-														}))
-													}
-													className="ml-1 text-primary text-sm dark:text-extra-light font-medium hover:underline"
-												>
-													{showAll ? t('common.showLess') : t('common.showMore')}
-												</button>
-											)}
+											</p>
 										</div>
 									);
 								})}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -334,6 +334,7 @@
 		"requestingParty": "Requesting Party: ",
 		"selectDescription": "Select the Credential you want to present.",
 		"selectTitle": "Select",
+		"specificClaimsRequested": "The verifier has requested specific claims of the credential.",
 		"summaryDescription": "You are about to share <strong>only the following fields</strong> from the selected credentials.",
 		"summaryTitle": "Summary"
 	},

--- a/translation_coverage/coverage_el.json
+++ b/translation_coverage/coverage_el.json
@@ -1,6 +1,6 @@
 {
 	"schemaVersion": 1,
 	"label": "EL Coverage",
-	"message": "97.06%",
+	"message": "96.7%",
 	"color": "yellow"
 }

--- a/translation_coverage/coverage_pt.json
+++ b/translation_coverage/coverage_pt.json
@@ -1,6 +1,6 @@
 {
 	"schemaVersion": 1,
 	"label": "PT Coverage",
-	"message": "90.44%",
+	"message": "90.11%",
 	"color": "yellow"
 }


### PR DESCRIPTION
This PR improves the display in preview and selection steps in the Select Credentials Popup by:

- Removing the requested fields list from the preview step for a cleaner look.
- Ensuring that claims without a display label are now shown in the selection step using their path as the label.
- Adding UI microfixes to handle long, single-word strings gracefully, preventing overflow and maintaining a clean popup appearance.