### PR TITLE
Use Maskable Icons with Padding for Android PWA

### DIFF
--- a/vite-plugins/brandingManifest.ts
+++ b/vite-plugins/brandingManifest.ts
@@ -192,22 +192,36 @@ async function generateAllIcons({
 	}
 
 	// Manifest icons
-	const icons: ManifestOptions['icons'] = [];
+	const icons: ManifestOptions["icons"] = [];
 
-	const manifestIcon = sharp(logoDark.pathname).png()
+	const manifestIcon = sharp(logoDark.pathname).png();
+	const PADDING_RATIO = 0.10;
 
 	for (const size of manifestIconSizes) {
 		const sizeStr = `${size}x${size}`;
 		const fileName = `icon-${sizeStr}.png`;
 
-		manifestIcon
-			.resize(size, size)
-			.toFile(path.join(iconsDir, fileName))
+		const innerSize = Math.round(size * (1 - 2 * PADDING_RATIO));
+		const pad = Math.round((size - innerSize) / 2);
+
+		await manifestIcon
+			.clone()
+			.resize(innerSize, innerSize, { fit: "contain" })
+			.extend({
+				top: pad,
+				bottom: pad,
+				left: pad,
+				right: pad,
+				background: { r: 0, g: 0, b: 0, alpha: 0 },
+			})
+			.png()
+			.toFile(path.join(iconsDir, fileName));
 
 		icons.push({
 			src: `icons/${fileName}`,
 			sizes: sizeStr,
-			type: 'image/png'
+			type: 'image/png',
+			purpose: 'any maskable',
 		});
 	}
 


### PR DESCRIPTION
This PR fixes the Android PWA icon appearance.

- All generated icons now include a **10% transparent padding**
- All icons are marked as **`purpose: "any maskable"`**
- Prevents Android from applying its own default padding
- Results in correct rendering for circle and square launcher icons

This makes PWA icons look consistent and avoids stretching on Android.
