### PR TITLE
Don't override wallet-common in tests.Dockerfile

### DIFF
--- a/tests.Dockerfile
+++ b/tests.Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /home/node/app
 # Install dependencies first so rebuild of these layers is only needed when dependencies change
 COPY package.json yarn.lock .
 COPY .env.template .env
-RUN yarn cache clean -f && yarn install
+RUN yarn cache clean -f && yarn install --pure-lockfile
 
 COPY . .
 RUN npm run vitest

--- a/tests.Dockerfile
+++ b/tests.Dockerfile
@@ -1,21 +1,12 @@
 FROM node:22-bullseye-slim AS builder-base
 
-
-RUN apt-get update -y && apt-get install -y git && rm -rf /var/lib/apt/lists/* && git clone --branch master --single-branch --depth 1 https://github.com/wwWallet/wallet-common.git /lib/wallet-common
-
-WORKDIR /lib/wallet-common
-RUN yarn install && yarn build
+RUN apt-get update -y && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /home/node/app
 # Install dependencies first so rebuild of these layers is only needed when dependencies change
 COPY package.json yarn.lock .
 COPY .env.template .env
-
-WORKDIR /home/node/app
-
-RUN yarn cache clean -f && yarn add /lib/wallet-common && yarn install
-
-FROM builder-base AS test
+RUN yarn cache clean -f && yarn install
 
 COPY . .
 RUN npm run vitest


### PR DESCRIPTION
The wallet-common dependency is now defined as a commit-pinned Git dependency instead of a directory dependency since https://github.com/wwWallet/wallet-frontend/commit/39bf10a5c648d63264c0602a43c3d44446c1b47d, so we no longer need to clone wallet-common explicitly.

This is causing GHA failures such as this in #872: https://github.com/wwWallet/wallet-frontend/actions/runs/18222230410/job/51884610705?pr=872