### PR TITLE
Improve MDOC rendering for custom dates, objects and arrays

### DIFF
--- a/src/components/Credentials/CredentialInfo.jsx
+++ b/src/components/Credentials/CredentialInfo.jsx
@@ -6,6 +6,7 @@ import JsonViewer from '../JsonViewer/JsonViewer';
 import useScreenType from '../../hooks/useScreenType';
 import FullscreenPopup from '../Popups/FullscreenImg';
 import { Asterisk, Send } from 'lucide-react';
+import { isCborDate } from '@/utils/cborDate';
 
 const Legend = ({ showRequired, showRequested, t }) => {
 	if (!showRequired && !showRequested) return null;
@@ -190,11 +191,81 @@ const formatClaimValue = (value, imageAlt, fullscreenTitle, onImageClick) => {
 		}
 	}
 
+	if (isCborDate(value)) {
+		return formatDate(value.date, 'date');
+	}
+
 	if (typeof value === 'object') {
 		return renderJson(value);
 	}
 
 	return formatDate(value, 'date');
+};
+
+const flattenMdocSignedClaims = (signedClaims) => {
+	if (!signedClaims || typeof signedClaims !== 'object') {
+		return signedClaims;
+	}
+
+	const flattened = {};
+
+	Object.values(signedClaims).forEach(namespaceObj => {
+		if (
+			namespaceObj &&
+			typeof namespaceObj === 'object'
+		) {
+			Object.assign(flattened, namespaceObj);
+		}
+	});
+
+	return flattened;
+};
+
+const isNumericObject = (v) =>
+	v &&
+	typeof v === 'object' &&
+	!Array.isArray(v) &&
+	Object.keys(v).length > 0 &&
+	Object.keys(v).every(k => !isNaN(Number(k)));
+
+const normalizeArrayClaim = (value, display, required) => {
+	if (!Array.isArray(value)) return value;
+
+	return Object.fromEntries(
+		value.map((item, idx) => [
+			String(idx),
+			{
+				display,
+				value: item,
+				required
+			}
+		])
+	);
+};
+
+const normalizeMdocValue = (value, display, required) => {
+	if (Array.isArray(value)) {
+		return Object.fromEntries(
+			value.map((v, i) => [
+				String(i),
+				{
+					display,
+					value: v,
+					required
+				}
+			])
+		);
+	}
+
+	if (isNumericObject(value)) {
+		return value;
+	}
+
+	if (value && typeof value === 'object') {
+		return value;
+	}
+
+	return value;
 };
 
 const CredentialInfo = ({ parsedCredential, mainClassName = "text-sm lg:text-base w-full", fallbackClaims, requested }) => {
@@ -206,8 +277,29 @@ const CredentialInfo = ({ parsedCredential, mainClassName = "text-sm lg:text-bas
 	const requestedFields = requested?.fields ?? null;
 	const requestedDisplay = requested?.display ?? undefined;
 
-	const signedClaims = parsedCredential?.signedClaims;
-	const claims = parsedCredential?.metadata?.credential?.TypeMetadata?.claims;
+	const isMsoMdoc = parsedCredential?.metadata?.credential?.format === 'mso_mdoc';
+
+	const signedClaims = isMsoMdoc
+		? flattenMdocSignedClaims(parsedCredential?.signedClaims)
+		: parsedCredential?.signedClaims;
+
+	const claims = isMsoMdoc
+		? parsedCredential?.metadata?.credential?.TypeMetadata?.claims?.map(claim => {
+			const path = claim.path || [];
+
+			if (
+				parsedCredential?.metadata?.credential?.format === 'mso_mdoc' &&
+				path.length > 1
+			) {
+				return {
+					...claim,
+					path: path.slice(1),
+				};
+			}
+
+			return claim;
+		})
+		: parsedCredential?.metadata?.credential?.TypeMetadata?.claims;
 
 	// Define custom claims to display from signedClaims if claims is missing
 	const customClaims = fallbackClaims ? fallbackClaims :
@@ -322,12 +414,32 @@ const CredentialInfo = ({ parsedCredential, mainClassName = "text-sm lg:text-bas
 
 		const { label, description } = getLabelAndDescriptionByLang(claim.display || [], language, fallbackLng);
 		const display = { label, description };
+		const normalizedValue = normalizeMdocValue(
+			rawValue,
+			display,
+			claim.required
+		);
 
 		const imageAlt = label || '';
 		const fullscreenTitle = t('pageCredentials.credentialFullScreenTitle', {
 			friendlyName: label
 		});
-		const formattedValue = formatClaimValue(rawValue, imageAlt, fullscreenTitle, setFullscreenImage);
+		let formattedValue;
+
+		if (Array.isArray(rawValue)) {
+			formattedValue = normalizeArrayClaim(
+				normalizedValue,
+				display,
+				claim.required
+			);
+		} else {
+			formattedValue = formatClaimValue(
+				normalizedValue,
+				imageAlt,
+				fullscreenTitle,
+				setFullscreenImage
+			);
+		}
 
 		addToNestedObject(nestedClaims, claim.path, display, formattedValue, claim.required);
 	});
@@ -378,11 +490,15 @@ const CredentialInfo = ({ parsedCredential, mainClassName = "text-sm lg:text-bas
 				requested === fullPath || requested.startsWith(fullPath + '.') || fullPath.startsWith(requested + '.')
 			);
 
-			const isRequired = requestedFields && node.required;
+const isRequired = requestedFields && node.required;
 			if (!node.display) {
 				return renderClaims(value, [...currentPath, key]);
 			}
-			if (typeof value === 'object' && !React.isValidElement(value)) {
+			if (
+				typeof value === 'object' &&
+				value !== null &&
+				!React.isValidElement(value)
+			) {
 				return (
 					<div key={fullPath} className="w-full">
 						<details className="pl-2 py-1 rounded-md" open={isRequested || isRequired}>

--- a/src/components/Credentials/CredentialInfo.jsx
+++ b/src/components/Credentials/CredentialInfo.jsx
@@ -70,7 +70,14 @@ const getValueByPath = (path, obj) => {
 		!React.isValidElement(result) &&
 		Object.keys(result).length === 0
 	) {
-		return undefined;
+		if (result instanceof Map) {
+			if (result.size === 0) {
+				return undefined;
+			}
+		}
+		else if (Object.keys(result).length === 0) {
+			return undefined;
+		}
 	}
 
 	return result;
@@ -120,6 +127,35 @@ const expandDisplayClaims = (claims, signedClaims) => {
 	});
 
 	return expanded;
+};
+
+export const findDisplayForPath = (
+	visibleClaims,
+	path,
+	language,
+	fallbackLng,
+	getLabelAndDescriptionByLang
+) => {
+	const matchingClaim = visibleClaims.find(c =>
+		Array.isArray(c.path) &&
+		c.path.length === path.length &&
+		c.path.every((segment, index) => segment === path[index])
+	);
+
+	if (!matchingClaim?.display) {
+		return {
+			label: path[path.length - 1],
+			description: ''
+		};
+	}
+
+	const { label, description } = getLabelAndDescriptionByLang(
+		matchingClaim.display,
+		language,
+		fallbackLng
+	);
+
+	return { label, description };
 };
 
 const isDisplayClaim = (claim) => {
@@ -241,6 +277,34 @@ const normalizeArrayClaim = (value, display, required) => {
 			}
 		])
 	);
+};
+
+export const normalizeMapClaim = (
+	map,
+	parentPath,
+	visibleClaims,
+	language,
+	fallbackLng,
+	required,
+	getLabelAndDescriptionByLang
+) => {
+	if (!(map instanceof Map)) return [];
+
+	return Array.from(map.entries()).map(([key, value]) => {
+		const nestedPath = [...parentPath, key];
+
+		return {
+			display: findDisplayForPath(
+				visibleClaims,
+				nestedPath,
+				language,
+				fallbackLng,
+				getLabelAndDescriptionByLang
+			),
+			required,
+			value
+		};
+	});
 };
 
 const normalizeMdocValue = (value, display, required) => {
@@ -426,7 +490,17 @@ const CredentialInfo = ({ parsedCredential, mainClassName = "text-sm lg:text-bas
 		});
 		let formattedValue;
 
-		if (Array.isArray(rawValue)) {
+		if (rawValue instanceof Map) {
+			formattedValue = normalizeMapClaim(
+				rawValue,
+				claim.path,
+				visibleClaims,
+				language,
+				fallbackLng,
+				claim.required,
+				getLabelAndDescriptionByLang
+			);
+		} else if (Array.isArray(rawValue)) {
 			formattedValue = normalizeArrayClaim(
 				normalizedValue,
 				display,
@@ -490,7 +564,7 @@ const CredentialInfo = ({ parsedCredential, mainClassName = "text-sm lg:text-bas
 				requested === fullPath || requested.startsWith(fullPath + '.') || fullPath.startsWith(requested + '.')
 			);
 
-const isRequired = requestedFields && node.required;
+			const isRequired = requestedFields && node.required;
 			if (!node.display) {
 				return renderClaims(value, [...currentPath, key]);
 			}

--- a/src/components/JsonViewer/JsonViewer.jsx
+++ b/src/components/JsonViewer/JsonViewer.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { isCborDate, formatCborDate } from '@/utils/cborDate';
 
 const MAX_STRING_LENGTH = 100;
 
@@ -8,13 +9,29 @@ const JsonViewer = ({ name, value, depth = 0 }) => {
 	const [expanded, setExpanded] = useState(depth === 0);
 	const [showFullString, setShowFullString] = useState(false);
 
-	const isObject = (val) => val && typeof val === 'object' && !Array.isArray(val);
+	const isObject = (val) => val && typeof val === 'object' && !Array.isArray(val) && !(val instanceof Map);
 	const isArray = Array.isArray;
 
 	const toggleExpanded = () => setExpanded((prev) => !prev);
 	const toggleString = () => setShowFullString((prev) => !prev);
 
 	const indentClass = depth === 0 ? '' : 'pl-4';
+
+
+	if (isCborDate(value)) {
+		value = formatCborDate(value);
+	}
+
+	if (value instanceof Map) {
+		const normalized = Object.fromEntries(value);
+
+		// Single-entry map -> behave like scalar value
+		if (Object.keys(normalized).length === 1) {
+			value = Object.values(normalized)[0];
+		} else {
+			value = normalized;
+		}
+	}
 
 	if (isArray(value)) {
 		return (

--- a/src/utils/cborDate.ts
+++ b/src/utils/cborDate.ts
@@ -1,0 +1,45 @@
+type CborDateWrapper = {
+	date: Date | string | number;
+};
+
+/**
+ * Detects CBOR tag 1004 date wrapper objects.
+ */
+export const isCborDate = (value: unknown): value is CborDateWrapper => {
+	if (typeof value !== 'object' || value === null) {
+		return false;
+	}
+
+	if (!('date' in value)) {
+		return false;
+	}
+
+	const dateValue = value.date;
+
+	return (
+		dateValue instanceof Date ||
+		typeof dateValue === 'string' ||
+		typeof dateValue === 'number'
+	);
+};
+
+/**
+ * Formats a CBOR date wrapper into a localized date string.
+ */
+export const formatCborDate = (
+	value: CborDateWrapper,
+	locales: string | string[] = 'en-GB',
+): string => {
+	const rawDate = value.date;
+
+	const parsedDate =
+		rawDate instanceof Date
+			? rawDate
+			: new Date(rawDate);
+
+	if (Number.isNaN(parsedDate.getTime())) {
+		return String(rawDate);
+	}
+
+	return parsedDate.toLocaleDateString(locales);
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { truncateByWords } from "./truncateByWords";
 export { prettyDomain } from "./prettyDomain";
+export * from "./cborDate";


### PR DESCRIPTION
This PR improves MSO-MDOC rendering of Credential Information, in displayed form as well as JSON view.

- Custom CBOR dates are treated like normal strings.
- Arrays and objects now use the beautified dropdown that already existed for SD-JWT VCs.
- Error with maps showing as {Object(0)} in JSON has been fixed.