### PR TITLE
Create excluded IndexedDB paths

### DIFF
--- a/src/indexedDB.ts
+++ b/src/indexedDB.ts
@@ -36,6 +36,11 @@ const stores = {
 
 const PROXY_DEFAULT_MAX_AGE = 30 * 24 * 60 * 60 * 1000; // 30 days
 
+/** Paths to exclude from IndexedDB cache logic */
+export const EXCLUDED_INDEXEDDB_PATHS = new Set([
+	'/user/session/private-data',
+]);
+
 const storeNameMapping: { [key: string]: string } = {
 	'users': 'users',
 	'vc': 'vc',


### PR DESCRIPTION
This PR introduces `EXCLUDED_INDEXEDDB_PATHS` as a Set containing paths that should not be read from or written to IndexedDB.

All offline and forced-IndexedDB read/write logic in `getWithLocalDbKey` now checks against `EXCLUDED_INDEXEDDB_PATHS`.

Requests for excluded paths (such as `/user/session/private-data`) will always bypass IndexedDB and use the backend directly.

Prevents accidental caching or retrieval of sensitive or internal data in local storage.

The change is backward compatible and designed for easy extension by simply adding new paths to `EXCLUDED_INDEXEDDB_PATHS`.