### PR TITLE
Align theme colors with app backgrounds and use logo light for manifest icons

### DIFF
--- a/config/branding.ts
+++ b/config/branding.ts
@@ -362,7 +362,7 @@ export async function generateAllIcons({
 			.toFile(path.join(iconsDir, 'apple-touch-icon.png'));
 	}
 
-	const manifestLogoPathname = logoDark.pathname;
+	const manifestLogoPathname = logoLight.pathname;
 
 	for (const size of manifestIconSizes) {
 		const sizeStr = `${size}x${size}`;

--- a/config/files/manifest.ts
+++ b/config/files/manifest.ts
@@ -138,7 +138,7 @@ function generateManifest({ hash, name, icons }: GenerateManifestOptions): Parti
 		'start_url': '/',
 		'display': 'standalone',
 		'orientation': 'any',
-		'theme_color': '#111827',
+		'theme_color': '#0c0e11',
 		'description': `${name || 'wwWallet'} enables secure storage and management of verifiable credentials.`,
 		'background_color': '#ffffff',
 		'scope': '/',

--- a/config/files/theme.ts
+++ b/config/files/theme.ts
@@ -28,7 +28,7 @@ export default async function themeCSS(destDir: string, config: EnvConfigMap, ta
 		props: {
 			name: 'theme-color',
 			media: '(prefers-color-scheme: light)',
-			content: '#f8f9f9'
+			content: '#ffffff'
 		}
 	});
 	tagsToInject?.set('theme-color-dark', {


### PR DESCRIPTION
- Update `theme_color` index.html and manifest from the background color
- Use the light logo for manifest icons generate