### PR TITLE
Continue `www:config` reuse from #1050 in CLI injection

### DIFF
--- a/config/_cli_.ts
+++ b/config/_cli_.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { getBrandingHash } from './branding';
-import { injectConfigFiles, injectHtml } from './inject';
+import { injectConfigFiles, injectHtml, mergeConfigWithExistingHtml } from './inject';
 import { EnvConfigMapSchema } from './config';
 import { Tag } from './utils/resources';
 
@@ -19,7 +19,10 @@ import { Tag } from './utils/resources';
 	const brandingHash = getBrandingHash(resolve('branding')); // Compute branding hash from your branding folder
 	env.BRANDING_HASH = brandingHash;
 
-	const config = EnvConfigMapSchema.parse(env);
+	let config = EnvConfigMapSchema.parse(env);
+	const htmlFilePath = resolve(DEST_DIR, 'index.html');
+	const htmlContent = await readFile(htmlFilePath, 'utf-8');
+	config = mergeConfigWithExistingHtml(htmlContent, config);
 
 	const tagsToInject = new Map<string, Tag>();
 
@@ -28,9 +31,6 @@ import { Tag } from './utils/resources';
 		config,
 		tagsToInject,
 	});
-
-	const htmlFilePath = resolve(DEST_DIR, 'index.html');
-	const htmlContent = await readFile(htmlFilePath, 'utf-8');
 
 	const updatedHtml = await injectHtml({
 		html: htmlContent,

--- a/config/inject.ts
+++ b/config/inject.ts
@@ -46,6 +46,22 @@ export async function injectConfigFiles({ destDir, config, tagsToInject }: Injec
 	]);
 }
 
+export function mergeConfigWithExistingHtml(html: string, config: EnvConfigMap): EnvConfigMap {
+	const dom = new JSDOM(html);
+	const existingMetaConfig = getExistingMetaConfig(dom.window.document);
+
+	const existingEnvConfig = Object.fromEntries(
+		Object.entries(existingMetaConfig)
+			.filter(([key, value]) => key !== 'branding' && typeof value === 'string')
+			.map(([key, value]) => [key.toUpperCase(), value])
+	);
+
+	return {
+		...existingEnvConfig,
+		...config,
+	};
+}
+
 export type InjectHtmlOptions = {
 	/**
 	 * The HTML content to inject meta tags into.
@@ -106,21 +122,7 @@ export async function injectHtml({ html, config, tagsToInject, brandingHash }: I
 
 	// Inject meta tags
 	(function injectConfigMetaTags() {
-		const existingMetaTag = document.querySelector('meta[name="www:config"]');
-		let existingMetaConfig = {};
-
-		if (existingMetaTag) {
-			const existingContent = existingMetaTag.getAttribute('content');
-
-			if (existingContent) {
-				try {
-					existingMetaConfig = JSON.parse(existingContent);
-				} catch (error) {
-					console.warn('Failed to parse existing www:config meta tag:', error);
-				}
-			}
-		}
-
+		const existingMetaConfig = getExistingMetaConfig(document);
 		const metaConfig = {
 			...existingMetaConfig,
 			...getMetaConfigFromEnvConfig(config),
@@ -170,4 +172,25 @@ export async function injectHtml({ html, config, tagsToInject, brandingHash }: I
 	const updatedHtmlContent = dom.serialize().replace(/\n{2,}/g, '\n');
 
 	return updatedHtmlContent;
+}
+
+function getExistingMetaConfig(document: Document): Record<string, unknown> {
+	const existingMetaTag = document.querySelector('meta[name="www:config"]');
+
+	if (!existingMetaTag) {
+		return {};
+	}
+
+	const existingContent = existingMetaTag.getAttribute('content');
+
+	if (!existingContent) {
+		return {};
+	}
+
+	try {
+		return JSON.parse(existingContent) as Record<string, unknown>;
+	} catch (error) {
+		console.warn('Failed to parse existing www:config meta tag:', error);
+		return {};
+	}
 }


### PR DESCRIPTION
This PR continues the work from #1050 by reusing the existing `www:config` earlier in the CLI injection flow.

### What Changed

- Added `mergeConfigWithExistingHtml(...)` in `config/inject.ts`
- Updated `config/_cli_.ts` to read the existing `index.html` before calling `injectConfigFiles(...)`
- Extracted the `www:config` parsing logic