### PR TITLE
Feature/api versioning discover trust

### DIFF
--- a/src/AppProvider.tsx
+++ b/src/AppProvider.tsx
@@ -13,6 +13,7 @@ import { OpenID4VPContextProvider } from './context/OpenID4VPContextProvider';
 import { OpenID4VCIContextProvider } from './context/OpenID4VCIContextProvider';
 import { AppSettingsProvider } from './context/AppSettingsProvider';
 import { NotificationProvider } from './context/NotificationProvider';
+import { ApiVersionProvider } from './context/ApiVersionContext';
 
 // Hocs
 import { UriHandlerProvider } from './hocs/UriHandlerProvider';
@@ -25,25 +26,27 @@ type RootProviderProps = {
 const AppProvider: React.FC<RootProviderProps> = ({ children }) => {
 	return (
 		<StatusContextProvider>
-			<SessionContextProvider>
-				<CredentialsContextProvider>
-					<I18nextProvider i18n={i18n}>
-						<OpenID4VPContextProvider>
-							<OpenID4VCIContextProvider>
-								<UriHandlerProvider>
-									<AppSettingsProvider>
-										<NotificationProvider>
-											<NativeWrapperProvider>
-												{children}
-											</NativeWrapperProvider>
-										</NotificationProvider>
-									</AppSettingsProvider>
-								</UriHandlerProvider>
-							</OpenID4VCIContextProvider>
-						</OpenID4VPContextProvider>
-					</I18nextProvider>
-				</CredentialsContextProvider>
-			</SessionContextProvider>
+			<ApiVersionProvider>
+				<SessionContextProvider>
+					<CredentialsContextProvider>
+						<I18nextProvider i18n={i18n}>
+							<OpenID4VPContextProvider>
+								<OpenID4VCIContextProvider>
+									<UriHandlerProvider>
+										<AppSettingsProvider>
+											<NotificationProvider>
+												<NativeWrapperProvider>
+													{children}
+												</NativeWrapperProvider>
+											</NotificationProvider>
+										</AppSettingsProvider>
+									</UriHandlerProvider>
+								</OpenID4VCIContextProvider>
+							</OpenID4VPContextProvider>
+						</I18nextProvider>
+					</CredentialsContextProvider>
+				</SessionContextProvider>
+			</ApiVersionProvider>
 		</StatusContextProvider>
 	);
 };

--- a/src/context/ApiVersionContext.tsx
+++ b/src/context/ApiVersionContext.tsx
@@ -1,0 +1,127 @@
+/**
+ * ApiVersionContext - React context for API version management.
+ *
+ * This context provides:
+ * - The detected backend API version
+ * - Feature availability checks
+ * - Loading state during initial detection
+ *
+ * The API version is auto-detected from the backend's /status endpoint
+ * and cached for the session. Components can check feature availability
+ * without making additional network requests.
+ */
+
+import React, { createContext, useContext, useEffect, useState, useMemo, useCallback } from 'react';
+import {
+	getApiVersion,
+	refreshApiVersion,
+	getApiFeatures,
+	ApiVersionInfo,
+	DEFAULT_API_VERSION,
+	API_VERSION_DISCOVER_AND_TRUST,
+} from '@/lib/services/ApiVersionService';
+
+interface ApiVersionContextValue {
+	/** The detected API version (or default if not yet loaded) */
+	apiVersion: number;
+	/** Whether the API version is still being loaded */
+	isLoading: boolean;
+	/** Feature availability flags */
+	features: ApiVersionInfo['features'];
+	/** Force refresh the API version from the backend */
+	refresh: () => Promise<void>;
+	/** Check if a specific API version is supported */
+	supportsVersion: (version: number) => boolean;
+}
+
+const ApiVersionContext = createContext<ApiVersionContextValue>({
+	apiVersion: DEFAULT_API_VERSION,
+	isLoading: true,
+	features: {
+		discoverAndTrust: false,
+	},
+	refresh: async () => {},
+	supportsVersion: () => false,
+});
+
+export function ApiVersionProvider({ children }: React.PropsWithChildren) {
+	const [apiVersion, setApiVersion] = useState<number>(DEFAULT_API_VERSION);
+	const [isLoading, setIsLoading] = useState(true);
+
+	const loadApiVersion = useCallback(async () => {
+		setIsLoading(true);
+		try {
+			const version = await getApiVersion();
+			setApiVersion(version);
+		} catch (error) {
+			console.error('Failed to load API version:', error);
+			setApiVersion(DEFAULT_API_VERSION);
+		} finally {
+			setIsLoading(false);
+		}
+	}, []);
+
+	const refresh = useCallback(async () => {
+		setIsLoading(true);
+		try {
+			const version = await refreshApiVersion();
+			setApiVersion(version);
+		} finally {
+			setIsLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		loadApiVersion();
+	}, [loadApiVersion]);
+
+	const features = useMemo(() => getApiFeatures(apiVersion).features, [apiVersion]);
+
+	const supportsVersion = useCallback(
+		(version: number) => apiVersion >= version,
+		[apiVersion]
+	);
+
+	const value = useMemo<ApiVersionContextValue>(
+		() => ({
+			apiVersion,
+			isLoading,
+			features,
+			refresh,
+			supportsVersion,
+		}),
+		[apiVersion, isLoading, features, refresh, supportsVersion]
+	);
+
+	return (
+		<ApiVersionContext.Provider value={value}>
+			{children}
+		</ApiVersionContext.Provider>
+	);
+}
+
+/**
+ * Hook to access the API version context.
+ */
+export function useApiVersion(): ApiVersionContextValue {
+	const context = useContext(ApiVersionContext);
+	if (!context) {
+		throw new Error('useApiVersion must be used within an ApiVersionProvider');
+	}
+	return context;
+}
+
+/**
+ * Hook to check if discover-and-trust is available.
+ * Returns { available, isLoading } for convenient checks.
+ */
+export function useDiscoverAndTrust(): { available: boolean; isLoading: boolean } {
+	const { features, isLoading } = useApiVersion();
+	return {
+		available: features.discoverAndTrust,
+		isLoading,
+	};
+}
+
+// Export the context for direct access if needed
+export default ApiVersionContext;

--- a/src/lib/services/ApiVersionService.test.ts
+++ b/src/lib/services/ApiVersionService.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import axios from 'axios';
+
+import {
+	fetchApiVersion,
+	getApiVersion,
+	refreshApiVersion,
+	getApiFeatures,
+	isFeatureAvailable,
+	getCachedApiVersion,
+	DEFAULT_API_VERSION,
+	API_VERSION_DISCOVER_AND_TRUST,
+} from './ApiVersionService';
+
+// Mock axios
+vi.mock('axios');
+const mockedAxios = vi.mocked(axios);
+
+describe('ApiVersionService', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		// Reset cached version by calling the module fresh
+		// We'll need to test the caching behavior separately
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('fetchApiVersion', () => {
+		it('should return api_version from backend when present as number', async () => {
+			mockedAxios.get.mockResolvedValueOnce({
+				data: { status: 'ok', api_version: 2 },
+			});
+
+			const version = await fetchApiVersion();
+			expect(version).toBe(2);
+		});
+
+		it('should return api_version from backend when present as string', async () => {
+			mockedAxios.get.mockResolvedValueOnce({
+				data: { status: 'ok', api_version: '2' },
+			});
+
+			const version = await fetchApiVersion();
+			expect(version).toBe(2);
+		});
+
+		it('should return DEFAULT_API_VERSION when api_version is not present', async () => {
+			mockedAxios.get.mockResolvedValueOnce({
+				data: { status: 'ok' },
+			});
+
+			const version = await fetchApiVersion();
+			expect(version).toBe(DEFAULT_API_VERSION);
+		});
+
+		it('should return DEFAULT_API_VERSION when request fails', async () => {
+			mockedAxios.get.mockRejectedValueOnce(new Error('Network error'));
+
+			const version = await fetchApiVersion();
+			expect(version).toBe(DEFAULT_API_VERSION);
+		});
+
+		it('should return DEFAULT_API_VERSION for invalid api_version string', async () => {
+			mockedAxios.get.mockResolvedValueOnce({
+				data: { status: 'ok', api_version: 'invalid' },
+			});
+
+			const version = await fetchApiVersion();
+			expect(version).toBe(DEFAULT_API_VERSION);
+		});
+	});
+
+	describe('getApiFeatures', () => {
+		it('should indicate discoverAndTrust is available for version >= 2', () => {
+			const features = getApiFeatures(2);
+			expect(features.features.discoverAndTrust).toBe(true);
+
+			const features3 = getApiFeatures(3);
+			expect(features3.features.discoverAndTrust).toBe(true);
+		});
+
+		it('should indicate discoverAndTrust is not available for version < 2', () => {
+			const features = getApiFeatures(1);
+			expect(features.features.discoverAndTrust).toBe(false);
+
+			const features0 = getApiFeatures(0);
+			expect(features0.features.discoverAndTrust).toBe(false);
+		});
+
+		it('should include the version in the result', () => {
+			const features = getApiFeatures(2);
+			expect(features.version).toBe(2);
+		});
+	});
+
+	describe('constants', () => {
+		it('should have DEFAULT_API_VERSION set to 1', () => {
+			expect(DEFAULT_API_VERSION).toBe(1);
+		});
+
+		it('should have API_VERSION_DISCOVER_AND_TRUST set to 2', () => {
+			expect(API_VERSION_DISCOVER_AND_TRUST).toBe(2);
+		});
+	});
+
+	describe('getCachedApiVersion', () => {
+		it('should return DEFAULT_API_VERSION when cache is empty', () => {
+			// Note: This test might be flaky if run after other tests that populate the cache
+			// In a real scenario, we'd need to reset the module state between tests
+			const version = getCachedApiVersion();
+			expect(typeof version).toBe('number');
+		});
+	});
+
+	describe('isFeatureAvailable', () => {
+		it('should return true when cached version meets minimum', () => {
+			// This depends on cached state, so we test the function signature
+			const result = isFeatureAvailable(1);
+			expect(typeof result).toBe('boolean');
+		});
+	});
+});
+
+describe('ApiVersionService integration', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should call /status endpoint with correct parameters', async () => {
+		mockedAxios.get.mockResolvedValueOnce({
+			data: { status: 'ok', api_version: 2 },
+		});
+
+		await fetchApiVersion();
+
+		expect(mockedAxios.get).toHaveBeenCalledWith(
+			expect.stringContaining('/status'),
+			expect.objectContaining({
+				timeout: 5000,
+				headers: { 'Content-Type': 'application/json' },
+			})
+		);
+	});
+});

--- a/src/lib/services/ApiVersionService.test.ts
+++ b/src/lib/services/ApiVersionService.test.ts
@@ -6,7 +6,7 @@ import {
 	getApiVersion,
 	refreshApiVersion,
 	getApiFeatures,
-	isFeatureAvailable,
+	supportsApiVersion,
 	getCachedApiVersion,
 	DEFAULT_API_VERSION,
 	API_VERSION_DISCOVER_AND_TRUST,
@@ -114,10 +114,10 @@ describe('ApiVersionService', () => {
 		});
 	});
 
-	describe('isFeatureAvailable', () => {
+	describe('supportsApiVersion', () => {
 		it('should return true when cached version meets minimum', () => {
 			// This depends on cached state, so we test the function signature
-			const result = isFeatureAvailable(1);
+			const result = supportsApiVersion(1);
 			expect(typeof result).toBe('boolean');
 		});
 	});

--- a/src/lib/services/ApiVersionService.ts
+++ b/src/lib/services/ApiVersionService.ts
@@ -1,0 +1,119 @@
+/**
+ * API Version Service
+ *
+ * Handles discovery and management of the backend API version.
+ * The backend exposes an api_version field in the /status response
+ * that indicates which API features are available.
+ *
+ * API Version History:
+ * - Version 1: Original API (implicit, for backends that don't report api_version)
+ * - Version 2: Adds /api/discover-and-trust endpoint for combined discovery + trust evaluation
+ */
+
+import axios from 'axios';
+import { BACKEND_URL } from '@/config';
+
+// Minimum version for specific features
+export const API_VERSION_DISCOVER_AND_TRUST = 2;
+
+// Default version when backend doesn't report one (backwards compatibility)
+export const DEFAULT_API_VERSION = 1;
+
+export interface ApiVersionInfo {
+	version: number;
+	features: {
+		discoverAndTrust: boolean;
+	};
+}
+
+/**
+ * Fetches the API version from the backend status endpoint.
+ * Returns DEFAULT_API_VERSION if the backend doesn't support api_version.
+ */
+export async function fetchApiVersion(): Promise<number> {
+	try {
+		const response = await axios.get(`${BACKEND_URL}/status`, {
+			timeout: 5000,
+			headers: {
+				'Content-Type': 'application/json',
+			},
+		});
+
+		// Extract api_version from response, default to 1 if not present
+		const apiVersion = response.data?.api_version;
+		if (typeof apiVersion === 'string') {
+			const parsed = parseInt(apiVersion, 10);
+			return isNaN(parsed) ? DEFAULT_API_VERSION : parsed;
+		}
+		if (typeof apiVersion === 'number') {
+			return apiVersion;
+		}
+
+		return DEFAULT_API_VERSION;
+	} catch (error) {
+		console.warn('Failed to fetch API version from backend:', error);
+		return DEFAULT_API_VERSION;
+	}
+}
+
+/**
+ * Determines available features based on the API version.
+ */
+export function getApiFeatures(version: number): ApiVersionInfo {
+	return {
+		version,
+		features: {
+			discoverAndTrust: version >= API_VERSION_DISCOVER_AND_TRUST,
+		},
+	};
+}
+
+/**
+ * Cache for the discovered API version to avoid repeated calls.
+ */
+let cachedApiVersion: number | null = null;
+let cacheTimestamp: number = 0;
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Gets the API version, using cache when available.
+ * Call refreshApiVersion() to force a fresh fetch.
+ */
+export async function getApiVersion(): Promise<number> {
+	const now = Date.now();
+	if (cachedApiVersion !== null && now - cacheTimestamp < CACHE_TTL_MS) {
+		return cachedApiVersion;
+	}
+
+	cachedApiVersion = await fetchApiVersion();
+	cacheTimestamp = now;
+	return cachedApiVersion;
+}
+
+/**
+ * Forces a fresh fetch of the API version, updating the cache.
+ */
+export async function refreshApiVersion(): Promise<number> {
+	cachedApiVersion = await fetchApiVersion();
+	cacheTimestamp = Date.now();
+	return cachedApiVersion;
+}
+
+/**
+ * Checks if a specific feature is available based on the cached API version.
+ * If the version hasn't been fetched yet, assumes DEFAULT_API_VERSION.
+ */
+export function isFeatureAvailable(minVersion: number): boolean {
+	if (cachedApiVersion === null) {
+		return DEFAULT_API_VERSION >= minVersion;
+	}
+	return cachedApiVersion >= minVersion;
+}
+
+/**
+ * Gets the current cached version (or default if not yet fetched).
+ * Use this for synchronous checks when you've already called getApiVersion().
+ */
+export function getCachedApiVersion(): number {
+	return cachedApiVersion ?? DEFAULT_API_VERSION;
+}

--- a/src/lib/services/DiscoverAndTrustService.test.ts
+++ b/src/lib/services/DiscoverAndTrustService.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import axios from 'axios';
+
+import {
+	discoverAndTrust,
+	discoverAndTrustIssuer,
+	discoverAndTrustVerifier,
+	isDiscoverAndTrustAvailable,
+	DiscoverAndTrustRequest,
+	DiscoverAndTrustResponse,
+} from './DiscoverAndTrustService';
+import * as ApiVersionService from './ApiVersionService';
+
+// Mock axios
+vi.mock('axios');
+const mockedAxios = vi.mocked(axios);
+
+// Mock ApiVersionService
+vi.mock('./ApiVersionService', async () => {
+	const actual = await vi.importActual('./ApiVersionService');
+	return {
+		...actual,
+		getApiVersion: vi.fn(),
+		getCachedApiVersion: vi.fn(),
+	};
+});
+
+const mockedApiVersionService = vi.mocked(ApiVersionService);
+
+describe('DiscoverAndTrustService', () => {
+	const mockAuthToken = 'test-auth-token';
+	const mockSuccessResponse: DiscoverAndTrustResponse = {
+		trusted: true,
+		reason: 'Found in trust list',
+		discovery_status: 'success',
+		trust_framework: 'eudi',
+		trusted_certificates: ['-----BEGIN CERTIFICATE-----\nMIIB...'],
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('isDiscoverAndTrustAvailable', () => {
+		it('should return true when cached version >= 2', () => {
+			mockedApiVersionService.getCachedApiVersion.mockReturnValue(2);
+			expect(isDiscoverAndTrustAvailable()).toBe(true);
+		});
+
+		it('should return false when cached version < 2', () => {
+			mockedApiVersionService.getCachedApiVersion.mockReturnValue(1);
+			expect(isDiscoverAndTrustAvailable()).toBe(false);
+		});
+
+		it('should return true when cached version > 2', () => {
+			mockedApiVersionService.getCachedApiVersion.mockReturnValue(3);
+			expect(isDiscoverAndTrustAvailable()).toBe(true);
+		});
+	});
+
+	describe('discoverAndTrust', () => {
+		it('should throw error when API version < 2', async () => {
+			mockedApiVersionService.getApiVersion.mockResolvedValue(1);
+
+			const request: DiscoverAndTrustRequest = {
+				entity_identifier: 'https://issuer.example.com',
+				role: 'issuer',
+			};
+
+			await expect(discoverAndTrust(request, mockAuthToken)).rejects.toThrow(
+				'discover-and-trust requires API version 2'
+			);
+		});
+
+		it('should make POST request when API version >= 2', async () => {
+			mockedApiVersionService.getApiVersion.mockResolvedValue(2);
+			mockedAxios.post.mockResolvedValueOnce({ data: mockSuccessResponse });
+
+			const request: DiscoverAndTrustRequest = {
+				entity_identifier: 'https://issuer.example.com',
+				role: 'issuer',
+			};
+
+			const result = await discoverAndTrust(request, mockAuthToken);
+
+			expect(mockedAxios.post).toHaveBeenCalledWith(
+				expect.stringContaining('/api/discover-and-trust'),
+				request,
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						'Content-Type': 'application/json',
+						Authorization: `Bearer ${mockAuthToken}`,
+					}),
+					timeout: 30000,
+				})
+			);
+			expect(result).toEqual(mockSuccessResponse);
+		});
+
+		it('should include credential_type when provided', async () => {
+			mockedApiVersionService.getApiVersion.mockResolvedValue(2);
+			mockedAxios.post.mockResolvedValueOnce({ data: mockSuccessResponse });
+
+			const request: DiscoverAndTrustRequest = {
+				entity_identifier: 'https://issuer.example.com',
+				role: 'issuer',
+				credential_type: 'eu.europa.ec.eudi.pid.1',
+			};
+
+			await discoverAndTrust(request, mockAuthToken);
+
+			expect(mockedAxios.post).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({
+					credential_type: 'eu.europa.ec.eudi.pid.1',
+				}),
+				expect.any(Object)
+			);
+		});
+	});
+
+	describe('discoverAndTrustIssuer', () => {
+		it('should call discoverAndTrust with role=issuer', async () => {
+			mockedApiVersionService.getApiVersion.mockResolvedValue(2);
+			mockedAxios.post.mockResolvedValueOnce({ data: mockSuccessResponse });
+
+			await discoverAndTrustIssuer('https://issuer.example.com', mockAuthToken);
+
+			expect(mockedAxios.post).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({
+					entity_identifier: 'https://issuer.example.com',
+					role: 'issuer',
+				}),
+				expect.any(Object)
+			);
+		});
+
+		it('should include credential_type when provided', async () => {
+			mockedApiVersionService.getApiVersion.mockResolvedValue(2);
+			mockedAxios.post.mockResolvedValueOnce({ data: mockSuccessResponse });
+
+			await discoverAndTrustIssuer(
+				'https://issuer.example.com',
+				mockAuthToken,
+				'eu.europa.ec.eudi.pid.1'
+			);
+
+			expect(mockedAxios.post).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({
+					credential_type: 'eu.europa.ec.eudi.pid.1',
+				}),
+				expect.any(Object)
+			);
+		});
+	});
+
+	describe('discoverAndTrustVerifier', () => {
+		it('should call discoverAndTrust with role=verifier', async () => {
+			mockedApiVersionService.getApiVersion.mockResolvedValue(2);
+			mockedAxios.post.mockResolvedValueOnce({ data: mockSuccessResponse });
+
+			await discoverAndTrustVerifier('https://verifier.example.com', mockAuthToken);
+
+			expect(mockedAxios.post).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({
+					entity_identifier: 'https://verifier.example.com',
+					role: 'verifier',
+				}),
+				expect.any(Object)
+			);
+		});
+	});
+
+	describe('error handling', () => {
+		it('should propagate axios errors', async () => {
+			mockedApiVersionService.getApiVersion.mockResolvedValue(2);
+			mockedAxios.post.mockRejectedValueOnce(new Error('Network error'));
+
+			const request: DiscoverAndTrustRequest = {
+				entity_identifier: 'https://issuer.example.com',
+				role: 'issuer',
+			};
+
+			await expect(discoverAndTrust(request, mockAuthToken)).rejects.toThrow('Network error');
+		});
+	});
+});
+
+describe('DiscoverAndTrustResponse types', () => {
+	it('should accept valid response with all fields', () => {
+		const response: DiscoverAndTrustResponse = {
+			issuer_metadata: { credential_issuer: 'https://issuer.example.com' },
+			trusted: true,
+			reason: 'Trust established',
+			trusted_certificates: ['-----BEGIN CERTIFICATE-----\n...'],
+			trust_framework: 'eudi',
+			discovery_status: 'success',
+		};
+
+		expect(response.trusted).toBe(true);
+		expect(response.discovery_status).toBe('success');
+	});
+
+	it('should accept valid response with minimal fields', () => {
+		const response: DiscoverAndTrustResponse = {
+			trusted: false,
+			reason: 'Not in trust list',
+			discovery_status: 'failed',
+			discovery_error: 'Connection refused',
+		};
+
+		expect(response.trusted).toBe(false);
+		expect(response.discovery_status).toBe('failed');
+	});
+
+	it('should accept verifier response', () => {
+		const response: DiscoverAndTrustResponse = {
+			verifier_metadata: { client_id: 'verifier-123' },
+			trusted: true,
+			reason: 'Verified',
+			discovery_status: 'success',
+		};
+
+		expect(response.verifier_metadata).toBeDefined();
+	});
+});

--- a/src/lib/services/DiscoverAndTrustService.ts
+++ b/src/lib/services/DiscoverAndTrustService.ts
@@ -1,0 +1,140 @@
+/**
+ * Discover and Trust Service
+ *
+ * This service provides combined entity discovery and trust evaluation.
+ * It's used when the backend supports API version 2+ (with /api/discover-and-trust endpoint).
+ *
+ * For older backends (API version 1), the frontend falls back to the legacy
+ * behavior where discovery and trust evaluation are handled separately.
+ */
+
+import axios from 'axios';
+import { BACKEND_URL } from '@/config';
+import {
+	getApiVersion,
+	API_VERSION_DISCOVER_AND_TRUST,
+	getCachedApiVersion,
+} from './ApiVersionService';
+
+/**
+ * Request payload for the discover-and-trust endpoint.
+ */
+export interface DiscoverAndTrustRequest {
+	/** The issuer or verifier identifier (URL) */
+	entity_identifier: string;
+	/** Role: "issuer" or "verifier" */
+	role: 'issuer' | 'verifier';
+	/** Optional credential type (docType for mDOC, vct for SD-JWT) */
+	credential_type?: string;
+}
+
+/**
+ * Response from the discover-and-trust endpoint.
+ */
+export interface DiscoverAndTrustResponse {
+	/** Discovered issuer metadata (if role=issuer) */
+	issuer_metadata?: Record<string, unknown>;
+	/** Discovered verifier metadata (if role=verifier) */
+	verifier_metadata?: Record<string, unknown>;
+	/** Whether the entity is trusted */
+	trusted: boolean;
+	/** Reason for the trust decision */
+	reason: string;
+	/** Trusted certificates in PEM format (if any) */
+	trusted_certificates?: string[];
+	/** Trust framework that authorized the entity */
+	trust_framework?: string;
+	/** Discovery status: "success", "partial", or "failed" */
+	discovery_status: 'success' | 'partial' | 'failed';
+	/** Error message if discovery failed */
+	discovery_error?: string;
+}
+
+/**
+ * Checks if the discover-and-trust feature is available.
+ * This uses the cached API version for synchronous checks.
+ * Call ensureApiVersionLoaded() first if you need a guaranteed check.
+ */
+export function isDiscoverAndTrustAvailable(): boolean {
+	return getCachedApiVersion() >= API_VERSION_DISCOVER_AND_TRUST;
+}
+
+/**
+ * Ensures the API version has been loaded from the backend.
+ * Call this during app initialization or before making feature availability checks.
+ */
+export async function ensureApiVersionLoaded(): Promise<number> {
+	return await getApiVersion();
+}
+
+/**
+ * Performs combined discovery and trust evaluation via the backend.
+ * Only available when API version >= 2.
+ *
+ * @throws Error if the feature is not available or if the request fails
+ */
+export async function discoverAndTrust(
+	request: DiscoverAndTrustRequest,
+	authToken: string
+): Promise<DiscoverAndTrustResponse> {
+	const apiVersion = await getApiVersion();
+
+	if (apiVersion < API_VERSION_DISCOVER_AND_TRUST) {
+		throw new Error(
+			`discover-and-trust requires API version ${API_VERSION_DISCOVER_AND_TRUST}, ` +
+			`but backend reports version ${apiVersion}`
+		);
+	}
+
+	const response = await axios.post<DiscoverAndTrustResponse>(
+		`${BACKEND_URL}/api/discover-and-trust`,
+		request,
+		{
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${authToken}`,
+			},
+			timeout: 30000, // 30 second timeout for discovery + trust evaluation
+		}
+	);
+
+	return response.data;
+}
+
+/**
+ * Discovers and evaluates trust for an issuer.
+ * Convenience wrapper around discoverAndTrust.
+ */
+export async function discoverAndTrustIssuer(
+	issuerIdentifier: string,
+	authToken: string,
+	credentialType?: string
+): Promise<DiscoverAndTrustResponse> {
+	return discoverAndTrust(
+		{
+			entity_identifier: issuerIdentifier,
+			role: 'issuer',
+			credential_type: credentialType,
+		},
+		authToken
+	);
+}
+
+/**
+ * Discovers and evaluates trust for a verifier.
+ * Convenience wrapper around discoverAndTrust.
+ */
+export async function discoverAndTrustVerifier(
+	verifierIdentifier: string,
+	authToken: string,
+	credentialType?: string
+): Promise<DiscoverAndTrustResponse> {
+	return discoverAndTrust(
+		{
+			entity_identifier: verifierIdentifier,
+			role: 'verifier',
+			credential_type: credentialType,
+		},
+		authToken
+	);
+}

--- a/src/lib/services/DiscoverAndTrustService.ts
+++ b/src/lib/services/DiscoverAndTrustService.ts
@@ -13,7 +13,7 @@ import { BACKEND_URL } from '@/config';
 import {
 	getApiVersion,
 	API_VERSION_DISCOVER_AND_TRUST,
-	getCachedApiVersion,
+	supportsApiVersion,
 } from './ApiVersionService';
 
 /**
@@ -56,7 +56,7 @@ export interface DiscoverAndTrustResponse {
  * Call ensureApiVersionLoaded() first if you need a guaranteed check.
  */
 export function isDiscoverAndTrustAvailable(): boolean {
-	return getCachedApiVersion() >= API_VERSION_DISCOVER_AND_TRUST;
+	return supportsApiVersion(API_VERSION_DISCOVER_AND_TRUST);
 }
 
 /**
@@ -77,12 +77,11 @@ export async function discoverAndTrust(
 	request: DiscoverAndTrustRequest,
 	authToken: string
 ): Promise<DiscoverAndTrustResponse> {
-	const apiVersion = await getApiVersion();
+	await ensureApiVersionLoaded();
 
-	if (apiVersion < API_VERSION_DISCOVER_AND_TRUST) {
+	if (!supportsApiVersion(API_VERSION_DISCOVER_AND_TRUST)) {
 		throw new Error(
-			`discover-and-trust requires API version ${API_VERSION_DISCOVER_AND_TRUST}, ` +
-			`but backend reports version ${apiVersion}`
+			`discover-and-trust requires API version ${API_VERSION_DISCOVER_AND_TRUST} or higher`
 		);
 	}
 

--- a/src/lib/services/OpenID4VCIHelper.ts
+++ b/src/lib/services/OpenID4VCIHelper.ts
@@ -9,6 +9,61 @@ import { OpenidAuthorizationServerMetadataSchema, OpenidCredentialIssuerMetadata
 import type { OpenidAuthorizationServerMetadata, OpenidCredentialIssuerMetadata } from 'wallet-common'
 import { isDiscoverAndTrustAvailable, discoverAndTrustIssuer } from './DiscoverAndTrustService';
 
+/**
+ * Verifies and extracts metadata from signed_metadata JWT if present.
+ * Returns the verified payload as metadata, or null if verification fails.
+ */
+async function verifySignedMetadata(
+	metadata: OpenidCredentialIssuerMetadata
+): Promise<{ metadata: OpenidCredentialIssuerMetadata } | null> {
+	if (!metadata.signed_metadata) {
+		return { metadata };
+	}
+
+	try {
+		const headerB64 = metadata.signed_metadata.split('.')[0];
+		const parsedHeader = JSON.parse(new TextDecoder().decode(base64url.decode(headerB64)));
+
+		if (!parsedHeader.x5c) {
+			return null;
+		}
+
+		const publicKey = await importX509(getPublicKeyFromB64Cert(parsedHeader.x5c[0]), parsedHeader.alg);
+		const { payload } = await jwtVerify(metadata.signed_metadata, publicKey);
+		return { metadata: payload as OpenidCredentialIssuerMetadata };
+	} catch (err) {
+		console.error('Failed to verify signed_metadata:', err);
+		return null;
+	}
+}
+
+/**
+ * Attempts to fetch issuer metadata via the discover-and-trust API.
+ * Returns null if the API is unavailable or if discovery fails.
+ */
+async function tryDiscoverAndTrust(
+	credentialIssuerIdentifier: string,
+	appToken: string | null
+): Promise<{ metadata: OpenidCredentialIssuerMetadata } | null | 'fallback'> {
+	if (!isDiscoverAndTrustAvailable() || !appToken) {
+		return 'fallback';
+	}
+
+	try {
+		const result = await discoverAndTrustIssuer(credentialIssuerIdentifier, appToken);
+
+		if (result.discovery_status !== 'success' || !result.issuer_metadata) {
+			console.warn('discover-and-trust returned non-success status:', result.discovery_status);
+			return 'fallback';
+		}
+
+		return verifySignedMetadata(result.issuer_metadata as OpenidCredentialIssuerMetadata);
+	} catch (err) {
+		console.warn('discover-and-trust failed, falling back to proxy:', err);
+		return 'fallback';
+	}
+}
+
 export function useOpenID4VCIHelper(): IOpenID4VCIHelper {
 	const httpProxy = useHttpProxy();
 	const { api } = useContext(SessionContext);
@@ -31,38 +86,9 @@ export function useOpenID4VCIHelper(): IOpenID4VCIHelper {
 	const getCredentialIssuerMetadata = useCallback(
 		async (credentialIssuerIdentifier: string, useCache?: boolean): Promise<{ metadata: OpenidCredentialIssuerMetadata } | null> => {
 			// Try the new discover-and-trust API first if available
-			if (isDiscoverAndTrustAvailable()) {
-				const appToken = api.getAppToken();
-				if (appToken) {
-					try {
-						const result = await discoverAndTrustIssuer(credentialIssuerIdentifier, appToken);
-						if (result.discovery_status === 'success' && result.issuer_metadata) {
-							const metadata = result.issuer_metadata as OpenidCredentialIssuerMetadata;
-							// Handle signed_metadata if present
-							if (metadata.signed_metadata) {
-								try {
-									const parsedHeader = JSON.parse(new TextDecoder().decode(base64url.decode(metadata.signed_metadata.split('.')[0])));
-									if (parsedHeader.x5c) {
-										const publicKey = await importX509(getPublicKeyFromB64Cert(parsedHeader.x5c[0]), parsedHeader.alg);
-										const { payload } = await jwtVerify(metadata.signed_metadata, publicKey);
-										return { metadata: payload as OpenidCredentialIssuerMetadata };
-									}
-									return null;
-								}
-								catch (err) {
-									console.error(err);
-									return null;
-								}
-							}
-							return { metadata };
-						}
-						// Fall through to legacy approach if discovery failed
-						console.warn('discover-and-trust returned non-success status:', result.discovery_status);
-					} catch (err) {
-						// Fall through to legacy approach on error
-						console.warn('discover-and-trust failed, falling back to proxy:', err);
-					}
-				}
+			const discoverResult = await tryDiscoverAndTrust(credentialIssuerIdentifier, api.getAppToken());
+			if (discoverResult !== 'fallback') {
+				return discoverResult;
 			}
 
 			// Legacy approach using HTTP proxy
@@ -73,22 +99,7 @@ export function useOpenID4VCIHelper(): IOpenID4VCIHelper {
 					OpenidCredentialIssuerMetadataSchema,
 					useCache,
 				);
-				if (metadata.signed_metadata) {
-					try {
-						const parsedHeader = JSON.parse(new TextDecoder().decode(base64url.decode(metadata.signed_metadata.split('.')[0])));
-						if (parsedHeader.x5c) {
-							const publicKey = await importX509(getPublicKeyFromB64Cert(parsedHeader.x5c[0]), parsedHeader.alg);
-							const { payload } = await jwtVerify(metadata.signed_metadata, publicKey);
-							return { metadata: payload as OpenidCredentialIssuerMetadata };
-						}
-						return null;
-					}
-					catch (err) {
-						console.error(err);
-						return null;
-					}
-				}
-				return { metadata };
+				return verifySignedMetadata(metadata);
 			}
 			catch (err) {
 				console.error(err);

--- a/src/lib/services/OpenID4VP/OpenID4VP.ts
+++ b/src/lib/services/OpenID4VP/OpenID4VP.ts
@@ -9,6 +9,7 @@ import { extractSAN, getPublicKeyFromB64Cert } from "../../utils/pki";
 import axios from "axios";
 import { BACKEND_URL, OPENID4VP_SAN_DNS_CHECK_SSL_CERTS, OPENID4VP_SAN_DNS_CHECK } from "../../../config";
 import { useHttpProxy } from "../HttpProxy/HttpProxy";
+import { isDiscoverAndTrustAvailable, discoverAndTrustVerifier } from '../DiscoverAndTrustService';
 import { useCallback, useContext, useMemo } from "react";
 import SessionContext from "@/context/SessionContext";
 import CredentialsContext from "@/context/CredentialsContext";
@@ -599,6 +600,25 @@ export function useOpenID4VP({
 			}
 		}
 
+		// Evaluate verifier trust via discover-and-trust API if available
+		if (isDiscoverAndTrustAvailable()) {
+			const appToken = api.getAppToken();
+			if (appToken) {
+				try {
+					const verifierUrl = response_uri ? new URL(response_uri).origin : client_id;
+					const trustResult = await discoverAndTrustVerifier(verifierUrl, appToken);
+					if (!trustResult.trusted) {
+						console.warn('Verifier not trusted:', trustResult.reason);
+						return { error: HandleAuthorizationRequestError.NONTRUSTED_VERIFIER };
+					}
+					console.log('Verifier trust verified:', trustResult.reason);
+				} catch (err) {
+					// Log but don't fail - fall back to certificate-based trust
+					console.warn('discover-and-trust verifier check failed, using certificate-based trust:', err);
+				}
+			}
+		}
+
 		if (sessionStorage.getItem('last_used_nonce') === nonce) {
 			return { error: HandleAuthorizationRequestError.OLD_STATE };
 		}
@@ -652,6 +672,7 @@ export function useOpenID4VP({
 			parsedTransactionData,
 		};
 	}, [
+		api,
 		httpProxy,
 		openID4VPRelyingPartyStateRepository,
 		matchCredentialsToDCQL,


### PR DESCRIPTION
This is an implementation of pluggable trust for issue #994. The implementation depends on the API in https://github.com/sirosfoundation/go-wallet-backend/pull/6:

A new backend API (cf pr 6 to go-wallet-backend above) is introduced that handles issuer and verifier metadata discovery and trust. This API removes the need for using the http proxy for metadata discovery and also uses go-trust (or similar solution) to provide pluggable trust decisions. The change to the frontend is minimal and backwards compatibility is maintained via api versioning which is also added as a feature in this PR.

