### PR TITLE
Update wallet-common version for correct vp_token handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typescript": "^5.1.6",
     "uuid": "^9.0.0",
     "vite-plugin-pwa": "^0.21.1",
-    "wallet-common": "git+https://github.com/wwWallet/wallet-common.git#19e7ec23fd8277b0efef88bd2c5b8da051bf28b6",
+    "wallet-common": "git+https://github.com/wwWallet/wallet-common.git#b0fb76941820d1b3868840661baf7e056773ba62",
     "web-vitals": "^2.1.4",
     "workbox-core": "^7.3.0",
     "workbox-expiration": "^7.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7342,9 +7342,9 @@ w3c-xmlserializer@^5.0.0:
   dependencies:
     xml-name-validator "^5.0.0"
 
-"wallet-common@git+https://github.com/wwWallet/wallet-common.git#19e7ec23fd8277b0efef88bd2c5b8da051bf28b6":
+"wallet-common@git+https://github.com/wwWallet/wallet-common.git#b0fb76941820d1b3868840661baf7e056773ba62":
   version "0.0.1"
-  resolved "git+https://github.com/wwWallet/wallet-common.git#19e7ec23fd8277b0efef88bd2c5b8da051bf28b6"
+  resolved "git+https://github.com/wwWallet/wallet-common.git#b0fb76941820d1b3868840661baf7e056773ba62"
   dependencies:
     "@auth0/mdl" "^2.2.0"
     "@sd-jwt/core" "^0.10.0"


### PR DESCRIPTION
Based on https://github.com/wwWallet/wallet-common/pull/94
Handles case mentioned in #817 

wwWallet was returning DCQL vp_token entries as strings:
`{"query_0":"<vp>"}`
but OpenID4VP 1.0 requires arrays:
`{"query_0":["<vp>"]}`
