### PR TITLE
Isolate metadata image generation and fallback on timeout

### DIFF
--- a/config/branding.ts
+++ b/config/branding.ts
@@ -4,7 +4,8 @@ import path from "node:path";
 import crypto from "node:crypto";
 import sharp from "sharp";
 import { z } from "zod";
-import convert, { RGB } from "color-convert";
+import convert from "color-convert";
+import type { RGB } from "color-convert";
 
 // ============================================
 // TYPES
@@ -597,6 +598,7 @@ export class MetadataImage {
 	private static readonly IMAGE_WIDTH = 1200;
 	private static readonly IMAGE_HEIGHT = 628;
 	private static readonly LOGO_SIZE = 250;
+	private static readonly FALLBACK_LOGO_SIZE = 340;
 	private static readonly MARGIN = 100;
 
 	// Typography
@@ -718,6 +720,54 @@ export class MetadataImage {
 			type: "image/png",
 			source: pngBuffer,
 		}
+	}
+
+	public static async generateMetadataImageFallback(): Promise<{ type: string; source: Buffer; }> {
+		const sourceDir = path.resolve("branding");
+
+		const logoFile = findLogoFile(sourceDir, "logo_dark");
+		if (!logoFile) {
+			throw new Error("Logo not found");
+		}
+
+		const themeFile = findBrandingFile(sourceDir, "theme.json");
+		if (!themeFile) {
+			throw new Error("theme.json not found");
+		}
+
+		const theme = getThemeFile(themeFile.pathname);
+
+		return {
+			type: "image/png",
+			source: await this.createFallbackMetadataImage(theme.brand.color, logoFile.pathname),
+		};
+	}
+
+	private static async createFallbackMetadataImage(background: string, logoPath: string): Promise<Buffer> {
+		const logoBuffer = await sharp(logoPath)
+			.resize(this.FALLBACK_LOGO_SIZE, this.FALLBACK_LOGO_SIZE, { fit: "contain" })
+			.png()
+			.toBuffer();
+		const logoY = Math.round((this.IMAGE_HEIGHT / 2) - (this.FALLBACK_LOGO_SIZE / 2));
+		const logoX = Math.round((this.IMAGE_WIDTH / 2) - (this.FALLBACK_LOGO_SIZE / 2));
+
+		return await sharp({
+			create: {
+				width: this.IMAGE_WIDTH,
+				height: this.IMAGE_HEIGHT,
+				channels: 4,
+				background,
+			},
+		})
+			.composite([
+				{
+					input: logoBuffer,
+					left: logoX,
+					top: logoY,
+				},
+			])
+			.png()
+			.toBuffer();
 	}
 
 	private static wrapTextToLines(text: string, maxLineLength: number): string[] {

--- a/config/files/metadata-image-worker.ts
+++ b/config/files/metadata-image-worker.ts
@@ -8,16 +8,18 @@ function getFlag(flag: string): string | undefined {
 	return index >= 0 ? args[index + 1] : undefined;
 }
 
-const dest = getFlag('--dest');
-const title = getFlag('--title');
+(async () => {
+	const dest = getFlag('--dest');
+	const title = getFlag('--title');
 
-if (!dest) {
-	throw new Error('Missing required flag --dest');
-}
+	if (!dest) {
+		throw new Error('Missing required flag --dest');
+	}
 
-if (!title) {
-	throw new Error('Missing required flag --title');
-}
+	if (!title) {
+		throw new Error('Missing required flag --title');
+	}
 
-const image = await MetadataImage.generateMetadataImage({ title });
-await writeFile(dest, image.source);
+	const image = await MetadataImage.generateMetadataImage({ title });
+	await writeFile(dest, image.source);
+})();

--- a/config/files/metadata-image-worker.ts
+++ b/config/files/metadata-image-worker.ts
@@ -1,0 +1,23 @@
+import { writeFile } from 'node:fs/promises';
+import { MetadataImage } from '../branding.ts';
+
+const args = process.argv.slice(2);
+
+function getFlag(flag: string): string | undefined {
+	const index = args.indexOf(flag);
+	return index >= 0 ? args[index + 1] : undefined;
+}
+
+const dest = getFlag('--dest');
+const title = getFlag('--title');
+
+if (!dest) {
+	throw new Error('Missing required flag --dest');
+}
+
+if (!title) {
+	throw new Error('Missing required flag --title');
+}
+
+const image = await MetadataImage.generateMetadataImage({ title });
+await writeFile(dest, image.source);

--- a/config/files/metadata-image.ts
+++ b/config/files/metadata-image.ts
@@ -1,8 +1,13 @@
-import path from 'node:path';
+import path, { dirname, join } from 'node:path';
+import { execFile } from 'node:child_process';
 import { writeFile } from 'node:fs/promises';
+import { promisify } from 'node:util';
 import { MetadataImage } from '../branding';
 import { EnvConfigMap } from '../config';
 import { TagsMap } from '../utils/resources';
+
+const execFileAsync = promisify(execFile);
+const METADATA_IMAGE_TIMEOUT_MS = 3000;
 
 /**
  * Generates a metadata image based on the provided configuration and writes it to the specified destination directory.
@@ -20,9 +25,29 @@ export default async function metadataImage(destDir: string, config: EnvConfigMa
 		await MetadataImage.setupFontsEnvironment(cacheDir);
 	}
 
-	const image = await MetadataImage.generateMetadataImage(generationConfig);
+	const filePath = path.join(destDir, fileName);
+	const tsxPath = join(dirname(process.execPath), 'tsx');
 
-	await writeFile(path.join(destDir, fileName), image.source);
+	try {
+		await execFileAsync(
+			tsxPath,
+			[
+				path.resolve('config', 'files', 'metadata-image-worker.ts'),
+				'--dest',
+				filePath,
+				'--title',
+				generationConfig.title,
+			],
+			{
+				cwd: process.cwd(),
+				timeout: METADATA_IMAGE_TIMEOUT_MS,
+			},
+		);
+	} catch (error) {
+		console.warn('Metadata image generation failed, using fallback image.', error);
+		const image = await MetadataImage.generateMetadataImageFallback();
+		await writeFile(filePath, image.source);
+	}
 
 	tagsToInject?.set('og-image', {
 		tag: 'meta',

--- a/config/files/metadata-image.ts
+++ b/config/files/metadata-image.ts
@@ -1,4 +1,4 @@
-import path, { dirname, join } from 'node:path';
+import path from 'node:path';
 import { execFile } from 'node:child_process';
 import { writeFile } from 'node:fs/promises';
 import { promisify } from 'node:util';

--- a/config/files/metadata-image.ts
+++ b/config/files/metadata-image.ts
@@ -26,7 +26,6 @@ export default async function metadataImage(destDir: string, config: EnvConfigMa
 	}
 
 	const filePath = path.join(destDir, fileName);
-	const tsxPath = join(dirname(process.execPath), 'tsx');
 
 	try {
 		await execFileAsync(

--- a/config/files/metadata-image.ts
+++ b/config/files/metadata-image.ts
@@ -30,8 +30,9 @@ export default async function metadataImage(destDir: string, config: EnvConfigMa
 
 	try {
 		await execFileAsync(
-			tsxPath,
+			process.execPath,
 			[
+				...process.execArgv,
 				path.resolve('config', 'files', 'metadata-image-worker.ts'),
 				'--dest',
 				filePath,


### PR DESCRIPTION
Adds a resilient fallback for metadata image generation when the normal `image.png` render hangs or fails, on low-capacity and testing VM environments.

Changes
- move metadata image generation into a dedicated worker process
- isolate the timeout to the image.png generation step only
- generate a simplified fallback image (without text, centered the logo) if the worker fails or times out