### PR TITLE
Fix: make install prompt text non-clickable and simplify icon rendering

### DIFF
--- a/src/components/PWAInstall/PWAInstallPrompt.jsx
+++ b/src/components/PWAInstall/PWAInstallPrompt.jsx
@@ -20,9 +20,9 @@ const PWAInstallPrompt = () => {
 						) : (
 							<Download className='mr-2' size={32} />
 						)}
-						<a href="/" className={`font-semibold cursor-pointer transition-all duration-300 text-sm`}>
+						<p className='font-semibold text-sm'>
 							{t('pwaInstallPrompt.message')}
-						</a>
+						</p>
 					</div>
 					<div className='flex items-center space-y'>
 						<Button

--- a/src/components/PWAInstall/PWAInstallPrompt.jsx
+++ b/src/components/PWAInstall/PWAInstallPrompt.jsx
@@ -15,11 +15,7 @@ const PWAInstallPrompt = () => {
 			<div className={`w-full flex justify-center ${screenType === 'desktop' && 'mt-5'}`}>
 				<div className='flex border border-lm-gray-400 dark:border-dm-gray-600 m-3 p-3 rounded-lg shadow justify-between w-full sm:w-96'>
 					<div className='flex items-center text-lm-gray-900 dark:text-dm-gray-100'>
-						{screenType !== 'desktop' ? (
-							<Download className='mr-2' size={32} />
-						) : (
-							<Download className='mr-2' size={32} />
-						)}
+						<Download className='mr-2' size={32} />
 						<p className='font-semibold text-sm'>
 							{t('pwaInstallPrompt.message')}
 						</p>


### PR DESCRIPTION
This PR updates the PWA install prompt UI in `PWAInstallPrompt` with two focused improvements:
- Removes click behaviorfrom the prompt message text.
- Simplifies redundant icon rendering logic.
