### PR TITLE
Match OHTTP behavior to axios on errors

### DIFF
--- a/src/lib/services/HttpProxy/HttpProxy.ts
+++ b/src/lib/services/HttpProxy/HttpProxy.ts
@@ -122,7 +122,7 @@ export function useHttpProxy(): IHttpProxy {
 							url,
 						})
 						response.data = response.body;
-						if (response.status !== 200) {
+						if (response.data.status > 299 || response.data.status < 200) {
 							const axiosHeaders = AxiosHeaders.from(headers as Record<string, string>);
 							throw new AxiosError(
 								`Request failed with status code ${response.status}`,
@@ -319,7 +319,7 @@ export function useHttpProxy(): IHttpProxy {
 					response = {
 						data: { ...response }
 					};
-					if (response.data.status !== 200) {
+					if (response.data.status > 299 || response.data.status < 200) {
 						const axiosHeaders = AxiosHeaders.from(headers as Record<string, string>);
 						throw new AxiosError(
 							`Request failed with status code ${response.data.status}`,


### PR DESCRIPTION
PR #1036 was too strict on only 200 status codes and did not fix the gap between OHTTP and Axios response code handling.
The fix in this PR throws on non 2xx codes.