### PR TITLE
Use theme context for logo variants

### DIFF
--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -10,7 +10,7 @@ const Header = () => {
 		<header className="sticky top-0 z-50 w-full bg-inherit text-inherit flex items-center justify-between md:hidden border-b border-lm-gray-400 dark:border-dm-gray-600 transition-all duration-300 p-3">
 			<ConnectionStatusIcon size='small' className="transition-all duration-300" />
 			<div className="flex items-center">
-				<Logo type='dark' aClassName='mr-2' imgClassName="cursor-pointer transition-all duration-300 w-8" />
+				<Logo aClassName='mr-2' imgClassName="cursor-pointer transition-all duration-300 w-8" />
 				<a href="/" className="text-lm-gray-900 dark:text-dm-gray-100 font-bold cursor-pointer transition-all duration-300 text-sm">
 					{t('common.walletName')}
 				</a>

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -1,17 +1,20 @@
 import { BRANDING } from '@/config';
-import React, { useEffect, useState } from 'react';
+import React, { useContext } from 'react';
+import AppSettingsContext from '@/context/AppSettingsContext';
 import { useTranslation } from 'react-i18next';
 
+type LogoType = 'light' | 'dark';
+
 interface LogoProps {
-	type?: 'light' | 'dark'; // Determines the type of logo (light or dark)
+	type?: LogoType; // Determines the type of logo (light or dark)
 	clickable?: boolean;
 	alt?: string;
 	aClassName?: string; // Class for the <a> element
 	imgClassName?: string; // Class for the <img> element
 }
 
-function getLogoUrl(type: string): string {
-	return type === 'light' || type === ''
+function getLogoUrl(type: LogoType): string {
+	return type === 'light'
 		? BRANDING.LOGO_LIGHT
 		: BRANDING.LOGO_DARK;
 }
@@ -24,27 +27,8 @@ const Logo: React.FC<LogoProps> = ({
 	imgClassName = '',
 }) => {
 	const { t } = useTranslation();
-	const [logoUrl, setLogoUrl] = useState<string>(getLogoUrl(type));
-
-	useEffect(() => {
-		if (type) return;
-
-		const html = document.documentElement;
-		const observer = new MutationObserver((mutations) => {
-			for (const mutation of mutations) {
-				if (
-					mutation.type === 'attributes' &&
-					mutation.attributeName === 'data-theme'
-				) {
-					setLogoUrl(getLogoUrl(html.getAttribute('data-theme')));
-					}
-			}
-		});
-
-		observer.observe(html, { attributes: true, attributeFilter: ['data-theme'] });
-
-		return () => observer.disconnect();
-	}, [type]);
+	const { resolvedColorScheme } = useContext(AppSettingsContext);
+	const logoUrl = getLogoUrl(type ?? resolvedColorScheme);
 
 	const img = <img src={logoUrl} alt={alt || t('common.walletName')} className={imgClassName} />
 


### PR DESCRIPTION
Updates the `Logo` component to fall back to `AppSettingsContext.resolvedColorScheme` when no explicit `type` prop is provided.

Also removes the hardcoded dark logo from the mobile header so it follows the active theme automatically.