### PR TITLE
Swap readme logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="./branding/logo_light.svg" width="80" style="max-width: 100%; float:left; margin-right: 20px;"/>
+<img src="./branding/logo_dark.svg" width="80" style="max-width: 100%; float:left; margin-right: 20px;"/>
 
 # wwWallet
 


### PR DESCRIPTION
The logo in README.md was missed in #912, swapping it here.
