### PR TITLE
fix(vite): include wallet-common in optimizeDeps for proper pre-bundling

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -56,6 +56,9 @@ export default defineConfig(({ mode }) => {
 				'@': '/src',
 			},
 		},
+		optimizeDeps: {
+			include: ['wallet-common'],
+		},
 		server: {
 			host: true,
 			port: 3000,


### PR DESCRIPTION
Add `wallet-common` to Vite `optimizeDeps.include` to ensure it is properly pre-bundled during development.