### PR TITLE
Add typecheck script

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,9 +79,10 @@
     "start-docker": "npx vite --no-open",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "VITE_CJS_IGNORE_WARNING=true vitest run",
+    "test": "yarn typecheck && VITE_CJS_IGNORE_WARNING=true vitest run",
     "test-start": "VITE_CJS_IGNORE_WARNING=true vitest",
-    "translations": "node translation_coverage/translations.js"
+    "translations": "node translation_coverage/translations.js",
+    "typecheck": "tsc --noEmit"
   },
   "repository": "https://github.com/wwwallet/wallet-frontend",
   "license": "BSD-2-Clause"


### PR DESCRIPTION
This PR updates the test script to run `typecheck` (`tsc --noEmit`) before executing tests. Now, running `yarn test` provides console feedback for both type errors and failing tests