### PR TITLE
Update branding assets via runtime cache 

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -83,6 +83,7 @@ registerRoute(
 
 registerRoute(
 	({ url }) =>
+		url.pathname.endsWith(".ico") ||
 		url.pathname.endsWith(".png") ||
 		url.pathname.endsWith(".jpg") ||
 		url.pathname.endsWith(".jpeg") ||

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -68,6 +68,20 @@ registerRoute(
 );
 
 registerRoute(
+	({ request, url }) =>
+		request.destination === "style" &&
+		url.pathname.endsWith("theme.css"),
+	new StaleWhileRevalidate({
+		cacheName: "theme",
+		plugins: [
+			new ExpirationPlugin({
+				maxEntries: 5,
+			}),
+		],
+	})
+);
+
+registerRoute(
 	({ url }) =>
 		url.pathname.endsWith(".png") ||
 		url.pathname.endsWith(".jpg") ||

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,6 +44,7 @@ export default defineConfig(async ({ mode }) => {
 				manifest: false, // Vite will use `public/manifest.json` automatically
 				injectManifest: {
 					maximumFileSizeToCacheInBytes: env.GENERATE_SOURCEMAP === 'true' ? 12 * 1024 * 1024 : 4 * 1024 * 1024,
+					globIgnores: ['theme.css'],
 					additionalManifestEntries: [
 						{ url: './manifest.json', revision: manifestRevision },
 						{ url: './favicon.ico', revision: brandingHash },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,7 +47,6 @@ export default defineConfig(async ({ mode }) => {
 					globIgnores: ['theme.css'],
 					additionalManifestEntries: [
 						{ url: './manifest.json', revision: manifestRevision },
-						{ url: './favicon.ico', revision: brandingHash },
 					],
 				},
 			}),


### PR DESCRIPTION
This PR fixes stale branding assets after deploys.

Previously, `theme.css` and `favicon.ico` could be served from the Workbox precache, which meant a normal reload could still show old branding until a hard refresh.

### Changes

- exclude `theme.css` from the Workbox precache
- serve `theme.css` through a runtime cache using `StaleWhileRevalidate`
- remove `favicon.ico` from `additionalManifestEntries`
- include `.ico` files in the existing runtime image cache route
- keep `manifest.json` explicitly precached

### Why

`theme.css` is already versioned by the branding hash, so it is better handled as a runtime-cached asset than as a precached one. This allows the app to pick up new branding on normal reloads while still keeping offline support.

The favicon now follows the same runtime caching approach as the other image assets.