### PR TITLE
Load reflect-metadata at app entrypoint for tsyringe

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-transition-group": "^4.4.5",
     "react-webcam": "^7.2.0",
     "reactour": "^1.19.2",
+    "reflect-metadata": "^0.2.2",
     "sharp": "^0.34.5",
     "styled-components": "^6.1.13",
     "swiper": "^11.1.14",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,4 +1,5 @@
 // Index.jsx
+import 'reflect-metadata';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,4 +1,5 @@
 // Index.jsx
+// Required by @peculiar/x509 via wallet-common before tsyringe is evaluated.
 import 'reflect-metadata';
 import React from 'react';
 import { createRoot } from 'react-dom/client';


### PR DESCRIPTION
This fixes a production startup crash (white screen) caused by missing Reflect metadata polyfill required by `tsyringe`.

> Uncaught Error: tsyringe requires a reflect polyfill. Please add 'import "reflect-metadata"' to the top of your entry point.