### PR TITLE
Fix Cached Users Refresh in useLocalStorageKeystore

### DIFF
--- a/src/hocs/UriHandler.tsx
+++ b/src/hocs/UriHandler.tsx
@@ -60,8 +60,6 @@ export const UriHandler = ({ children }) => {
 		}
 		const u = getCachedUsers().filter((user) => user.userHandleB64u === userHandle)[0];
 		if (u) {
-			console.log("X: new", u)
-			console.log("X: prev", cachedUser)
 			setCachedUser(u);
 		}
 	}, [getCachedUsers, getUserHandleB64u, setCachedUser, cachedUser, isLoggedIn]);

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -204,7 +204,6 @@ const WebauthnSignupLogin = ({
 	isSubmitting,
 	setIsSubmitting,
 	isLoginCache,
-	setIsLoginCache,
 	error,
 	setError,
 }: {
@@ -212,7 +211,6 @@ const WebauthnSignupLogin = ({
 	isSubmitting: boolean,
 	setIsSubmitting: (isSubmitting: boolean) => void,
 	isLoginCache: boolean,
-	setIsLoginCache: (isLoginCache: boolean) => void,
 	error: React.ReactNode,
 	setError: (error: React.ReactNode) => void,
 }) => {
@@ -376,7 +374,6 @@ const WebauthnSignupLogin = ({
 	};
 
 	const onForgetCachedUser = (cachedUser: CachedUser) => {
-		setIsLoginCache(keystore.getCachedUsers().length - 1 > 0);
 		keystore.forgetCachedUser(cachedUser);
 	};
 
@@ -631,7 +628,13 @@ const Auth = () => {
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
 	const navigate = useNavigate();
-	const [isLoginCache, setIsLoginCache] = useState(keystore.getCachedUsers().length > 0);
+
+	const { getCachedUsers } = keystore;
+	const [isLoginCache, setIsLoginCache] = useState(getCachedUsers().length > 0);
+
+	useEffect(() => {
+		setIsLoginCache(getCachedUsers().length > 0);
+	}, [getCachedUsers, setIsLoginCache]);
 
 	useEffect(() => {
 		if (isLoggedIn) {
@@ -763,7 +766,6 @@ const Auth = () => {
 					isSubmitting={isSubmitting}
 					setIsSubmitting={setIsSubmitting}
 					isLoginCache={isLoginCache}
-					setIsLoginCache={setIsLoginCache}
 					error={webauthnError}
 					setError={setWebauthnError}
 				/>

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -441,7 +441,7 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 
 	const getCachedUsers = useCallback((): CachedUser[] => {
 		return [...(cachedUsers || [])];
-	}, []);
+	}, [cachedUsers]);
 
 	const forgetCachedUser = useCallback((user: CachedUser): void => {
 		setCachedUsers((cachedUsers) => cachedUsers.filter((cu) => cu.userHandleB64u !== user.userHandleB64u));


### PR DESCRIPTION
This PR fixes an issue where `getCachedUsers` could return stale data,
causing inconsistencies such as:
- Cached users not updating immediately after logout.
- Forgetting a cached user requiring a reload to reflect changes.