### PR TITLE
Fix cache invalidation for runtime config updates

### DIFF
--- a/config/files/manifest.ts
+++ b/config/files/manifest.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { copyScreenshots, generateAllIcons, Icons } from '../branding';
@@ -27,6 +28,10 @@ export default async function brandingManifest(destDir: string, config: EnvConfi
 
 	const manifestPath = resolve(destDir, 'manifest.json');
 	const manifestContent = JSON.stringify(manifest, null, 2);
+	const manifestRevision = getManifestRevision({
+		brandingHash,
+		name: config.STATIC_NAME || 'wwWallet',
+	});
 
 	await Promise.all([
 		writeFile(manifestPath, manifestContent, 'utf-8'),
@@ -37,7 +42,7 @@ export default async function brandingManifest(destDir: string, config: EnvConfi
 		tag: 'link',
 		props: {
 			rel: 'manifest',
-			href: pathWithBase(config.BASE_PATH, `manifest.json?v=${brandingHash}`),
+			href: pathWithBase(config.BASE_PATH, `manifest.json?v=${manifestRevision}`),
 		}
 	});
 	tagsToInject?.set('apple-touch-icon', {
@@ -54,6 +59,17 @@ export default async function brandingManifest(destDir: string, config: EnvConfi
 			href: pathWithBase(config.BASE_PATH, `favicon.ico?v=${brandingHash}`),
 		},
 	});
+}
+
+export function getManifestRevision({ brandingHash, name }: { brandingHash?: string; name?: string }) {
+	return crypto
+		.createHash('sha256')
+		.update(JSON.stringify({
+			brandingHash: brandingHash || '',
+			name: name || 'wwWallet',
+		}))
+		.digest('hex')
+		.slice(0, 12);
 }
 
 export type GenerateManifestOptions = {

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -4,7 +4,7 @@ import { clientsClaim } from "workbox-core";
 import { ExpirationPlugin } from "workbox-expiration";
 import { precacheAndRoute, cleanupOutdatedCaches, createHandlerBoundToURL, } from "workbox-precaching";
 import { registerRoute } from "workbox-routing";
-import { StaleWhileRevalidate, CacheFirst } from "workbox-strategies";
+import { StaleWhileRevalidate, CacheFirst, NetworkFirst } from "workbox-strategies";
 
 const basePath = new URL(self.registration.scope).pathname.replace(/\/?$/, '/') || '/';
 
@@ -31,6 +31,12 @@ const SPA_ROUTE_ALLOWLIST = [
 	/^\/history\/[^/]+$/,                // History detail
 ];
 
+const appShellHandler = createHandlerBoundToURL(`${basePath}index.html`);
+const appShellStrategy = new NetworkFirst({
+	cacheName: "app-shell",
+	networkTimeoutSeconds: 3,
+});
+
 registerRoute(
 	({ request, url }) => {
 		if (request.mode !== "navigate") return false;
@@ -41,7 +47,24 @@ registerRoute(
 
 		return SPA_ROUTE_ALLOWLIST.some((re) => re.test(pathname));
 	},
-	createHandlerBoundToURL(`${basePath}index.html`)
+	async ({ event }) => {
+		const appShellUrl = new URL(`${basePath}index.html`, self.location.origin);
+
+		try {
+			const response = await appShellStrategy.handle({
+				event,
+				request: new Request(appShellUrl, {
+					credentials: "same-origin",
+				}),
+			});
+
+			if (response) {
+				return response;
+			}
+		} catch {}
+
+		return appShellHandler({ event });
+	}
 );
 
 registerRoute(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,9 +7,16 @@ import checker from 'vite-plugin-checker';
 import { VitePWA } from 'vite-plugin-pwa';
 import tailwindcss from '@tailwindcss/vite';
 import { InjectConfigPlugin } from './vite-plugins';
+import { getManifestRevision } from './config/files/manifest';
+import { getBrandingHash } from './config/branding';
 
 export default defineConfig(async ({ mode }) => {
 	const env = loadEnv(mode, process.cwd(), '');
+	const brandingHash = getBrandingHash(resolve('branding'));
+	const manifestRevision = getManifestRevision({
+		brandingHash,
+		name: env.STATIC_NAME || 'wwWallet',
+	});
 
 	mkdirSync(resolve('public'), { recursive: true });
 
@@ -38,8 +45,8 @@ export default defineConfig(async ({ mode }) => {
 				injectManifest: {
 					maximumFileSizeToCacheInBytes: env.GENERATE_SOURCEMAP === 'true' ? 12 * 1024 * 1024 : 4 * 1024 * 1024,
 					additionalManifestEntries: [
-						{ url: './manifest.json', revision: env.BRANDING_HASH },
-						{ url: './favicon.ico', revision: env.BRANDING_HASH },
+						{ url: './manifest.json', revision: manifestRevision },
+						{ url: './favicon.ico', revision: brandingHash },
 					],
 				},
 			}),


### PR DESCRIPTION
Ensures runtime config updates are picked up without stale cache behavior.

- fetch index.html from network first, with cache fallback for offline use
- version manifest.json using manifest inputs so env-driven changes invalidate correctly
- keep offline support for the manifest via service worker precache