### PR TITLE
fix: use uppercase for http methods when using proxy

### DIFF
--- a/src/lib/services/HttpProxy/HttpProxy.ts
+++ b/src/lib/services/HttpProxy/HttpProxy.ts
@@ -306,7 +306,7 @@ export function useHttpProxy(): IHttpProxy {
 					response = await axios.post(`${walletBackendServerUrl}/proxy`, {
 						headers: headers,
 						url: url,
-						method: 'post',
+						method: 'POST',
 						data: body,
 					}, {
 						timeout: TIMEOUT,


### PR DESCRIPTION
If the backend proxy does not convert the request method into uppercase, the proxy will fail because lowercase HTTP methods do not exist.