### PR TITLE
Fix zod schema infinite heap error

### DIFF
--- a/src/lib/services/OpenID4VCIHelper.ts
+++ b/src/lib/services/OpenID4VCIHelper.ts
@@ -93,7 +93,7 @@ export function useOpenID4VCIHelper(): IOpenID4VCIHelper {
 const fetchDataWithSchemaWithFallback = useCallback(
 	async function fetchDataWithSchemaWithFallback<T>(
 		endpointPaths: string[],
-		schema: z.ZodSchema<T>,
+		schema: any,
 		useCache?: boolean
 	): Promise<T | null> {
 		const errors: Array<{ path: string; error: Error }> = [];
@@ -145,7 +145,7 @@ const fetchDataWithSchemaWithFallback = useCallback(
 				`${credentialIssuerIdentifier}/.well-known/openid-configuration`,
 			];
 
-			const metadata = await fetchDataWithSchemaWithFallback(endpointPaths, OpenidCredentialIssuerMetadataSchema, useCache);
+			const metadata = await fetchDataWithSchemaWithFallback<OpenidCredentialIssuerMetadata>(endpointPaths, OpenidCredentialIssuerMetadataSchema, useCache);
 			if (!metadata) {
 				return null;
 			}
@@ -188,7 +188,7 @@ const fetchDataWithSchemaWithFallback = useCallback(
 				`${credentialIssuerIdentifier}/${wellKnownOauthAuthorizationServer}`,
 				`${credentialIssuerIdentifier}/${wellKnownOpenidConfiguration}`
 			];
-			authzServerMetadata = await fetchDataWithSchemaWithFallback(endpointPaths, OpenidAuthorizationServerMetadataSchema, useCache);
+			authzServerMetadata = await fetchDataWithSchemaWithFallback<OpenidAuthorizationServerMetadata>(endpointPaths, OpenidAuthorizationServerMetadataSchema, useCache);
 
 			return authzServerMetadata ? { authzServerMetadata } : null;
 		},

--- a/src/lib/services/OpenID4VCIHelper.ts
+++ b/src/lib/services/OpenID4VCIHelper.ts
@@ -8,7 +8,6 @@ import { MdocIacasResponse, MdocIacasResponseSchema, prependToPath } from "walle
 import { OpenidAuthorizationServerMetadataSchema, OpenidCredentialIssuerMetadataSchema } from 'wallet-common';
 import type { OpenidAuthorizationServerMetadata, OpenidCredentialIssuerMetadata } from 'wallet-common'
 import { OPENID4VCI_REDIRECT_URI } from "@/config";
-import { z } from "zod";
 
 export function useOpenID4VCIHelper(): IOpenID4VCIHelper {
 	const httpProxy = useHttpProxy();


### PR DESCRIPTION
This PR fixes a Typescript issue with a big Zod schema that caused the `Type instantiation is excessively deep and possibly infinite.` warning, as well as actual `maximum heap size exceeded` errors. Now, the Zod schema is typed as `any` to avoid this issue. Zod validates it anyway so it is safe to use any in this scenario.