### PR TITLE
Show error popup on PAR failure, add configurable popup loading delay

### DIFF
--- a/src/components/Popups/PopupLayout.jsx
+++ b/src/components/Popups/PopupLayout.jsx
@@ -1,14 +1,30 @@
 // PopupLayout.js
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Modal from 'react-modal';
 import Spinner from '../Shared/Spinner';
 import Header from '../Layout/Header';
 
-const PopupLayout = ({ isOpen, onClose, loading = false, fullScreen = false, children, padding = 'p-4', shouldCloseOnOverlayClick = true }) => {
+const PopupLayout = ({ isOpen, onClose, loading = false, loadingDelayMs = 0, fullScreen = false, children, padding = 'p-4', shouldCloseOnOverlayClick = true }) => {
+	const [showLoading, setShowLoading] = useState(false);
+
+	useEffect(() => {
+		if (!loading) {
+			setShowLoading(false);
+			return;
+		}
+
+		if (loadingDelayMs <= 0) {
+			setShowLoading(true);
+			return;
+		}
+
+		const timeoutId = setTimeout(() => setShowLoading(true), loadingDelayMs);
+		return () => clearTimeout(timeoutId);
+	}, [loading, loadingDelayMs]);
 
 	if (!isOpen) return null;
 
-	if (loading) {
+	if (loading && showLoading) {
 		return (
 			<Modal
 				isOpen={true}

--- a/src/components/Popups/PopupLayout.jsx
+++ b/src/components/Popups/PopupLayout.jsx
@@ -4,7 +4,7 @@ import Modal from 'react-modal';
 import Spinner from '../Shared/Spinner';
 import Header from '../Layout/Header';
 
-const PopupLayout = ({ isOpen, onClose, loading = false, loadingDelayMs = 0, fullScreen = false, children, padding = 'p-4', shouldCloseOnOverlayClick = true }) => {
+const PopupLayout = ({ isOpen, onClose, loading = false, showLoadingAfterMs = 0, fullScreen = false, children, padding = 'p-4', shouldCloseOnOverlayClick = true }) => {
 	const [showLoading, setShowLoading] = useState(false);
 
 	useEffect(() => {
@@ -13,14 +13,14 @@ const PopupLayout = ({ isOpen, onClose, loading = false, loadingDelayMs = 0, ful
 			return;
 		}
 
-		if (loadingDelayMs <= 0) {
+		if (showLoadingAfterMs <= 0) {
 			setShowLoading(true);
 			return;
 		}
 
-		const timeoutId = setTimeout(() => setShowLoading(true), loadingDelayMs);
+		const timeoutId = setTimeout(() => setShowLoading(true), showLoadingAfterMs);
 		return () => clearTimeout(timeoutId);
-	}, [loading, loadingDelayMs]);
+	}, [loading, showLoadingAfterMs]);
 
 	if (!isOpen) return null;
 

--- a/src/components/Popups/RedirectPopup.jsx
+++ b/src/components/Popups/RedirectPopup.jsx
@@ -4,11 +4,11 @@ import Button from '../Buttons/Button';
 import PopupLayout from './PopupLayout';
 import { ExternalLink } from 'lucide-react';
 
-const RedirectPopup = ({ loading, loadingDelayMs = 0, onClose, handleContinue, popupTitle, popupMessage }) => {
+const RedirectPopup = ({ loading, showLoadingAfterMs = 0, onClose, handleContinue, popupTitle, popupMessage }) => {
 	const { t } = useTranslation();
 
 	return (
-		<PopupLayout isOpen={true} onClose={onClose} loading={loading} loadingDelayMs={loadingDelayMs}>
+		<PopupLayout isOpen={true} onClose={onClose} loading={loading} showLoadingAfterMs={showLoadingAfterMs}>
 			<h2 className="text-lg font-bold mb-2 text-lm-gray-900 dark:text-dm-gray-100">
 				<ExternalLink size={20} className="inline mr-1 mb-1" />
 				{popupTitle}

--- a/src/components/Popups/RedirectPopup.jsx
+++ b/src/components/Popups/RedirectPopup.jsx
@@ -4,11 +4,11 @@ import Button from '../Buttons/Button';
 import PopupLayout from './PopupLayout';
 import { ExternalLink } from 'lucide-react';
 
-const RedirectPopup = ({ loading, onClose, handleContinue, popupTitle, popupMessage }) => {
+const RedirectPopup = ({ loading, loadingDelayMs = 0, onClose, handleContinue, popupTitle, popupMessage }) => {
 	const { t } = useTranslation();
 
 	return (
-		<PopupLayout isOpen={true} onClose={onClose} loading={loading}>
+		<PopupLayout isOpen={true} onClose={onClose} loading={loading} loadingDelayMs={loadingDelayMs}>
 			<h2 className="text-lg font-bold mb-2 text-lm-gray-900 dark:text-dm-gray-100">
 				<ExternalLink size={20} className="inline mr-1 mb-1" />
 				{popupTitle}

--- a/src/pages/AddCredentials/AddCredentials.jsx
+++ b/src/pages/AddCredentials/AddCredentials.jsx
@@ -231,7 +231,7 @@ const AddCredentials = () => {
 			{showRedirectPopup && selectedCredentialConfiguration && (
 				<RedirectPopup
 					loading={loading}
-					loadingDelayMs={200}
+					showLoadingAfterMs={200}
 					onClose={handleCancel}
 					handleContinue={handleContinue}
 					popupTitle={redirectPopupContent?.title}

--- a/src/pages/AddCredentials/AddCredentials.jsx
+++ b/src/pages/AddCredentials/AddCredentials.jsx
@@ -13,6 +13,7 @@ import CredentialsContext from '@/context/CredentialsContext';
 import useFilterItemByLang from '@/hooks/useFilterItemByLang';
 import { buildCredentialConfiguration } from '@/components/QueryableList/CredentialsDisplayUtils';
 import { buildCredentialRedirectPopupContent } from '@/components/Popups/credentialRedirectPopupContent';
+import MessagePopup from '@/components/Popups/MessagePopup';
 
 const AddCredentials = () => {
 	const { isOnline } = useContext(StatusContext);
@@ -24,6 +25,7 @@ const AddCredentials = () => {
 
 	const [selectedCredentialConfiguration, setSelectedCredentialConfiguration] = useState(null);
 	const [loading, setLoading] = useState(false);
+	const [messagePopupState, setMessagePopupState] = useState(null);
 
 	const openID4VCIHelper = useOpenID4VCIHelper();
 	const { openID4VCI } = useContext(OpenID4VCIContext);
@@ -172,10 +174,12 @@ const AddCredentials = () => {
 		setSelectedCredentialConfiguration(null);
 	};
 
-	const handleContinue = () => {
+	const handleContinue = async () => {
 		setLoading(true);
-
-		if (selectedCredentialConfiguration) {
+		try {
+			if (!selectedCredentialConfiguration) {
+				return;
+			}
 			const { credentialConfigurationId, credentialIssuerIdentifier } = selectedCredentialConfiguration;
 
 			const userHandleB64u = keystore.getUserHandleB64u();
@@ -183,19 +187,26 @@ const AddCredentials = () => {
 				console.error("Could not generate authorization request because user handle is null");
 				return;
 			}
-			openID4VCI.generateAuthorizationRequest(credentialIssuerIdentifier, credentialConfigurationId).then((result) => {
-				if ('url' in result) {
-					const { url } = result;
-					window.location.href = url;
-				}
-			}).catch((err) => {
-				console.error(err)
-				console.error("Couldn't generate authz req")
-			});
-		}
 
-		setLoading(false);
-		setShowRedirectPopup(false);
+			const result = await openID4VCI.generateAuthorizationRequest(credentialIssuerIdentifier, credentialConfigurationId);
+			if ('url' in result) {
+				const { url } = result;
+				window.location.href = url;
+			}
+		} catch (err) {
+			console.error(err);
+			console.error("Couldn't generate authz req");
+			setMessagePopupState({
+				type: 'error',
+				message: {
+					title: t('issuance.error'),
+					description: t('messagePopup.addCredentialProcessFailed.defaultDescription'),
+				},
+			});
+		} finally {
+			setLoading(false);
+			setShowRedirectPopup(false);
+		}
 	};
 
 	return (
@@ -220,10 +231,18 @@ const AddCredentials = () => {
 			{showRedirectPopup && selectedCredentialConfiguration && (
 				<RedirectPopup
 					loading={loading}
+					loadingDelayMs={200}
 					onClose={handleCancel}
 					handleContinue={handleContinue}
 					popupTitle={redirectPopupContent?.title}
 					popupMessage={redirectPopupContent?.message}
+				/>
+			)}
+			{messagePopupState && (
+				<MessagePopup
+					type={messagePopupState.type}
+					message={messagePopupState.message}
+					onClose={() => setMessagePopupState(null)}
 				/>
 			)}
 		</>


### PR DESCRIPTION
This PR adds user-facing error handling for PAR failures in the Add Credentials flow.
It also introduces configurable popup loading delay to prevent spinner flicker in fast-fail cases (like in PAR failures).

### Changes
In AddCredentials:
- Switched `handleContinue` to `async`/`await` with `try`/`catch`/`finally`
- Added `MessagePopup` error handling when authorization request (PAR) generation fails
- Added configurable delayed loading support in `PopupLayout` via `showLoadingAfterMs` (default 0 for backward compatibility)
- Updated `RedirectPopup` to accept and forward `showLoadingAfterMs`
- Applied `showLoadingAfterMs={200}` in Add Credentials redirect popup to avoid brief spinner blink when PAR fails quickly.

#### Notes
- `showLoadingAfterMs` is optional, existing popup behavior stays unchanged unless explicitly set.
- This PR keeps the change scoped to Add Credentials, loading-delay could be added to other popups as needed 
