### PR TITLE
Refactor foldAllEventsIntoBaseState: WalletStateContainer to foldState: WalletState

### DIFF
--- a/src/services/WalletStateOperations.ts
+++ b/src/services/WalletStateOperations.ts
@@ -723,15 +723,10 @@ export namespace WalletStateOperations {
 	}
 
 	/**
-	 * Returns container with the whole history of the container folded into the base state
-	 * @param walletStateContainer
-	 * @returns
+	 * Returns the result of folding all event history into the base state.
 	 */
-	export function foldAllEventsIntoBaseState(walletStateContainer: WalletStateContainer) {
-		// get deep copy
-		const container: WalletStateContainer = { ...walletStateContainer };
-		container.S = container.events.reduce(walletStateReducer, container.S);
-		return container;
+	export function foldState(container: WalletStateContainer): WalletState {
+		return container.events.reduce(walletStateReducer, container.S);
 	}
 
 	/**

--- a/src/services/keystore.ts
+++ b/src/services/keystore.ts
@@ -370,8 +370,8 @@ export async function importMainKey(exportedMainKey: BufferSource): Promise<Cryp
 export async function openPrivateData(exportedMainKey: BufferSource, privateData: EncryptedContainer): Promise<[PrivateData, CryptoKey, WalletState]> {
 	const mainKey = await importMainKey(exportedMainKey);
 	const openedPrivateData = await decryptPrivateData(privateData.jwe, mainKey);
-	const calculatedState = WalletStateOperations.foldAllEventsIntoBaseState(openedPrivateData);
-	return [openedPrivateData, mainKey, calculatedState.S];
+	const calculatedState = WalletStateOperations.foldState(openedPrivateData);
+	return [openedPrivateData, mainKey, calculatedState];
 }
 
 async function generateEncapsulationKeypair(): Promise<[EncapsulationPublicKeyInfo, CryptoKey]> {


### PR DESCRIPTION
Originally from https://github.com/wwWallet/wallet-frontend/pull/740#discussion_r2228225444:

The current name and function signature
`foldAllEventsIntoBaseState(walletStateContainer: WalletStateContainer): WalletStateContainer` is misleading, since this function does not empty the `events` or update the `lastEventHash` of the returned container. Thus, the returned container is not a valid `WalletStateContainer` since adding any events to it will make the event history inconsistent.

Fortunately this function is currently used only to compute the effective state, and not to add any new events to the returned container. Thus we can refactor the function to return only the state component instead of the whole container.