### PR TITLE
Request JSON response in fetchAndParseWithSchema

### DIFF
--- a/src/lib/services/OpenID4VCIHelper.ts
+++ b/src/lib/services/OpenID4VCIHelper.ts
@@ -17,7 +17,7 @@ export function useOpenID4VCIHelper(): IOpenID4VCIHelper {
 	const fetchAndParseWithSchema = useCallback(
 		async function fetchAndParseWithSchema<T>(path: string, schema: any, useCache: boolean = true, cacheOnError: boolean = false): Promise<T> {
 			try {
-				const response = await httpProxy.get(path, {}, { useCache: useCache !== undefined ? useCache : true, cacheOnError });
+				const response = await httpProxy.get(path, {"Accept": "application/json"}, { useCache: useCache !== undefined ? useCache : true, cacheOnError });
 				if (!response) throw new Error("Couldn't get response");
 
 				const result = schema.safeParse(response.data);


### PR DESCRIPTION
This PR adds an `"Accept": "application/json"` in the request in function fetchAndParseWithSchema().

From the function's name, it is implied that a JSON response is expected, which shall be parsed against a JSON Schema or Zod Schema.

Without this Accept header, credential issuers which may serve both unencrypted JSONs or encrypted JWTs will now be asked to serve a JSON response.