### PR TITLE
Merge runtime config into existing www:config instead of replacing it

### DIFF
--- a/config/inject.ts
+++ b/config/inject.ts
@@ -106,7 +106,25 @@ export async function injectHtml({ html, config, tagsToInject, brandingHash }: I
 
 	// Inject meta tags
 	(function injectConfigMetaTags() {
-		const metaConfig = getMetaConfigFromEnvConfig(config);
+		const existingMetaTag = document.querySelector('meta[name="www:config"]');
+		let existingMetaConfig = {};
+
+		if (existingMetaTag) {
+			const existingContent = existingMetaTag.getAttribute('content');
+
+			if (existingContent) {
+				try {
+					existingMetaConfig = JSON.parse(existingContent);
+				} catch (error) {
+					console.warn('Failed to parse existing www:config meta tag:', error);
+				}
+			}
+		}
+
+		const metaConfig = {
+			...existingMetaConfig,
+			...getMetaConfigFromEnvConfig(config),
+		};
 
 		// Add branding logo meta tags
 		const { logo_light, logo_dark } = findLogoFiles(resolve('branding'));


### PR DESCRIPTION
This change updates ther config injection so runtime env values are merged into the existing `www:config` meta envs instead of replacing it entirely.

## Change

- Read the existing `meta[name="www:config"]` from the built HTML
- Merge runtime config on top of the existing config
- Keep runtime values as the source of truth when the same key exists in both
