### PR TITLE
Fix offline asset caching (manifest, favicon) and add font runtime cache

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -8,7 +8,9 @@ import { StaleWhileRevalidate } from "workbox-strategies";
 
 clientsClaim();
 
-precacheAndRoute(self.__WB_MANIFEST);
+precacheAndRoute(self.__WB_MANIFEST, {
+	ignoreURLParametersMatching: [/^v$/],
+});
 
 const SPA_ROUTE_ALLOWLIST = [
 	/^\/$/,                              // Home

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -57,6 +57,18 @@ registerRoute(
 	})
 );
 
+registerRoute(
+	({ request }) => request.destination === "font",
+	new CacheFirst({
+		cacheName: "fonts",
+		plugins: [
+			new ExpirationPlugin({
+				maxEntries: 50,
+			}),
+		],
+	})
+);
+
 self.addEventListener('install', (event) => {
 	self.skipWaiting();
 });

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -4,7 +4,7 @@ import { clientsClaim } from "workbox-core";
 import { ExpirationPlugin } from "workbox-expiration";
 import { precacheAndRoute, createHandlerBoundToURL, cleanupOutdatedCaches, } from "workbox-precaching";
 import { registerRoute } from "workbox-routing";
-import { StaleWhileRevalidate } from "workbox-strategies";
+import { StaleWhileRevalidate, CacheFirst } from "workbox-strategies";
 
 clientsClaim();
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,8 +48,8 @@ export default defineConfig(({ mode }) => {
 				injectManifest: {
 					maximumFileSizeToCacheInBytes: env.VITE_GENERATE_SOURCEMAP === 'true' ? 12 * 1024 * 1024 : 4 * 1024 * 1024,
 					additionalManifestEntries: [
-						{ url: "/manifest.json", revision: null },
-						{ url: "/favicon.ico", revision: null },
+						{ url: "/manifest.json", revision: env.VITE_BRANDING_HASH },
+						{ url: "/favicon.ico", revision: env.VITE_BRANDING_HASH },
 					],
 				},
 			}),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,6 +47,10 @@ export default defineConfig(({ mode }) => {
 				manifest: false, // Vite will use `public/manifest.json` automatically
 				injectManifest: {
 					maximumFileSizeToCacheInBytes: env.VITE_GENERATE_SOURCEMAP === 'true' ? 12 * 1024 * 1024 : 4 * 1024 * 1024,
+					additionalManifestEntries: [
+						{ url: "/manifest.json", revision: null },
+						{ url: "/favicon.ico", revision: null },
+					],
 				},
 			}),
 


### PR DESCRIPTION
Some static assets were not reliably available offline:

- `manifest.json` and favicon.ico could fail when requested with cache-busting query params (?v=...)
- `/assets/*.woff and /assets/*.woff2` fonts were not cached by the Service Worker
- This resulted in ERR_INTERNET_DISCONNECTED when offline

### Solution

1. Explicitly added manifest.json and favicon.ico to Workbox `additionalManifestEntries`
   to guarantee they are precached.

2. Enabled `ignoreURLParametersMatching: [/^v$/]` to ensure cache-busted requests
   (e.g. /manifest.json?v=hash) correctly match the precached entries.

3. Added a `CacheFirst` runtime route for `request.destination === "font"`
   to cache `/assets/*.woff and /assets/*.woff2` after first successful load.
