### PR TITLE
Improve handling of credential images with unknown dimensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "typescript": "^5.1.6",
     "uuid": "^9.0.0",
     "vite-plugin-pwa": "^0.21.1",
-    "wallet-common": "git+https://github.com/wwWallet/wallet-common.git#131445c5632254835f7acb9364af487a045f9951",
+    "wallet-common": "git+https://github.com/wwWallet/wallet-common.git#246121b27629c1d3f40322de4ae677192775623a",
     "web-vitals": "^2.1.4",
     "workbox-core": "^7.3.0",
     "workbox-expiration": "^7.3.0",

--- a/src/components/Credentials/CredentialGridCard.jsx
+++ b/src/components/Credentials/CredentialGridCard.jsx
@@ -4,7 +4,7 @@ import i18n from '@/i18n';
 import { useCredentialName } from '@/hooks/useCredentialName';
 import CredentialImage from './CredentialImage';
 
-const CredentialGridCard = ({ vcEntity, onClick, latestCredentials }) => {
+const CredentialGridCard = ({ vcEntity, onClick, latestCredentials, fixedRatio }) => {
 	const { t } = useTranslation();
 
 	const credentialName = useCredentialName(
@@ -31,6 +31,7 @@ const CredentialGridCard = ({ vcEntity, onClick, latestCredentials }) => {
 				parsedCredential={vcEntity.parsedCredential}
 				className={`w-full h-full object-cover rounded-xl ${latestCredentials.has(vcEntity.batchId) ? 'highlight-filter' : ''
 					}`}
+				fixedRatio={fixedRatio}
 			/>
 		</button>
 	);

--- a/src/components/Credentials/CredentialImage.jsx
+++ b/src/components/Credentials/CredentialImage.jsx
@@ -4,7 +4,17 @@ import UsagesRibbon from "./UsagesRibbon";
 import DefaultCred from "../../assets/images/cred.png";
 import { CredentialCardSkeleton } from '../Skeletons';
 
-const CredentialImage = ({ vcEntity, className, onClick, showRibbon = true, vcEntityInstances = null, filter = null, onLoad, borderColor = undefined }) => {
+const CredentialImage = ({
+	vcEntity,
+	className,
+	onClick,
+	showRibbon = true,
+	vcEntityInstances = null,
+	filter = null,
+	onLoad,
+	borderColor = undefined,
+	fixedRatio = true
+}) => {
 	const [imageSrc, setImageSrc] = useState(undefined);
 
 	useEffect(() => {
@@ -44,13 +54,20 @@ const CredentialImage = ({ vcEntity, className, onClick, showRibbon = true, vcEn
 		<>
 			{vcEntity && imageSrc ? (
 				<>
-					<img src={imageSrc} alt={"Credential"} className={className} onClick={onClick} />
-					{showRibbon &&
-						<ExpiredRibbon vcEntity={vcEntity} borderColor={borderColor} />
-					}
-					{showRibbon &&
-						<UsagesRibbon vcEntityInstances={vcEntityInstances} borderColor={borderColor} />
-					}
+					<div className={`relative w-full overflow-visible ${fixedRatio ? 'aspect-[1.6]' : ''}`}>
+						<img
+							src={imageSrc}
+							alt="Credential"
+							className={`w-full h-full w-full h-full object-cover object-top ${className ?? ''}`}
+							onClick={onClick}
+						/>
+						{showRibbon &&
+							<ExpiredRibbon vcEntity={vcEntity} borderColor={borderColor} />
+						}
+						{showRibbon &&
+							<UsagesRibbon vcEntityInstances={vcEntityInstances} borderColor={borderColor} />
+						}
+					</div>
 				</>
 			) : (
 				<CredentialCardSkeleton />

--- a/src/components/Credentials/CredentialLayout.jsx
+++ b/src/components/Credentials/CredentialLayout.jsx
@@ -41,7 +41,7 @@ const UsageStats = ({ zeroSigCount, sigTotal, screenType, t }) => {
 	);
 };
 
-const CredentialLayout = ({ children, title = null, displayCredentialInfo = null }) => {
+const CredentialLayout = ({ children, title = null, displayCredentialInfo = null, fixedRatioImage = true }) => {
 	const { batchId } = useParams();
 	const screenType = useScreenType();
 	const [showFullscreenImgPopup, setShowFullscreenImgPopup] = useState(false);
@@ -72,6 +72,7 @@ const CredentialLayout = ({ children, title = null, displayCredentialInfo = null
 		onClick = () => setShowFullscreenImgPopup(true),
 		ariaLabel,
 		title,
+		fixedRatioImage = false
 	}) => (
 		<button
 			id="show-full-screen-credential"
@@ -85,6 +86,7 @@ const CredentialLayout = ({ children, title = null, displayCredentialInfo = null
 				parsedCredential={vcEntity.parsedCredential}
 				className={className}
 				showRibbon={showRibbon}
+				fixedRatio={fixedRatioImage}
 			/>
 		</button>
 	);
@@ -93,7 +95,7 @@ const CredentialLayout = ({ children, title = null, displayCredentialInfo = null
 		<div className="w-full flex flex-col lg:flex-row gap-4">
 			{/* LEFT COLUMN (always full width, shrinks on lg) */}
 			<div className="w-full lg:w-1/2 flex flex-col gap-4">
-				<CredentialImageButton showRibbon />
+				<CredentialImageButton showRibbon fixedRatioImage={false} />
 				{zeroSigCount !== null && sigTotal && (
 					<UsageStats zeroSigCount={zeroSigCount} sigTotal={sigTotal} screenType={screenType} t={t} />
 
@@ -118,7 +120,7 @@ const CredentialLayout = ({ children, title = null, displayCredentialInfo = null
 		<div className="w-full flex flex-col">
 			<div className={`flex flex-row items-center gap-5 mt-2 mb-4 px-2`}>
 				<div className='flex flex-col gap-4 w-4/5 xm:w-4/12'>
-					<CredentialImageButton showRibbon={false} />
+					<CredentialImageButton showRibbon={false} fixedRatioImage={fixedRatioImage} />
 					{screenType !== 'mobile' && zeroSigCount !== null && sigTotal && (
 						<UsageStats zeroSigCount={zeroSigCount} sigTotal={sigTotal} screenType={screenType} t={t} />
 
@@ -177,7 +179,7 @@ const CredentialLayout = ({ children, title = null, displayCredentialInfo = null
 			<PageDescription description={t('pageCredentials.details.description')} />
 
 			<div className={`w-full flex flex-col ${displayCredentialInfo && screenType === 'desktop' ? 'lg:flex-row gap-4' : ''} mt-0 lg:mt-5 px-2`}>
-				{screenType === 'desktop' && displayCredentialInfo ? <DesktopLayout /> : <MobileLayout />}
+				{ (screenType === 'desktop' || !fixedRatioImage) ? <DesktopLayout /> : <MobileLayout />}
 			</div>
 			{/* Fullscreen credential Popup*/}
 			{showFullscreenImgPopup && (
@@ -185,7 +187,7 @@ const CredentialLayout = ({ children, title = null, displayCredentialInfo = null
 					isOpen={showFullscreenImgPopup}
 					onClose={() => setShowFullscreenImgPopup(false)}
 					content={
-						<CredentialImage vcEntity={vcEntity} className={"max-w-full max-h-full rounded-xl"} showRibbon={false} />
+						<CredentialImage vcEntity={vcEntity} className={"max-w-full max-h-full rounded-xl"} showRibbon={false} fixedRatio={false} />
 					}
 				/>
 			)}

--- a/src/components/Credentials/CredentialSlideCard.jsx
+++ b/src/components/Credentials/CredentialSlideCard.jsx
@@ -4,7 +4,7 @@ import i18n from '@/i18n';
 import CredentialImage from './CredentialImage';
 import { useCredentialName } from '@/hooks/useCredentialName';
 
-const CredentialSlideCard = ({ vcEntity, isActive, latestCredentials, onClick }) => {
+const CredentialSlideCard = ({ vcEntity, isActive, latestCredentials, onClick, fixedRatio }) => {
 	const { t } = useTranslation();
 
 	const credentialName = useCredentialName(
@@ -32,6 +32,7 @@ const CredentialSlideCard = ({ vcEntity, isActive, latestCredentials, onClick })
 				parsedCredential={vcEntity.parsedCredential}
 				className={`w-full h-full object-cover rounded-xl ${latestCredentials.has(vcEntity.batchId) ? 'highlight-filter' : ''
 					}`}
+				fixedRatio={fixedRatio}
 			/>
 		</button>
 	);

--- a/src/pages/Home/Credential.jsx
+++ b/src/pages/Home/Credential.jsx
@@ -181,7 +181,7 @@ const Credential = () => {
 
 	return (
 
-		<CredentialLayout title={t('pageCredentials.credentialTitle')} displayCredentialInfo={vcEntity && <CredentialInfo parsedCredential={vcEntity.parsedCredential} />}>
+		<CredentialLayout title={t('pageCredentials.credentialTitle')} fixedRatioImage={false} displayCredentialInfo={vcEntity && <CredentialInfo parsedCredential={vcEntity.parsedCredential} />}>
 			<>
 				<div className="w-full pt-2 px-2">
 					{screenType !== 'mobile' ? (

--- a/src/pages/Home/Credential.jsx
+++ b/src/pages/Home/Credential.jsx
@@ -181,7 +181,7 @@ const Credential = () => {
 
 	return (
 
-		<CredentialLayout title={t('pageCredentials.credentialTitle')} fixedRatioImage={false} displayCredentialInfo={vcEntity && <CredentialInfo parsedCredential={vcEntity.parsedCredential} />}>
+		<CredentialLayout title={credentialName} fixedRatioImage={false} displayCredentialInfo={vcEntity && <CredentialInfo parsedCredential={vcEntity.parsedCredential} />}>
 			<>
 				<div className="w-full pt-2 px-2">
 					{screenType !== 'mobile' ? (

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -130,6 +130,7 @@ const Home = () => {
 															vcEntity={vcEntity}
 															latestCredentials={latestCredentials}
 															onClick={handleImageClick}
+															fixedRatio={false}
 														/>
 													))}
 												</div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7281,9 +7281,9 @@ w3c-xmlserializer@^5.0.0:
   dependencies:
     xml-name-validator "^5.0.0"
 
-"wallet-common@git+https://github.com/wwWallet/wallet-common.git#131445c5632254835f7acb9364af487a045f9951":
+"wallet-common@git+https://github.com/wwWallet/wallet-common.git#246121b27629c1d3f40322de4ae677192775623a":
   version "0.0.1"
-  resolved "git+https://github.com/wwWallet/wallet-common.git#131445c5632254835f7acb9364af487a045f9951"
+  resolved "git+https://github.com/wwWallet/wallet-common.git#246121b27629c1d3f40322de4ae677192775623a"
   dependencies:
     "@auth0/mdl" "^2.2.0"
     "@sd-jwt/core" "^0.10.0"


### PR DESCRIPTION
Improve how credential images with unknown dimensions are displayed in the wallet.

This updates the credential images and credential view so images with taller or unexpected proportions can render correctly without breaking the layout or being forced into an unsuitable aspect ratio. It also keeps the option to open and view the full image when needed.

Closes #1023

**Example Before:**

  <img src="https://github.com/user-attachments/assets/edbfaac6-e970-454f-b9c0-047f13e383bf" width="240" />
  <img src="https://github.com/user-attachments/assets/58b7b141-9bf9-43fe-94c9-e2113ba96ee9" width="240" />
  <img src="https://github.com/user-attachments/assets/e8fc489e-f2a0-4c0f-9710-d1a4331d99a4" width="240" />
<img src="https://github.com/user-attachments/assets/e8981805-db91-474b-8d63-d50adc7821d0" width="600" />

---
**Example After:**

<img width="240" src="https://github.com/user-attachments/assets/7be5ffdc-b020-4f3d-8c95-289dfdc8a972" />
<img width="240" src="https://github.com/user-attachments/assets/ae17cff3-5811-4410-9ae3-42ef9ae06947" />
<img width="240" src="https://github.com/user-attachments/assets/cdeca4c1-0e54-4bd8-8cff-07a66556a635" />
<img width="600" src="https://github.com/user-attachments/assets/ff69ca78-87af-4ca1-8fe8-174c10b8604b" />
