### PR TITLE
Send firebase config to service worker on page load

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,34 +1,22 @@
 importScripts("https://www.gstatic.com/firebasejs/10.1.0/firebase-app-compat.js");
 importScripts("https://www.gstatic.com/firebasejs/10.1.0/firebase-messaging-compat.js");
 
+self.addEventListener('message', ({data}) => {
+	firebase.initializeApp(data);
 
-// the Firebase config object
-const firebaseConfig = {
-	apiKey: "AIzaSyAfAxdW05Q-fWlMEUEBkPr8avW6GRNjUcE",
-	authDomain: "ediplomas-wallet.firebaseapp.com",
-	projectId: "ediplomas-wallet",
-	storageBucket: "ediplomas-wallet.appspot.com",
-	messagingSenderId: "598999145142",
-	appId: "1:598999145142:web:9561c751460a10b6836417",
-	measurementId: "G-SY9LQ8597Y"
-};
+	const messaging = firebase.messaging();
 
+	messaging.onBackgroundMessage(function(payload) {
+		console.log('Received background message ', payload);
+		const notificationTitle = payload.data.title;
+		const notificationOptions = {
+			body: payload.data.body,
+			data: { url: '/' },
+		};
 
-firebase.initializeApp(firebaseConfig);
-const messaging = firebase.messaging();
-
-
-messaging.onBackgroundMessage(function(payload) {
-	console.log('Received background message ', payload);
-	const notificationTitle = payload.data.title;
-	const notificationOptions = {
-		body: payload.data.body,
-		data: { url: '/' },
-	};
-
-	self.registration.showNotification(notificationTitle,
-		notificationOptions);
-});
+		self.registration.showNotification(notificationTitle, notificationOptions);
+	});
+})
 
 self.addEventListener('notificationclick', function (event) {
 	console.log('Notification click Received.!!!!!!');


### PR DESCRIPTION
This PR get's rid of the static firebaseConfig in `firebase-messaging-sw.js` in favour of loading the Firebase config from environment variables that are then sent to the service worker on page load.

Why?: In order to automate the setup of wwWallet (SIROS is working on this), it greatly helps having these values be loaded dynamically.

Considerations: I am sure there is a better way to achieve this and I'm happy to make improvements to this solution, if it's interesting to the rest of the team.
