### PR TITLE
Fix: clear in-memory keystore state on cross-tab logout

### DIFF
--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -196,6 +196,8 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 	const closeSessionTabLocal = useCallback(
 		async (): Promise<void> => {
 			eventTarget.dispatchEvent(new CustomEvent(KeystoreEvent.CloseSessionTabLocal));
+			setPrivateData(null);
+			setCalculatedWalletState(null);
 			clearSessionStorage();
 		},
 		[clearSessionStorage, eventTarget],


### PR DESCRIPTION
When a user logs in from a second tab, the first tab is auto-logged-out as expected. However, trying to log in from the first tab using a cached user could fail with:

`Failed to open keystore Error: Key store is closed.`

This happened because the cross-tab logout flow cleared session storage, but left in-memory keystore state alive in the first tab until a full reload.

### Changes

- Clear in-memory `privateData` on local cross-tab session close
- Clear in-memory `calculatedWalletState` on local cross-tab session close

### Verification

- Log in with a user in tab 1
- Log with a user in tab 2
- Return to tab 1
- Log in using a cached user entry
- Confirm login succeeds without reloading