### PR TITLE
Add global function nativeWrapper.isKeystoreOpen()

### DIFF
--- a/src/AppProvider.tsx
+++ b/src/AppProvider.tsx
@@ -7,6 +7,7 @@ import { OpenID4VPContextProvider } from './context/OpenID4VPContextProvider';
 import { OpenID4VCIContextProvider } from './context/OpenID4VCIContextProvider';
 import { AppSettingsProvider } from './context/AppSettingsProvider';
 import UriHandler from './hocs/UriHandler';
+import { NativeWrapperProvider } from './context/NativeWrapper';
 
 type RootProviderProps = {
 	children: ReactNode;
@@ -21,7 +22,9 @@ const AppProvider: React.FC<RootProviderProps> = ({ children }) => {
 						<OpenID4VCIContextProvider>
 							<UriHandler>
 								<AppSettingsProvider>
-									{children}
+									<NativeWrapperProvider>
+										{children}
+									</NativeWrapperProvider>
 								</AppSettingsProvider>
 							</UriHandler>
 						</OpenID4VCIContextProvider>

--- a/src/context/NativeWrapper.tsx
+++ b/src/context/NativeWrapper.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+
+import { useLocalStorageKeystore } from '../services/LocalStorageKeystore';
+import keystoreEvents from '../services/keystoreEvents';
+
+
+declare global {
+	interface Window {
+		nativeWrapper?: NativeWrapper;
+	}
+
+	interface NativeWrapper {
+		isKeystoreOpen(): Promise<boolean>;
+	}
+}
+
+
+export const NativeWrapperProvider = ({ children }) => {
+	const keystore = useLocalStorageKeystore(keystoreEvents);
+
+	useEffect(
+		() => {
+			if (window.nativeWrapper) {
+				window.nativeWrapper.isKeystoreOpen = async () => keystore.isOpen();
+			}
+		},
+		[keystore],
+	);
+
+	return children;
+};


### PR DESCRIPTION
The native wrapper apps need a way to check whether "the wallet is open". Currently they can do that by checking for the presence of `mainKey` in `window.sessionStorage`, but this is brittle since that's an implementation detail - indeed, `privateData` moved from `localStorage` to IndexedDB in https://github.com/wwWallet/wallet-frontend/pull/740 for example.

This adds an `isKeystoreOpen(): Promise<boolean>` method to `window.nativeWrapper` (when `window.nativeWrapper` is already defined) as a more stable integration point to check whether the keystore is open.