### PR TITLE
Add Padding to Generated Apple Touch Icon for iOS

### DIFF
--- a/vite-plugins/brandingManifest.ts
+++ b/vite-plugins/brandingManifest.ts
@@ -175,18 +175,19 @@ async function generateAllIcons({
 		const ICON_SIZE = 180;
 		const PADDING = 20;
 
-		sharp(logoDark.pathname)
+		await sharp(logoLight.pathname)
 			.resize(ICON_SIZE - PADDING * 2, ICON_SIZE - PADDING * 2, {
 				fit: "contain",
 			})
+			.flatten({ background: { r: 255, g: 255, b: 255, alpha: 1 } })
 			.extend({
 				top: PADDING,
 				bottom: PADDING,
 				left: PADDING,
 				right: PADDING,
+				background: { r: 255, g: 255, b: 255, alpha: 1 },
 			})
 			.png()
-			.resize(180, 180)
 			.toFile(path.join(iconsDir, 'apple-touch-icon.png'));
 	}
 


### PR DESCRIPTION
This PR improves the generated `apple-touch-icon.png` used by iOS PWAs.

### What was changed
- Added 20px padding around the logo during the Apple Touch Icon generation.
- Prevents the logo from appearing stretched when added to the iOS home screen.

### Why
iOS does not auto-apply padding to icons and displays the PNG directly.  
Without padding, the logo fills the rounded squircle mask and looks distorted.