### PR TITLE
feat: Add support for multiple enc algorithms for credential response encryption

### DIFF
--- a/src/lib/services/OpenID4VCI/CredentialRequest.ts
+++ b/src/lib/services/OpenID4VCI/CredentialRequest.ts
@@ -272,7 +272,8 @@ export function useCredentialRequest() {
 		}
 
 		const credentialResponse = await httpProxy.post(credentialEndpointURLRef.current, credentialEndpointBody, httpHeaders);
-		if (encryptionRequested && credentialResponse.headers['content-type'] === 'application/jwt') {
+		const contentType = credentialResponse.headers['Content-Type'] ?? credentialResponse.headers['content-type'];
+		if (encryptionRequested && typeof contentType === 'string' && contentType.startsWith('application/jwt')) {
 			const result = await compactDecrypt(credentialResponse.data as string, ephemeralKeypair.privateKey).then((r) => ({ data: r, err: null })).catch((err) => ({ data: null, err: err }));
 			if (result.err) {
 				throw new Error("Credential Response decryption failed");

--- a/src/lib/services/OpenID4VCI/CredentialRequest.ts
+++ b/src/lib/services/OpenID4VCI/CredentialRequest.ts
@@ -235,10 +235,11 @@ export function useCredentialRequest() {
 
 			const credentialResponseEncryptionSupportedErrors = [];
 
-			const walletSupportedAlg = 'ECDH-ES';
+			const walletSupportedAlg = ['ECDH-ES'];
 			const issuerSupportedAlgs = credentialIssuerMetadata.metadata.credential_response_encryption.alg_values_supported;
-			if (!issuerSupportedAlgs.includes(walletSupportedAlg)) {
-				credentialResponseEncryptionSupportedErrors.push("Unsupported credential_response_encryption.alg_values_supported. ['ECDH-ES'] are supported");
+			const mutuallySupportedAlg = walletSupportedAlg.find(alg => issuerSupportedAlgs.includes(alg));
+			if (!mutuallySupportedAlg) {
+				credentialResponseEncryptionSupportedErrors.push(`Unsupported credential_response_encryption.alg_values_supported. [${walletSupportedAlg.join(', ')}] are supported`);
 			}
 
 			const walletSupportedEnc = ['A128CBC-HS256', 'A256GCM'];
@@ -260,11 +261,11 @@ export function useCredentialRequest() {
 			if (encryptionRequested) {
 				const ephemeralPublicKeyJwk = await exportJWK(ephemeralKeypair.publicKey);
 				credentialEndpointBody.credential_response_encryption = {
-					alg: walletSupportedAlg,
+					alg: mutuallySupportedAlg,
 					enc: mutuallySupportedEnc,
 					jwk: {
 						...ephemeralPublicKeyJwk,
-						alg: walletSupportedAlg,
+						alg: mutuallySupportedAlg,
 						use: 'enc'
 					},
 				};

--- a/src/lib/services/OpenID4VCI/CredentialRequest.ts
+++ b/src/lib/services/OpenID4VCI/CredentialRequest.ts
@@ -237,8 +237,12 @@ export function useCredentialRequest() {
 			if (!credentialIssuerMetadata.metadata.credential_response_encryption.alg_values_supported.includes('ECDH-ES')) {
 				credentialResponseEncryptionSupportedErrors.push("Unsupported credential_response_encryption.alg_values_supported. ['ECDH-ES'] are supported");
 			}
-			if (!credentialIssuerMetadata.metadata.credential_response_encryption.enc_values_supported.includes('A128CBC-HS256')) {
-				credentialResponseEncryptionSupportedErrors.push("Unsupported credential_response_encryption.enc_values_supported. ['A128CBC-HS256'] are supported");
+
+			const walletSupportedEnc = ['A128CBC-HS256', 'A256GCM'];
+			const issuerSupportedEnc = credentialIssuerMetadata.metadata.credential_response_encryption.enc_values_supported;
+			const mutuallySupportedEnc = walletSupportedEnc.find(enc => issuerSupportedEnc.includes(enc));
+			if (!mutuallySupportedEnc) {
+				credentialResponseEncryptionSupportedErrors.push("Unsupported credential_response_encryption.enc_values_supported. ['A128CBC-HS256', 'A256GCM'] are supported");
 			}
 
 			if (credentialResponseEncryptionSupportedErrors.length > 0) {
@@ -254,8 +258,12 @@ export function useCredentialRequest() {
 				const ephemeralPublicKeyJwk = await exportJWK(ephemeralKeypair.publicKey);
 				credentialEndpointBody.credential_response_encryption = {
 					alg: 'ECDH-ES',
-					enc: 'A128CBC-HS256',
-					jwk: { ...ephemeralPublicKeyJwk, "use": "enc", },
+					enc: mutuallySupportedEnc,
+					jwk: {
+						...ephemeralPublicKeyJwk,
+						alg: 'ECDH-ES',
+						use: 'enc'
+					},
 				};
 			}
 		}

--- a/src/lib/services/OpenID4VCI/CredentialRequest.ts
+++ b/src/lib/services/OpenID4VCI/CredentialRequest.ts
@@ -234,7 +234,10 @@ export function useCredentialRequest() {
 			const encryptionRequired = credentialIssuerMetadata.metadata.credential_response_encryption.encryption_required;
 
 			const credentialResponseEncryptionSupportedErrors = [];
-			if (!credentialIssuerMetadata.metadata.credential_response_encryption.alg_values_supported.includes('ECDH-ES')) {
+
+			const walletSupportedAlg = 'ECDH-ES';
+			const issuerSupportedAlgs = credentialIssuerMetadata.metadata.credential_response_encryption.alg_values_supported;
+			if (!issuerSupportedAlgs.includes(walletSupportedAlg)) {
 				credentialResponseEncryptionSupportedErrors.push("Unsupported credential_response_encryption.alg_values_supported. ['ECDH-ES'] are supported");
 			}
 
@@ -257,11 +260,11 @@ export function useCredentialRequest() {
 			if (encryptionRequested) {
 				const ephemeralPublicKeyJwk = await exportJWK(ephemeralKeypair.publicKey);
 				credentialEndpointBody.credential_response_encryption = {
-					alg: 'ECDH-ES',
+					alg: walletSupportedAlg,
 					enc: mutuallySupportedEnc,
 					jwk: {
 						...ephemeralPublicKeyJwk,
-						alg: 'ECDH-ES',
+						alg: walletSupportedAlg,
 						use: 'enc'
 					},
 				};


### PR DESCRIPTION
## Summary
<!-- What does this PR change and why? -->
Fixes wwWallet/wallet-frontend#1070 by implementing support for `A256GCM` as a fallback `enc` algorithm for credential response encryption.
Before this change, wwWallet only accepted `A128CBC-HS256`. 

## Type of change
<!-- Check all that apply -->
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Documentation
- [ ] Tests
- [ ] Build/CI
- [ ] Chore

## Related issues / tickets
<!-- Link issues with keywords to auto-close, e.g. "Fixes #123" -->
- Fixes wwWallet/wallet-frontend#1070
- Related sirosfoundation/wallet-frontend#43

## Changes
<!-- Bullet list of the key changes -->
- Add `A256GCM` to the wallet's supported `enc` algorithms for credential response encryption
- Replace hardcoded `enc` selection with capability negotiation against the issuer's `enc_values_supported`
- Extract `ECDH-ES` alg string into a `walletSupportedAlg` constant, eliminating repeated string literals
- Add `alg: 'ECDH-ES'` to the ephemeral JWK for improved RFC 7517 compliance
- Fix `Content-Type` header lookup to check both `Content-Type` and `content-type` (case-insensitive fallback)
- Switch `content-type` check from strict equality to `startsWith` to allow media type parameters (e.g. `application/jwt; charset=utf-8`)

## Checklist
- [x] I self-reviewed my changes
- [ ] I added/updated tests (or explained why not)
- [ ] I updated documentation (if needed)
- [x] I ran the relevant checks locally (lint/unit/integration)
- [x] I verified backward compatibility / migration notes (if needed)
- [ ] I added monitoring/logging (if needed)

