### PR TITLE
fix: remove duplicate navigation after login/signup finish

### DIFF
--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -255,7 +255,6 @@ const WebauthnSignupLogin = ({
 	const onLogin = async (webauthnHints: string[], cachedUser?: CachedUser) => {
 		const result = await api.loginWebauthn(keystore, promptForPrfRetry, webauthnHints, cachedUser);
 		if (result.ok) {
-			navigate(from, { replace: true });
 
 		} else {
 			// Using a switch here so the t() argument can be a literal, to ease searching
@@ -297,7 +296,6 @@ const WebauthnSignupLogin = ({
 			retrySignupFrom,
 		);
 		if (result.ok) {
-			navigate(from, { replace: true });
 
 		} else if (result.err) {
 			// Using a switch here so the t() argument can be a literal, to ease searching


### PR DESCRIPTION
This PR fixes the following scenario:

In a tab where the user is not authenticated in wwwallet, the user starts the flow from the verifier. After being redirected to the wwwallet, login process is completed but the user is not navigated to the logged-in page.
