### PR TITLE
Update PRF Compatibility Chrome on Linux & Cross-device with iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ The PRF (Pseudo Random Function) extension in WebAuthn enables the evaluation of
       <td>Linux</td>
       <td>iOS</td>
       <td>Hybrid</td>
-      <td>❌</td>
+      <td>✅</td>
       <td>❌</td>
       <td> </td>
     </tr>


### PR DESCRIPTION
Chrome 148.0.7778.167 (on Linux) 
iOS 16.5 (fbfc3007-154e-4ecc-8c0b-6e020557d7bd) 
PRF output on credentials.create is now supported
