### PR TITLE
Fix: generate valid PWA icons (any + maskable) and remove Lighthouse warnings

### DIFF
--- a/vite-plugins/brandingManifest.ts
+++ b/vite-plugins/brandingManifest.ts
@@ -194,15 +194,22 @@ async function generateAllIcons({
 	// Manifest icons
 	const icons: ManifestOptions["icons"] = [];
 
-	const manifestIcon = sharp(logoDark.pathname).png();
+	const manifestIcon = sharp(logoLight.pathname).png();
 	const PADDING_RATIO = 0.10;
 
 	for (const size of manifestIconSizes) {
 		const sizeStr = `${size}x${size}`;
 		const fileName = `icon-${sizeStr}.png`;
 
-		const innerSize = Math.round(size * (1 - 2 * PADDING_RATIO));
-		const pad = Math.round((size - innerSize) / 2);
+		const isMaskable = size >= 192;
+
+		let innerSize = size;
+		let pad = 0;
+
+		if (isMaskable) {
+			pad = Math.round(size * PADDING_RATIO);
+			innerSize = size - 2 * pad;
+		}
 
 		await manifestIcon
 			.clone()
@@ -221,9 +228,19 @@ async function generateAllIcons({
 			src: `icons/${fileName}`,
 			sizes: sizeStr,
 			type: 'image/png',
-			purpose: 'any maskable',
+			purpose: 'any',
 		});
+
+		if (isMaskable) {
+			icons.push({
+				src: `icons/${fileName}`,
+				sizes: sizeStr,
+				type: 'image/png',
+				purpose: 'maskable',
+			});
+		}
 	}
+
 
 	return icons;
 }


### PR DESCRIPTION
This PR fixes our generated PWA icons so they are valid for both regular and maskable usage and pass Lighthouse checks.

### Changes

- Update `BrandingManifestPlugin` icon generation:
  - Keep small icons (16, 32, 64) **without padding** to avoid size mismatches.
  - For large icons (192, 512), apply ~10% padding and ~80% safe area using:
    - `pad = Math.round(size * 0.10)`
    - `innerSize = size - 2 * pad`
  - Ensure final output size always matches the declared size (e.g. 192×192, 512×512).

- Adjust manifest `purpose` handling:
  - For every size, add a standard icon entry with `purpose: "any"`.
  - For large sizes (≥ 192), add an additional entry with `purpose: "maskable"`.
  - Avoid using `"any maskable"`, which Lighthouse discourages.

### Result

- Fixes Lighthouse warnings about:
  - Icon actual size not matching specified size.
  - Discouraged use of `purpose: "any maskable"`.
  - Missing ≥144px icon with `purpose` unset or set to `"any"`.

- Keeps proper maskable icons for Android while maintaining a valid installable PWA manifest.

### Testing

- Run dev server.
- Clear site data in DevTools (**Application → Clear storage → Clear site data**).
- Re-run Lighthouse PWA audit and confirm:
  - No icon size mismatches.
  - No `any maskable` warnings.
  - Installability passes with a ≥144px `purpose: "any"` icon.
