### PR TITLE
Refactor HistoryList to avoid duplicate fetching when history prop is provided

### DIFF
--- a/src/components/History/HistoryList.jsx
+++ b/src/components/History/HistoryList.jsx
@@ -1,4 +1,5 @@
-import React, { useState, useContext, useEffect } from 'react';
+// components/History/HistoryList.jsx
+import React, { useState, useContext, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useScreenType from '../../hooks/useScreenType';
 import { formatDate } from '../../functions/DateFormat';
@@ -10,75 +11,82 @@ import SessionContext from '@/context/SessionContext';
 import useFetchPresentations from '@/hooks/useFetchPresentations';
 import { reverse, compareBy } from '@/util';
 
-const HistoryList = ({ batchId = null, title = '', limit = null }) => {
-	const { keystore } = useContext(SessionContext);
+/** ------------------ Pure view (NO data fetching here) ------------------ */
+function HistoryListView({ batchId = null, title = '', limit = null, history = {} }) {
+	const navigate = useNavigate();
+	const screenType = useScreenType();
+
+	// normalize in case history is [] (some callers return [] on empty)
+	const normalized = (history && !Array.isArray(history)) ? history : {};
+	const groups = useMemo(() => Object.values(normalized), [normalized]);
 
 	const [isImageModalOpen, setImageModalOpen] = useState(false);
-	const screenType = useScreenType();
-	const navigate = useNavigate();
+	const [selectedByBatch, setSelectedByBatch] = useState(null);
+	const [selectedByTx, setSelectedByTx] = useState(null);
 
-	const history = useFetchPresentations(keystore, batchId, null);
-
-	const [selectedHistoryItemFilteredByBatchId, setSelectedHistoryItemFilteredByBatchId] = useState(null);
-	const [selectedHistoryItemFilteredByTransactionId, setSelectedHistoryItemFilteredByTransactionId] = useState(null);
 	useEffect(() => {
-		if (batchId !== null && history !== null && Object.values(history).length > 0) {
-			setSelectedHistoryItemFilteredByBatchId(Object.values(history)[0]);
-		}
-	}, [batchId, history]);
+		if (batchId !== null && groups.length > 0) setSelectedByBatch(groups[0]);
+		else setSelectedByBatch(null);
+	}, [batchId, groups]);
 
-	const handleHistoryItemClick = async (item) => {
-		console.log('extractPresentations', item);
+	const handleHistoryItemClick = (item) => {
 		const transactionId = item[0].presentation.transactionId;
-		if (screenType === 'mobile') {
-			navigate(`/history/${transactionId}`);
-		}
+		if (screenType === 'mobile') navigate(`/history/${transactionId}`);
 		else {
-			setSelectedHistoryItemFilteredByTransactionId(item);
+			setSelectedByTx(item);
+			setImageModalOpen(true);
 		}
-		setImageModalOpen(true);
 	};
+
+	const sorted = useMemo(
+		() =>
+			groups
+				.slice()
+				.sort(
+					reverse(compareBy(item => item[0].presentation.presentationTimestampSeconds))
+				),
+		[groups]
+	);
 
 	return (
 		<>
 			<div className="py-2 w-full">
-				{title && Object.values(history).length > 0 && <H3 heading={title} />}
+				{title && groups.length > 0 && <H3 heading={title} />}
 				<div className="overflow-auto space-y-2" style={{ maxHeight: '85vh' }}>
-					{Object.values(history)
-						.sort(reverse(compareBy(item => item[0].presentation.presentationTimestampSeconds)))
-						.slice(0, limit ?? Object.values(history).length)
-						.map(item => ( // note: an item is an array of presentations (see useFetchPresentations hook)
-							<button
-								id={`credential-history-item-${item[0].presentation.transactionId}`}
-								key={item[0].presentation.transactionId}
-								className="bg-gray-50 dark:bg-gray-800 text-sm px-4 py-2 dark:text-white border border-gray-200 shadow-sm dark:border-gray-600 rounded-md cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 break-words w-full text-left"
-								style={{ wordBreak: 'break-all' }}
-								onClick={() => handleHistoryItemClick(item)}
-							>
-								<div className="font-bold">{item[0].presentation.audience}</div>
-								<div>{formatDate(item[0].presentation.presentationTimestampSeconds)}</div>
-							</button>
-						))}
+					{(limit ? sorted.slice(0, limit) : sorted).map(item => (
+						<button
+							id={`credential-history-item-${item[0].presentation.transactionId}`}
+							key={item[0].presentation.transactionId}
+							className="bg-gray-50 dark:bg-gray-800 text-sm px-4 py-2 dark:text-white border border-gray-200 shadow-sm dark:border-gray-600 rounded-md cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 break-words w-full text-left"
+							style={{ wordBreak: 'break-all' }}
+							onClick={() => handleHistoryItemClick(item)}
+						>
+							<div className="font-bold">{item[0].presentation.audience}</div>
+							<div>{formatDate(item[0].presentation.presentationTimestampSeconds)}</div>
+						</button>
+					))}
 				</div>
 			</div>
 
-			{/* History Detail Popup */}
 			<HistoryDetailPopup
 				isOpen={isImageModalOpen}
 				onClose={() => setImageModalOpen(false)}
-				historyItem={
-					(selectedHistoryItemFilteredByTransactionId ?
-						selectedHistoryItemFilteredByTransactionId :
-						(selectedHistoryItemFilteredByBatchId ?
-							selectedHistoryItemFilteredByBatchId : []
-						)
-					)
-
-
-				}
+				historyItem={selectedByBatch ?? selectedByTx ?? []}
 			/>
 		</>
 	);
-};
+}
 
-export default HistoryList;
+function HistoryListFetcher({ batchId = null, title = '', limit = null }) {
+	const { keystore } = useContext(SessionContext);
+	const history = useFetchPresentations(keystore, batchId, null);
+	return <HistoryListView batchId={batchId} title={title} limit={limit} history={history} />;
+}
+
+/** If `history` prop is provided → no hook call. Otherwise fetcher calls the hook. */
+export default function HistoryList({ batchId = null, title = '', limit = null, history = null }) {
+	if (history) {
+		return <HistoryListView batchId={batchId} title={title} limit={limit} history={history} />;
+	}
+	return <HistoryListFetcher batchId={batchId} title={title} limit={limit} />;
+}

--- a/src/pages/History/History.jsx
+++ b/src/pages/History/History.jsx
@@ -29,7 +29,7 @@ const History = () => {
 					{t('pageHistory.noFound')}
 				</p>
 			) : (
-				<HistoryList />
+				<HistoryList history={history}/>
 			)}
 		</div>
 	);

--- a/src/pages/Home/Credential.jsx
+++ b/src/pages/Home/Credential.jsx
@@ -164,7 +164,7 @@ const Credential = () => {
 							{t('pageHistory.noFound')}
 						</p>
 					) : (
-						<HistoryList batchId={batchId} />
+						<HistoryList batchId={batchId} history={history} />
 					)}
 				</>
 		},


### PR DESCRIPTION
This PR refactors the HistoryList component to prevent unnecessary calls to `useFetchPresentations` when a history prop is already available from the parent.

Changes:
- Split `HistoryList` logic into a pure view (`HistoryListView`) and a fetcher wrapper (`HistoryListFetcher`).
- The public HistoryList now decides whether to render with provided history (no fetching) 
  or use the fetcher to call useFetchPresentations.
- Ensures that history is only fetched once at the top-level and reused across child components.
- Improves performance and avoids duplicate data parsing/filtering.