### PR TITLE
Show insufficient creds warning when wallet is empty

### DIFF
--- a/src/lib/services/OpenID4VP/OpenID4VP.ts
+++ b/src/lib/services/OpenID4VP/OpenID4VP.ts
@@ -262,7 +262,9 @@ export function useOpenID4VP({ showCredentialSelectionPopup, showStatusPopup, sh
 				console.error('DCQL shaping error for this VC:', e);
 			}
 		}
-
+		if (shapedCredentials.length === 0) {
+			return { error: HandleAuthorizationRequestError.INSUFFICIENT_CREDENTIALS };
+		}
 		const parsedQuery = DcqlQuery.parse(dcqlJson);
 		DcqlQuery.validate(parsedQuery);
 		const result = await DcqlQuery.query(parsedQuery, shapedCredentials);


### PR DESCRIPTION
Restore 'Insufficient Creds' warning when the wallet is empty and a DCQL query is received