### PR TITLE
Update pre-commit hook to not add newlines in translation files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
         name: Minor auto-fixes
-        exclude: ^(node_modules|dist|build|public)/
+        exclude: ^(node_modules|dist|build|public|src/locales/[^/]+\.json)/
 
   - repo: local
     hooks:


### PR DESCRIPTION
Fixes 'No final newline expected' for locales/*.json files 