### PR TITLE
Hide recent items on Add Credentials when few configurations are available

### DIFF
--- a/src/pages/AddCredentials/AddCredentials.jsx
+++ b/src/pages/AddCredentials/AddCredentials.jsx
@@ -206,7 +206,7 @@ const AddCredentials = () => {
 					<QueryableList
 						isOnline={isOnline}
 						list={credentialConfigurations}
-						recent={recent}
+						recent={credentialConfigurations.length < 6 ? [] : recent}
 						queryField='credentialConfigurationDisplayName'
 						translationPrefix='pageAddCredentials'
 						identifierField='identifierField'


### PR DESCRIPTION

Hide the Recent section on the Add Credentials page when the available credential configurations are below the minimum (`< 6`) threshold.

### Change

Update `AddCredentials` to pass an empty `recent` list to `QueryableList` when the number of available credential configurations is below the threshold `(< 6`)
