### PR TITLE
Fix blank screen by adding Suspense for lazy popups

### DIFF
--- a/src/hocs/UriHandlerProvider.tsx
+++ b/src/hocs/UriHandlerProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useContext, useRef, useCallback } from "react";
+import React, { useEffect, useState, useContext, useRef, useCallback, Suspense } from "react";
 import { useLocation } from "react-router-dom";
 import StatusContext from "../context/StatusContext";
 import SessionContext from "../context/SessionContext";
@@ -350,12 +350,14 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 	return (
 		<>
 			{children}
-			{showPinInputPopup &&
-				<PinInputPopup isOpen={showPinInputPopup} setIsOpen={setShowPinInputPopup} />
-			}
-			{isMessagePopupOpen &&
-				<MessagePopup type={typeMessagePopup} message={textMessagePopup} onClose={() => setMessagePopup(false)} />
-			}
+			<Suspense fallback={null}>
+				{showPinInputPopup &&
+					<PinInputPopup isOpen={showPinInputPopup} setIsOpen={setShowPinInputPopup} />
+				}
+				{isMessagePopupOpen &&
+					<MessagePopup type={typeMessagePopup} message={textMessagePopup} onClose={() => setMessagePopup(false)} />
+				}
+			</Suspense>
 			{showSyncPopup &&
 				<SyncPopup message={textSyncPopup}
 					onClose={() => {


### PR DESCRIPTION
Adds a minimal `Suspense` boundary around lazy-loaded popup components in `UriHandlerProvider` (`MessagePopup`, `PinInputPopup`)

This prevents runtime crashes (React lazy-load error) when showing error popups during failed OpenID4VP presentation flows and restores expected popup behavior.





