### PR TITLE
Use OpenID4VPHandover session transcript for mdoc device response

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "typescript": "^5.1.6",
     "uuid": "^9.0.0",
     "vite-plugin-pwa": "^0.21.1",
-    "wallet-common": "git+https://github.com/wwWallet/wallet-common.git#7248778a756913a6f738694f48f4b10563726c8d",
+    "wallet-common": "git+https://github.com/wwWallet/wallet-common.git#a74c6f7d2e5c553c4d633d3af559b561026ce479",
     "web-vitals": "^2.1.4",
     "workbox-core": "^7.3.0",
     "workbox-expiration": "^7.3.0",

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -98,7 +98,7 @@ export interface LocalStorageKeystore {
 		CommitCallback,
 	]>,
 
-	generateDeviceResponse(mdocCredential: MDoc, presentationDefinition: any, mdocGeneratedNonce: string, verifierGeneratedNonce: string, clientId: string, responseUri: string, verifierEncryptionJwk?: JsonWebKey | Record<string, unknown>): Promise<{ deviceResponseMDoc: MDoc }>,
+	generateDeviceResponse(mdocCredential: MDoc, presentationDefinition: any, mdocGeneratedNonce: string, verifierGeneratedNonce: string, clientId: string, responseUri: string, verifierEncryptionJwk?: JsonWebKey | Record<string, unknown>, handoverType?: "redirect" | "dc_api", dcApiOrigin?: string): Promise<{ deviceResponseMDoc: MDoc }>,
 	generateDeviceResponseWithProximity(mdocCredential: MDoc, presentationDefinition: any, sessionTranscriptBytes: any): Promise<{ deviceResponseMDoc: MDoc }>,
 
 	getCalculatedWalletState(): WalletState | null,
@@ -639,8 +639,8 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 	);
 
 	const generateDeviceResponse = useCallback(
-		async (mdocCredential: MDoc, presentationDefinition: any, mdocGeneratedNonce: string, verifierGeneratedNonce: string, clientId: string, responseUri: string, verifierEncryptionJwk?: JsonWebKey | Record<string, unknown>): Promise<{ deviceResponseMDoc: MDoc }> => (
-			await keystore.generateDeviceResponse(await openPrivateData(), mdocCredential as any, presentationDefinition, mdocGeneratedNonce, verifierGeneratedNonce, clientId, responseUri, verifierEncryptionJwk) as unknown as { deviceResponseMDoc: MDoc }
+		async (mdocCredential: MDoc, presentationDefinition: any, mdocGeneratedNonce: string, verifierGeneratedNonce: string, clientId: string, responseUri: string, verifierEncryptionJwk?: JsonWebKey | Record<string, unknown>, handoverType?: "redirect" | "dc_api", dcApiOrigin?: string): Promise<{ deviceResponseMDoc: MDoc }> => (
+			await keystore.generateDeviceResponse(await openPrivateData(), mdocCredential as any, presentationDefinition, mdocGeneratedNonce, verifierGeneratedNonce, clientId, responseUri, verifierEncryptionJwk, handoverType, dcApiOrigin) as unknown as { deviceResponseMDoc: MDoc }
 		),
 		[openPrivateData]
 	);

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -98,7 +98,7 @@ export interface LocalStorageKeystore {
 		CommitCallback,
 	]>,
 
-	generateDeviceResponse(mdocCredential: MDoc, presentationDefinition: any, mdocGeneratedNonce: string, verifierGeneratedNonce: string, clientId: string, responseUri: string): Promise<{ deviceResponseMDoc: MDoc }>,
+	generateDeviceResponse(mdocCredential: MDoc, presentationDefinition: any, mdocGeneratedNonce: string, verifierGeneratedNonce: string, clientId: string, responseUri: string, verifierEncryptionJwk?: JsonWebKey | Record<string, unknown>): Promise<{ deviceResponseMDoc: MDoc }>,
 	generateDeviceResponseWithProximity(mdocCredential: MDoc, presentationDefinition: any, sessionTranscriptBytes: any): Promise<{ deviceResponseMDoc: MDoc }>,
 
 	getCalculatedWalletState(): WalletState | null,
@@ -639,8 +639,8 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 	);
 
 	const generateDeviceResponse = useCallback(
-		async (mdocCredential: MDoc, presentationDefinition: any, mdocGeneratedNonce: string, verifierGeneratedNonce: string, clientId: string, responseUri: string): Promise<{ deviceResponseMDoc: MDoc }> => (
-			await keystore.generateDeviceResponse(await openPrivateData(), mdocCredential as any, presentationDefinition, mdocGeneratedNonce, verifierGeneratedNonce, clientId, responseUri) as unknown as { deviceResponseMDoc: MDoc }
+		async (mdocCredential: MDoc, presentationDefinition: any, mdocGeneratedNonce: string, verifierGeneratedNonce: string, clientId: string, responseUri: string, verifierEncryptionJwk?: JsonWebKey | Record<string, unknown>): Promise<{ deviceResponseMDoc: MDoc }> => (
+			await keystore.generateDeviceResponse(await openPrivateData(), mdocCredential as any, presentationDefinition, mdocGeneratedNonce, verifierGeneratedNonce, clientId, responseUri, verifierEncryptionJwk) as unknown as { deviceResponseMDoc: MDoc }
 		),
 		[openPrivateData]
 	);

--- a/src/services/keystore.ts
+++ b/src/services/keystore.ts
@@ -8,8 +8,8 @@ import * as didUtil from "@cef-ebsi/key-did-resolver/dist/util.js";
 import * as config from '../config';
 import type { DidKeyVersion } from '../config';
 import { byteArrayEquals, filterObject, jsonParseTaggedBinary, jsonStringifyTaggedBinary, toBase64Url } from "../util";
+import { buildOpenId4VpSessionTranscriptBytes } from "wallet-common";
 import { SDJwt } from "@sd-jwt/core";
-import { cborEncode } from "@owf/mdoc";
 import { withHintsFromAllowCredentials } from "@/util-webauthn";
 import { addDeleteKeypairEvent, addNewKeypairEvent, CurrentSchema, foldState, SchemaV1, SchemaV2, SchemaV3 } from "./WalletStateSchema";
 import { createDeviceResponseForPresentationDefinition, extractDevicePublicKeyJwkFromMdoc, type MDoc } from "../utils/mdocHolderContext";
@@ -1239,43 +1239,7 @@ export async function generateKeypairs(
 	return [{ keypairs }, newPrivateData];
 }
 
-export async function generateDeviceResponse([privateData, mainKey, calculatedState]: [PrivateData, CryptoKey, WalletState], mdocCredential: MDoc, presentationDefinition: any, mdocGeneratedNonce: string, verifierGeneratedNonce: string, clientId: string, responseUri: string, verifierEncryptionJwk?: JsonWebKey | Record<string, unknown>): Promise<{ deviceResponseMDoc: MDoc }> {
-
-	const base64urlToBytes = (base64urlValue: string): Uint8Array => {
-		const base64 = base64urlValue.replace(/-/g, "+").replace(/_/g, "/");
-		const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
-		const binary = atob(padded);
-		const bytes = new Uint8Array(binary.length);
-		for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-		return bytes;
-	};
-
-	const getSessionTranscriptBytesForOID4VP = async (
-		clId: string,
-		respUri: string,
-		nonce: string,
-		encJwk?: JsonWebKey | Record<string, unknown>
-	) => {
-		const thumbprintB64u = encJwk
-			? await jose.calculateJwkThumbprint(encJwk as jose.JWK, "sha256")
-			: null;
-		const jwkThumbprint = thumbprintB64u ? base64urlToBytes(thumbprintB64u) : null;
-
-		const handoverInfoBytes = cborEncode(
-			[clId, nonce, jwkThumbprint, respUri]
-		);
-		const handoverInfoHash = new Uint8Array(
-			await crypto.subtle.digest("SHA-256", handoverInfoBytes)
-		);
-
-		return cborEncode(
-			[
-				null,
-				null,
-				["OpenID4VPHandover", handoverInfoHash],
-			]
-		);
-	};
+export async function generateDeviceResponse([privateData, mainKey, calculatedState]: [PrivateData, CryptoKey, WalletState], mdocCredential: MDoc, presentationDefinition: any, mdocGeneratedNonce: string, verifierGeneratedNonce: string, clientId: string, responseUri: string, verifierEncryptionJwk?: JsonWebKey | Record<string, unknown>, handoverType: "redirect" | "dc_api" = "redirect", dcApiOrigin?: string): Promise<{ deviceResponseMDoc: MDoc }> {
 	const devicePublicKeyJwk = extractDevicePublicKeyJwkFromMdoc(mdocCredential);
 	const kid = await jose.calculateJwkThumbprint(devicePublicKeyJwk, "sha256");
 	console.log("KID = ", kid)
@@ -1293,13 +1257,21 @@ export async function generateDeviceResponse([privateData, mainKey, calculatedSt
 	console.log("verifierGeneratedNonce = ", verifierGeneratedNonce);
 	console.log("clientId = ", clientId);
 	console.log("responseUri = ", responseUri);
+	console.log("handoverType = ", handoverType);
 
-	const sessionTranscriptBytes = await getSessionTranscriptBytesForOID4VP(
+	const resolvedDcApiOrigin = handoverType === "dc_api"
+		? (dcApiOrigin ?? clientId.replace(/^origin:/, ""))
+		: undefined;
+
+	const sessionTranscriptBytes = await buildOpenId4VpSessionTranscriptBytes({
+		subtle: crypto.subtle,
+		handoverType,
 		clientId,
 		responseUri,
-		verifierGeneratedNonce,
-		verifierEncryptionJwk
-	);
+		nonce: verifierGeneratedNonce,
+		dcApiOrigin: resolvedDcApiOrigin,
+		verifierEncryptionJwk,
+	});
 
 	const uint8ArrayToHexString = (uint8Array: Uint8Array) => Array.from(uint8Array, byte => byte.toString(16).padStart(2, '0')).join('');
 	console.log("Session transcript bytes (HEX): ", uint8ArrayToHexString(new Uint8Array(sessionTranscriptBytes)));

--- a/src/services/keystore.ts
+++ b/src/services/keystore.ts
@@ -11,7 +11,7 @@ import * as config from '../config';
 import type { DidKeyVersion } from '../config';
 import { byteArrayEquals, filterObject, jsonParseTaggedBinary, jsonStringifyTaggedBinary, toBase64Url } from "../util";
 import { SDJwt } from "@sd-jwt/core";
-import { cborEncode, CoseKey, DataItem, DeviceRequest, DocRequest, Holder, ItemsRequest, IssuerSigned, type DeviceResponse, type MdocContext } from "@owf/mdoc";
+import { cborEncode, CoseKey, DeviceRequest, DocRequest, Holder, ItemsRequest, IssuerSigned, type DeviceResponse, type MdocContext } from "@owf/mdoc";
 import { withHintsFromAllowCredentials } from "@/util-webauthn";
 import { addDeleteKeypairEvent, addNewKeypairEvent, CurrentSchema, foldState, SchemaV1, SchemaV2, SchemaV3 } from "./WalletStateSchema";
 
@@ -1432,27 +1432,43 @@ export async function generateKeypairs(
 	return [{ keypairs }, newPrivateData];
 }
 
-export async function generateDeviceResponse([privateData, mainKey, calculatedState]: [PrivateData, CryptoKey, WalletState], mdocCredential: MDoc, presentationDefinition: any, mdocGeneratedNonce: string, verifierGeneratedNonce: string, clientId: string, responseUri: string): Promise<{ deviceResponseMDoc: MDoc }> {
+export async function generateDeviceResponse([privateData, mainKey, calculatedState]: [PrivateData, CryptoKey, WalletState], mdocCredential: MDoc, presentationDefinition: any, mdocGeneratedNonce: string, verifierGeneratedNonce: string, clientId: string, responseUri: string, verifierEncryptionJwk?: JsonWebKey | Record<string, unknown>): Promise<{ deviceResponseMDoc: MDoc }> {
 
-	const getSessionTranscriptBytesForOID4VP = async (clId: string, respUri: string, nonce: string, mdocNonce: string) => cborEncode(
-		DataItem.fromData(
+	const base64urlToBytes = (base64urlValue: string): Uint8Array => {
+		const base64 = base64urlValue.replace(/-/g, "+").replace(/_/g, "/");
+		const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+		const binary = atob(padded);
+		const bytes = new Uint8Array(binary.length);
+		for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+		return bytes;
+	};
+
+	const getSessionTranscriptBytesForOID4VP = async (
+		clId: string,
+		respUri: string,
+		nonce: string,
+		encJwk?: JsonWebKey | Record<string, unknown>
+	) => {
+		const thumbprintB64u = encJwk
+			? await jose.calculateJwkThumbprint(encJwk as jose.JWK, "sha256")
+			: null;
+		const jwkThumbprint = thumbprintB64u ? base64urlToBytes(thumbprintB64u) : null;
+
+		const handoverInfoBytes = cborEncode(
+			[clId, nonce, jwkThumbprint, respUri]
+		);
+		const handoverInfoHash = new Uint8Array(
+			await crypto.subtle.digest("SHA-256", handoverInfoBytes)
+		);
+
+		return cborEncode(
 			[
 				null,
 				null,
-				[
-					await crypto.subtle.digest(
-						'SHA-256',
-						cborEncode([clId, mdocNonce]),
-					),
-					await crypto.subtle.digest(
-						'SHA-256',
-						cborEncode([respUri, mdocNonce]),
-					),
-					nonce
-				]
+				["OpenID4VPHandover", handoverInfoHash],
 			]
-		)
-	);
+		);
+	};
 	const devicePublicKeyJwk = extractDevicePublicKeyJwkFromMdoc(mdocCredential);
 	const kid = await jose.calculateJwkThumbprint(devicePublicKeyJwk, "sha256");
 	console.log("KID = ", kid)
@@ -1475,7 +1491,7 @@ export async function generateDeviceResponse([privateData, mainKey, calculatedSt
 		clientId,
 		responseUri,
 		verifierGeneratedNonce,
-		mdocGeneratedNonce
+		verifierEncryptionJwk
 	);
 
 	const uint8ArrayToHexString = (uint8Array: Uint8Array) => Array.from(uint8Array, byte => byte.toString(16).padStart(2, '0')).join('');

--- a/yarn.lock
+++ b/yarn.lock
@@ -7101,9 +7101,9 @@ w3c-xmlserializer@^5.0.0:
   dependencies:
     xml-name-validator "^5.0.0"
 
-"wallet-common@git+https://github.com/wwWallet/wallet-common.git#7248778a756913a6f738694f48f4b10563726c8d":
+"wallet-common@git+https://github.com/wwWallet/wallet-common.git#a74c6f7d2e5c553c4d633d3af559b561026ce479":
   version "0.0.1"
-  resolved "git+https://github.com/wwWallet/wallet-common.git#7248778a756913a6f738694f48f4b10563726c8d"
+  resolved "git+https://github.com/wwWallet/wallet-common.git#a74c6f7d2e5c553c4d633d3af559b561026ce479"
   dependencies:
     "@noble/curves" "^2.2.0"
     "@owf/mdoc" "^0.6.0"


### PR DESCRIPTION
Update mdoc `DeviceResponse` generation to use OpenID4VPHandover-aligned transcript inputs (`client_id`, `nonce`, `response_uri`, optional verifier key thumbprint) as per [Openid4VP v1.0 - Handover and SessionTranscript Definitions](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-handover-and-sessiontranscr)

Depends on https://github.com/wwWallet/wallet-common/pull/104