### PR TITLE
Render Image Claims in CredentialInfo Component

### DIFF
--- a/src/components/Credentials/CredentialInfo.jsx
+++ b/src/components/Credentials/CredentialInfo.jsx
@@ -110,8 +110,22 @@ const formatClaimValue = (value) => {
 			</div>
 		);
 	}
-	if (typeof value === 'string' && !value.includes(' ') && value.length > 30) {
-		return value.slice(0, 30) + '…';
+	// Image handling
+	if (typeof value === 'string') {
+		const lower = value.toLowerCase();
+		if (lower.startsWith('data:image/')) {
+			return (
+				<img
+					src={value}
+					alt="Claim image"
+					className="max-h-10 max-w-full rounded border"
+				/>
+			);
+		}
+		// Long string fallback
+		if (!value.includes(' ') && value.length > 30) {
+			return value.slice(0, 30) + '…';
+		}
 	}
 	return formatDate(value, 'date');
 };


### PR DESCRIPTION
This PR enhances the CredentialInfo component to properly render claim values that are images.

Changes:
- Updated formatClaimValue to detect image values:
   - Supports `data:image/*;base64` data URIs.
- Renders these values as <img> elements with proper styling (`max-h-10`, `max-w-full`, rounded borders).
- Preserves existing behavior for booleans, JSON objects, long strings, and date formatting.
