### PR TITLE
Fix: Remove unsafe proxyCache deletion on failed requests

### DIFF
--- a/src/lib/services/HttpProxy/HttpProxy.ts
+++ b/src/lib/services/HttpProxy/HttpProxy.ts
@@ -2,7 +2,7 @@ import { useMemo, useRef, useContext, useEffect } from 'react';
 import axios, { AxiosError, AxiosHeaders } from 'axios';
 import { IHttpProxy, RequestHeaders, ResponseHeaders } from '../../interfaces/IHttpProxy';
 import StatusContext from '@/context/StatusContext';
-import { addItem, getItem, removeItem } from '@/indexedDB';
+import { addItem, getItem } from '@/indexedDB';
 import { encryptedHttpRequest, toArrayBuffer } from '@/lib/utils/ohttpHelpers';
 import { OHTTP_RELAY } from "@/config";
 import SessionContext from '@/context/SessionContext';
@@ -269,16 +269,13 @@ export function useHttpProxy(): IHttpProxy {
 					}
 
 					const fallback = await getItem('proxyCache', cacheKey, 'proxyCache');
+
 					if (fallback?.data) {
 						return {
 							status: 200,
 							headers: {},
 							data: fallback.data,
 						};
-					}
-
-					if (isOnlineRef.current) {
-						await removeItem('proxyCache', cacheKey, 'proxyCache');
 					}
 
 					return {


### PR DESCRIPTION
This PR removes the `removeItem` call from the failed request branch in `useHttpProxy`.

Previously, when a request failed while online, we attempted to delete the corresponding proxyCache entry. In cases where no cache entry existed, this resulted in unnecessary cache mutation.

The fallback logic remains unchanged, if a cached entry exists, it is still returned.

This may be related to #517 and requires further testing.