### PR TITLE
Clean up Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /home/node/app
 # Install dependencies first so rebuild of these layers is only needed when dependencies change
 COPY package.json yarn.lock .
 COPY .env.prod .env
-RUN yarn cache clean -f && yarn install
+RUN yarn cache clean -f && yarn install --frozen-lockfile
 
 FROM builder-base AS test
 

--- a/tests.Dockerfile
+++ b/tests.Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /home/node/app
 # Install dependencies first so rebuild of these layers is only needed when dependencies change
 COPY package.json yarn.lock .
 COPY .env.template .env
-RUN yarn cache clean -f && yarn install --pure-lockfile
+RUN yarn cache clean -f && yarn install --frozen-lockfile
 
 COPY . .
 RUN npm run test


### PR DESCRIPTION
- Delete outdated comment
- Optimize layer order by running `apt-get update` first. This prevents having to re-install git whenever dependencies change.
- Use `--frozen-lockfile` in `yarn install`, to ensure that installed dependencies match the lock file.