### PR TITLE
Fix missing arguments in finishUnlock calls

### DIFF
--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -444,7 +444,7 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 		user: UserData,
 	): Promise<EncryptedContainer> => {
 		const unlocked = await keystore.init(mainKey, keyInfo);
-		const privateData = await finishUnlock(unlocked, user, null);
+		const privateData = await finishUnlock(unlocked, user, null, async () => false);
 		return privateData;
 	},
 		[finishUnlock]
@@ -457,7 +457,7 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 			user: UserData,
 		): Promise<[EncryptedContainer, CommitCallback] | null> => {
 			const [unlockResult, newPrivateData] = await keystore.unlockPassword(privateData, password);
-			await finishUnlock(unlockResult, user, null);
+			await finishUnlock(unlockResult, user, null, async () => false);
 			return (
 				newPrivateData
 					?


### PR DESCRIPTION
Fixes these type errors:

```
TypeCheckError: Expected 4 arguments, but got 3.
 ❯ src/services/LocalStorageKeystore.ts:447:29

TypeCheckError: Expected 4 arguments, but got 3.
 ❯ src/services/LocalStorageKeystore.ts:460:10
```