### PR TITLE
Show Context Popups Only When User Is Logged In

### DIFF
--- a/src/context/OpenID4VCIContextProvider.tsx
+++ b/src/context/OpenID4VCIContextProvider.tsx
@@ -1,10 +1,13 @@
-import React, { useRef, useEffect, useState, useCallback } from "react";
+import React, { useRef, useEffect, useState, useCallback, useContext } from "react";
 import { useOpenID4VCI } from "../lib/services/OpenID4VCI/OpenID4VCI";
 import OpenID4VCIContext from "./OpenID4VCIContext";
 import IssuanceConsentPopup from "@/components/Popups/IssuanceConsentPopup";
 import MessagePopup from "@/components/Popups/MessagePopup";
+import SessionContext from "./SessionContext";
 
 export const OpenID4VCIContextProvider = ({ children }) => {
+
+	const { isLoggedin } = useContext(SessionContext);
 
 	const [popupConsentState, setPopupConsentState] = useState({
 		isOpen: false,
@@ -57,9 +60,13 @@ export const OpenID4VCIContextProvider = ({ children }) => {
 	return (
 		<OpenID4VCIContext.Provider value={{ openID4VCI }}>
 			{children}
-			<IssuanceConsentPopup popupConsentState={popupConsentState} setPopupConsentState={setPopupConsentState} showConsentPopup={showPopupConsent} hidePopupConsent={hidePopupConsent} />
-			{messagePopupState && (
-				<MessagePopup type={messagePopupState.type} message={messagePopupState.message} onClose={messagePopupState.onClose} />
+			{isLoggedin && (
+				<>
+					<IssuanceConsentPopup popupConsentState={popupConsentState} setPopupConsentState={setPopupConsentState} showConsentPopup={showPopupConsent} hidePopupConsent={hidePopupConsent} />
+					{messagePopupState && (
+						<MessagePopup type={messagePopupState.type} message={messagePopupState.message} onClose={messagePopupState.onClose} />
+					)}
+				</>
 			)}
 		</OpenID4VCIContext.Provider>
 	);

--- a/src/context/OpenID4VPContextProvider.tsx
+++ b/src/context/OpenID4VPContextProvider.tsx
@@ -5,9 +5,11 @@ import { useOpenID4VP } from "../lib/services/OpenID4VP/OpenID4VP";
 import OpenID4VPContext from "./OpenID4VPContext";
 import MessagePopup from "@/components/Popups/MessagePopup";
 import GenericConsentPopup from "@/components/Popups/GenericConsentPopup";
+import SessionContext from "./SessionContext";
 
 export const OpenID4VPContextProvider = ({ children }) => {
 	const { vcEntityList } = useContext<any>(CredentialsContext);
+	const { isLoggedin } = useContext<any>(SessionContext);
 
 	const [popupState, setPopupState] = useState({
 		isOpen: false,
@@ -96,13 +98,16 @@ export const OpenID4VPContextProvider = ({ children }) => {
 	return (
 		<OpenID4VPContext.Provider value={{ openID4VP }}>
 			{children}
-			<GenericConsentPopup popupConsentState={popupConsentState} setPopupConsentState={setPopupConsentState} showConsentPopup={showPopupConsent} hidePopupConsent={hidePopupConsent} />
-			<SelectCredentialsPopup popupState={popupState} setPopupState={setPopupState} showPopup={showPopup} hidePopup={hidePopup} vcEntityList={vcEntityList} />
-			{messagePopupState !== null ?
-				<MessagePopup type={messagePopupState.type} message={messagePopupState.message} onClose={messagePopupState.onClose} />
-				: <></>
-			}
-
+			{isLoggedin && (
+				<>
+					<GenericConsentPopup popupConsentState={popupConsentState} setPopupConsentState={setPopupConsentState} showConsentPopup={showPopupConsent} hidePopupConsent={hidePopupConsent} />
+					<SelectCredentialsPopup popupState={popupState} setPopupState={setPopupState} showPopup={showPopup} hidePopup={hidePopup} vcEntityList={vcEntityList} />
+					{messagePopupState !== null ?
+						<MessagePopup type={messagePopupState.type} message={messagePopupState.message} onClose={messagePopupState.onClose} />
+						: <></>
+					}
+				</>
+			)}
 		</OpenID4VPContext.Provider>
 	);
 }


### PR DESCRIPTION
This PR updates both `OpenID4VPContextProvider` and `OpenID4VCIContextProvider` to display all popups (credential selection, consent, and status/message popups) only when the user is logged in.

- Adds `isLoggedin` check from SessionContext to both providers.
- Wraps all popup components in a conditional block so that they render only if `isLoggedin` is true.
- Ensures that users who are not logged in will not see any popup.
