### PR TITLE
Update web app manifest metadata

### DIFF
--- a/config/branding.ts
+++ b/config/branding.ts
@@ -254,6 +254,50 @@ export type Icons = Array<{
 	purpose?: 'monochrome' | 'maskable' | 'any' | (string & {}) | ('monochrome' | 'maskable' | 'any')[];
 }>
 
+export type GetManifestIconEntriesOptions = Pick<GenerateAllIconsOptions, 'manifestIconSizes' | 'brandingHash'>;
+
+/**
+ * Builds manifest icon entries without writing icon files.
+ */
+export function getManifestIconEntries({
+	manifestIconSizes,
+	brandingHash,
+}: GetManifestIconEntriesOptions): Icons {
+	const hashSuffix = brandingHash ? `?v=${brandingHash}` : '';
+	const icons: Icons = [];
+
+	for (const size of manifestIconSizes) {
+		const sizeStr = `${size}x${size}`;
+		const noPurposeFile = `icon-${sizeStr}.png`;
+		const maskableFile = `icon-${sizeStr}-maskable.png`;
+
+		if (size === 192 || size === 512) {
+			icons.push({
+				src: `icons/${noPurposeFile}${hashSuffix}`,
+				sizes: sizeStr,
+				type: "image/png",
+			});
+
+			icons.push({
+				src: `icons/${maskableFile}${hashSuffix}`,
+				sizes: sizeStr,
+				type: "image/png",
+				purpose: "maskable",
+			});
+
+			continue;
+		}
+
+		icons.push({
+			src: `icons/${noPurposeFile}${hashSuffix}`,
+			sizes: sizeStr,
+			type: "image/png",
+		});
+	}
+
+	return icons;
+}
+
 /**
  * Generates all icons (favicon, apple touch icon, manifest icons).
  *
@@ -268,8 +312,6 @@ export async function generateAllIcons({
 	manifestIconSizes,
 	brandingHash,
 }: GenerateAllIconsOptions): Promise<Icons> {
-	const hashSuffix = brandingHash ? `?v=${brandingHash}` : '';
-
 	const favicon = findBrandingFile(sourceDir, path.join("favicon.ico"))
 		|| deprecated_findBrandingFile(path.join(sourceDir, "favicon.ico"));
 
@@ -320,9 +362,6 @@ export async function generateAllIcons({
 			.toFile(path.join(iconsDir, 'apple-touch-icon.png'));
 	}
 
-	// Manifest icons
-	const icons: Icons = [];
-
 	const manifestLogoPathname = logoDark.pathname;
 
 	for (const size of manifestIconSizes) {
@@ -367,12 +406,6 @@ export async function generateAllIcons({
 				.png()
 				.toFile(path.join(iconsDir, noPurposeFile));
 
-			icons.push({
-				src: `icons/${noPurposeFile}${hashSuffix}`,
-				sizes: sizeStr,
-				type: "image/png",
-			});
-
 			// ---------- MASKABLE - FULL WHITE BACKGROUND ----------
 			await sharp({
 				create: {
@@ -395,13 +428,6 @@ export async function generateAllIcons({
 				.png()
 				.toFile(path.join(iconsDir, maskableFile));
 
-			icons.push({
-				src: `icons/${maskableFile}${hashSuffix}`,
-				sizes: sizeStr,
-				type: "image/png",
-				purpose: "maskable",
-			});
-
 			continue;
 		}
 
@@ -410,15 +436,9 @@ export async function generateAllIcons({
 			.resize(size, size, { fit: "contain" })
 			.png()
 			.toFile(path.join(iconsDir, noPurposeFile));
-
-		icons.push({
-			src: `icons/${noPurposeFile}${hashSuffix}`,
-			sizes: sizeStr,
-			type: "image/png",
-		});
 	}
 
-	return icons;
+	return getManifestIconEntries({ manifestIconSizes, brandingHash });
 }
 
 // ============================================

--- a/config/files/manifest.ts
+++ b/config/files/manifest.ts
@@ -134,6 +134,7 @@ function generateManifest({ hash, name, icons }: GenerateManifestOptions): Parti
 				'label': 'Credential selection view'
 			}
 		],
+		'id': '/',
 		'start_url': '/',
 		'display': 'standalone',
 		'orientation': 'portrait',

--- a/config/files/manifest.ts
+++ b/config/files/manifest.ts
@@ -137,7 +137,7 @@ function generateManifest({ hash, name, icons }: GenerateManifestOptions): Parti
 		'id': '/',
 		'start_url': '/',
 		'display': 'standalone',
-		'orientation': 'portrait',
+		'orientation': 'any',
 		'theme_color': '#111827',
 		'description': `${name || 'wwWallet'} enables secure storage and management of verifiable credentials.`,
 		'background_color': '#ffffff',

--- a/config/files/manifest.ts
+++ b/config/files/manifest.ts
@@ -129,6 +129,7 @@ async function generateManifest({ hash, name, icons }: GenerateManifestOptions):
 		],
 		'start_url': '/',
 		'display': 'standalone',
+		'orientation': 'portrait',
 		'theme_color': '#111827',
 		'description': `${name || 'wwWallet'} enables secure storage and management of verifiable credentials.`,
 		'background_color': '#ffffff',

--- a/config/files/manifest.ts
+++ b/config/files/manifest.ts
@@ -1,11 +1,13 @@
 import crypto from 'node:crypto';
 import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
-import { copyScreenshots, generateAllIcons, Icons } from '../branding';
+import { copyScreenshots, generateAllIcons, getManifestIconEntries, Icons } from '../branding';
 import type { ManifestOptions } from 'vite-plugin-pwa';
 import { type EnvConfigMap } from '../config';
 import { type Tag } from '../utils/resources';
 import { pathWithBase } from '../utils/paths';
+
+const MANIFEST_ICON_SIZES = [16, 32, 64, 192, 512];
 
 /**
  * Generates a web app manifest and icons, and injects them into the build output.
@@ -16,11 +18,11 @@ export default async function brandingManifest(destDir: string, config: EnvConfi
 	const icons = await generateAllIcons({
 		sourceDir,
 		publicDir: destDir,
-		manifestIconSizes: [16, 32, 64, 192, 512],
+		manifestIconSizes: MANIFEST_ICON_SIZES,
 		brandingHash,
 	});
 
-	const manifest = await generateManifest({
+	const manifest = generateManifest({
 		hash: brandingHash,
 		name: config.STATIC_NAME || 'wwWallet',
 		icons,
@@ -28,10 +30,7 @@ export default async function brandingManifest(destDir: string, config: EnvConfi
 
 	const manifestPath = resolve(destDir, 'manifest.json');
 	const manifestContent = JSON.stringify(manifest, null, 2);
-	const manifestRevision = getManifestRevision({
-		brandingHash,
-		name: config.STATIC_NAME || 'wwWallet',
-	});
+	const manifestRevision = getManifestRevisionFromContent(manifestContent);
 
 	await Promise.all([
 		writeFile(manifestPath, manifestContent, 'utf-8'),
@@ -62,12 +61,20 @@ export default async function brandingManifest(destDir: string, config: EnvConfi
 }
 
 export function getManifestRevision({ brandingHash, name }: { brandingHash?: string; name?: string }) {
+	return getManifestRevisionFromContent(JSON.stringify(generateManifest({
+		hash: brandingHash,
+		name,
+		icons: getManifestIconEntries({
+			manifestIconSizes: MANIFEST_ICON_SIZES,
+			brandingHash,
+		}),
+	}), null, 2));
+}
+
+function getManifestRevisionFromContent(manifestContent: string) {
 	return crypto
 		.createHash('sha256')
-		.update(JSON.stringify({
-			brandingHash: brandingHash || '',
-			name: name || 'wwWallet',
-		}))
+		.update(manifestContent)
 		.digest('hex')
 		.slice(0, 12);
 }
@@ -90,7 +97,7 @@ export type GenerateManifestOptions = {
 /**
  * Generates a web app manifest based on provided options, including cache-busting for icons and screenshots.
  */
-async function generateManifest({ hash, name, icons }: GenerateManifestOptions): Promise<Partial<ManifestOptions>> {
+function generateManifest({ hash, name, icons }: GenerateManifestOptions): Partial<ManifestOptions> {
 	const hashSuffix = hash ? `?v=${hash}` : '';
 
 	return {


### PR DESCRIPTION
- Add `orientation: "portrait"` to the generated PWA manifest
- Add a stable manifest `id` to help browsers identify the installed app
- Hash the full generated manifest content for revision/cache busting
  - Share manifest icon entry generation between branding and manifest revision logic