### PR TITLE
Service Worker registration script that respects trusted types

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,6 @@
 <body>
 	<div id="root"></div>
 	<script type="module" src="/src/index.jsx"></script>
-	<script src="/sw-register.js" defer></script>
+	<script type="module" src="/src/sw-register.js" defer></script>
 </body>
 </html>

--- a/src/sw-register.js
+++ b/src/sw-register.js
@@ -1,3 +1,5 @@
+const appMode = import.meta.env.MODE || 'development';
+
 const tt = window.trustedTypes || window.TrustedTypes;
 
 const swPolicy = tt
@@ -11,7 +13,7 @@ const swPolicy = tt
 	})
 	: null;
 
-if ('serviceWorker' in navigator) {
+if (appMode === 'production' && 'serviceWorker' in navigator) {
 	window.addEventListener('load', () => {
 		const swUrl = '/service-worker.js';
 		const trustedSwUrl = swPolicy ? swPolicy.createScriptURL(swUrl) : swUrl;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig(({ mode }) => {
 			MobileWrapperWKAppLinksPlugin(env),
 			VitePWA({
 				registerType: 'autoUpdate',
-				injectRegister: 'null',
+				injectRegister: null,
 				srcDir: 'src',
 				filename: 'service-worker.js', // Custom service worker (MUST exist in `src/`)
 				strategies: 'injectManifest', // Uses `src/service-worker.js` for caching


### PR DESCRIPTION
Related to: https://github.com/wwWallet/wallet-frontend/issues/925

* Changed VitePWA so that it does not handle registration of service workers automatically
* Created a sw-register script that uses Trusted Types API to register a service worker when `import.meta.env.MODE === 'production'`