### PR TITLE
Set authenticatorAttachment along with hints during WebAuthn registration

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -11,7 +11,7 @@ import { useNavigate } from 'react-router-dom';
 import { UseStorageHandle, useClearStorages, useLocalStorage, useSessionStorage } from '../hooks/useStorage';
 import { addItem, getItem, EXCLUDED_INDEXEDDB_PATHS } from '../indexedDB';
 import { loginWebAuthnBeginOffline } from './LocalAuthentication';
-import { withHintsFromAllowCredentials } from '@/util-webauthn';
+import { withAuthenticatorAttachmentFromHints, withHintsFromAllowCredentials } from '@/util-webauthn';
 
 const walletBackendUrl = config.BACKEND_URL;
 
@@ -636,6 +636,7 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 							},
 						},
 						hints: webauthnHints,
+						authenticatorSelection: withAuthenticatorAttachmentFromHints({}, webauthnHints),
 					},
 				}) as PublicKeyCredential;
 				const response = credential.response as AuthenticatorAttestationResponse;

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -12,6 +12,7 @@ import useScreenType from '../../hooks/useScreenType';
 
 import { UserData, WebauthnCredential } from '../../api/types';
 import { compareBy, toBase64Url } from '../../util';
+import { withAuthenticatorAttachmentFromHints } from '@/util-webauthn';
 import { formatDate } from '../../functions/DateFormat';
 import type { WebauthnPrfEncryptionKeyInfo, WrappedKeyInfo } from '../../services/keystore';
 import { isPrfKeyV2, serializePrivateData } from '../../services/keystore';
@@ -121,11 +122,13 @@ const WebauthnRegistation = ({
 			if (beginData.challengeId) {
 				setBeginData(beginData);
 
+				const hints = [webauthnHint];
 				const createOptions = {
 					...beginData.createOptions,
 					publicKey: {
 						...beginData.createOptions.publicKey,
-						hints: [webauthnHint],
+						hints,
+						authenticatorSelection: withAuthenticatorAttachmentFromHints({}, hints),
 					},
 				};
 

--- a/src/util-webauthn.ts
+++ b/src/util-webauthn.ts
@@ -25,3 +25,27 @@ export function withHintsFromAllowCredentials(publicKey: PublicKeyCredentialRequ
 		],
 	};
 }
+
+export function withAuthenticatorAttachmentFromHints(authSel: AuthenticatorSelectionCriteria, hints: string[]): AuthenticatorSelectionCriteria {
+	const hintsSet = new Set(hints);
+	const hasClientDevice = hintsSet.has("client-device");
+	const hasHybrid = hintsSet.has("hybrid");
+	const hasSecurityKey = hintsSet.has("security-key");
+
+	const onlyPlatform = hasClientDevice && !(hasHybrid || hasSecurityKey);
+	const onlyExternal = (hasHybrid || hasSecurityKey) && !hasClientDevice;
+
+	if (onlyPlatform) {
+		return {
+			...authSel,
+			authenticatorAttachment: "platform",
+		};
+	} else if (onlyExternal) {
+		return {
+			...authSel,
+			authenticatorAttachment: "cross-platform",
+		};
+	} else {
+		return authSel;
+	}
+}


### PR DESCRIPTION
Fixes #792.

Setting `hints` is not (currently) always enough to direct the client UI to the desired flow. Setting `authenticatorAttachment` too sends a stronger signal to prefer a particular user flow.