### PR TITLE
Fix missing base AuthenticatorSelection argument

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -636,7 +636,7 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 							},
 						},
 						hints: webauthnHints,
-						authenticatorSelection: withAuthenticatorAttachmentFromHints({}, webauthnHints),
+						authenticatorSelection: withAuthenticatorAttachmentFromHints(beginData.createOptions.publicKey.authenticatorSelection, webauthnHints),
 					},
 				}) as PublicKeyCredential;
 				const response = credential.response as AuthenticatorAttestationResponse;

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -128,7 +128,7 @@ const WebauthnRegistation = ({
 					publicKey: {
 						...beginData.createOptions.publicKey,
 						hints,
-						authenticatorSelection: withAuthenticatorAttachmentFromHints({}, hints),
+						authenticatorSelection: withAuthenticatorAttachmentFromHints(beginData.createOptions.publicKey.authenticatorSelection, hints),
 					},
 				};
 


### PR DESCRIPTION
Fixes this issue introduced after #793 was merged:

```
wallet-backend-server-1  | webauthn register-finish {
wallet-backend-server-1  |   challengeId: '3ac92cf4-a4df-4c15-9f2a-2bc064460d72',
wallet-backend-server-1  |   displayName: 'El Dragon Linux Login',
wallet-backend-server-1  |   privateData: <Buffer 7b 22 6d 61 69 6e 4b 65 79 22 3a 7b 22 70 75 62 6c 69 63 4b 65 79 22 3a 7b 22 69 6d 70 6f 72 74 4b 65 79 22 3a 7b 22 66 6f 72 6d 61 74 22 3a 22 72 61 ... 1967 more bytes>,
wallet-backend-server-1  |   credential: {
wallet-backend-server-1  |     type: 'public-key',
wallet-backend-server-1  |     id: 'BSN1YbbKmTCpUa42s1gYJg',
wallet-backend-server-1  |     rawId: <Buffer 05 23 75 61 b6 ca 99 30 a9 51 ae 36 b3 58 18 26>,
wallet-backend-server-1  |     response: {
wallet-backend-server-1  |       attestationObject: <Buffer a3 63 66 6d 74 64 6e 6f 6e 65 67 61 74 74 53 74 6d 74 a0 68 61 75 74 68 44 61 74 61 58 94 a7 f4 47 ed 36 85 be 54 fb 0d ac fc 6d 48 ac e6 88 9f 09 31 ... 128 more bytes>,
wallet-backend-server-1  |       clientDataJSON: <Buffer 7b 22 74 79 70 65 22 3a 22 77 65 62 61 75 74 68 6e 2e 63 72 65 61 74 65 22 2c 22 63 68 61 6c 6c 65 6e 67 65 22 3a 22 6c 57 34 56 65 71 67 6f 42 67 32 ... 89 more bytes>,
wallet-backend-server-1  |       transports: [Array]
wallet-backend-server-1  |     },
wallet-backend-server-1  |     authenticatorAttachment: 'platform',
wallet-backend-server-1  |     clientExtensionResults: { prf: [Object] }
wallet-backend-server-1  |   }
wallet-backend-server-1  | }
wallet-backend-server-1  | webauthn register-finish challenge WebauthnChallengeEntity {
wallet-backend-server-1  |   id: '3ac92cf4-a4df-4c15-9f2a-2bc064460d72',
wallet-backend-server-1  |   type: 'create',
wallet-backend-server-1  |   userId: UserId { id: '48cf6a6d-fec8-44bb-96dc-e735d78a707c' },
wallet-backend-server-1  |   challenge: <Buffer 95 6e 15 7a a8 28 06 0d 8f c4 6f 7e e2 64 ff 25 d2 89 13 22 86 45 fc dc 36 e3 d9 13 2a 32 b1 a5>,
wallet-backend-server-1  |   prfSalt: null,
wallet-backend-server-1  |   createTime: 2025-09-03T11:17:50.000Z
wallet-backend-server-1  | }
wallet-backend-server-1  | /app/node_modules/@simplewebauthn/server/dist/registration/verifyRegistrationResponse.js:111
wallet-backend-server-1  |         throw new Error('User verification required, but user could not be verified');
wallet-backend-server-1  |               ^
wallet-backend-server-1  | 
wallet-backend-server-1  | Error: User verification required, but user could not be verified
wallet-backend-server-1  |     at Object.verifyRegistrationResponse (/app/node_modules/@simplewebauthn/server/dist/registration/verifyRegistrationResponse.js:111:15)
wallet-backend-server-1  | 
wallet-backend-server-1  | Node.js v18.20.8
wallet-backend-server-1 exited with code 0
```