### PR TITLE
Enable React Router v7 Future Flags (startTransition & relativeSplatPath)

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -22,7 +22,12 @@ initializeDataSource()
 // Create root and render app
 const root = createRoot(document.getElementById('root'));
 root.render(
-	<BrowserRouter>
+	<BrowserRouter
+		future={{
+			v7_startTransition: true,
+			v7_relativeSplatPath: true,
+		}}
+	>
 		<AppProvider>
 			<App />
 		</AppProvider>


### PR DESCRIPTION
This PR enables the React Router v7 *future flags* to silence upgrade warnings and adopt v7 behaviors early.

#### Details
React Router 6.28+ introduces optional "future" flags that preview v7 behavior.  
By adding these flags to the `<BrowserRouter>` configuration, we align our routing with upcoming changes:

- **`v7_startTransition`** – Wraps route state updates in `React.startTransition()` for smoother UI updates and better responsiveness during navigation.
- **`v7_relativeSplatPath`** – Changes how relative routes are resolved inside splat (`*`) routes for more predictable behavior.