### PR TITLE
Remove hardcoded reference to openid client

### DIFF
--- a/src/lib/services/OpenID4VCI/OpenID4VCI.ts
+++ b/src/lib/services/OpenID4VCI/OpenID4VCI.ts
@@ -331,6 +331,12 @@ export function useOpenID4VCI({ errorCallback, showPopupConsent, showMessagePopu
 				openID4VCIHelper.getAuthorizationServerMetadata(credentialIssuerIdentifier),
 				openID4VCIHelper.getClientId(credentialIssuerIdentifier)
 			]);
+
+			if (!clientId) {
+				console.error("clientId not found");
+				return ;
+			}
+
 			if (requestCredentialsParams.usingActiveAccessToken) {
 				console.log("Attempting with active access token")
 
@@ -601,6 +607,11 @@ export function useOpenID4VCI({ errorCallback, showPopupConsent, showMessagePopu
 				openID4VCIHelper.getCredentialIssuerMetadata(credentialIssuerIdentifier),
 				openID4VCIHelper.getClientId(credentialIssuerIdentifier)
 			]);
+
+			if (!clientId) {
+				console.error("clientId not found");
+				return;
+			}
 
 			if (authzServerMetadata.authzServeMetadata.pushed_authorization_request_endpoint) {
 				const res = await openID4VCIPushedAuthorizationRequest.generate(

--- a/src/lib/services/OpenID4VCIHelper.ts
+++ b/src/lib/services/OpenID4VCIHelper.ts
@@ -111,12 +111,12 @@ export function useOpenID4VCIHelper(): IOpenID4VCIHelper {
 					return { client_id: issuer.clientId };
 				}
 
-				return { client_id: "CLIENT123" };
+				return null;
 			}
 			catch (err) {
 				console.log("Could not get client_id for issuer " + credentialIssuerIdentifier + " Details:");
 				console.error(err);
-				return { client_id: "CLIENT123" };
+				return null;
 			}
 		},
 		[getExternalEntity]


### PR DESCRIPTION
If clientId cannot be extracted from issuer info, helper function returns null instead of fallback test clientid