### PR TITLE
Update keystore generateDeviceResponse for OID4VP1.0 E2EE

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typescript": "^5.1.6",
     "uuid": "^9.0.0",
     "vite-plugin-pwa": "^0.21.1",
-    "wallet-common": "git+https://github.com/wwWallet/wallet-common.git#1acfaa26cf37bb1ba834931d95f4353b9f91c9bd",
+    "wallet-common": "git+https://github.com/wwWallet/wallet-common.git#dce9ea74749417e15497718439cb73de32e17090",
     "web-vitals": "^2.1.4",
     "workbox-core": "^7.3.0",
     "workbox-expiration": "^7.3.0",

--- a/src/lib/types/OpenID4VPRelyingPartyState.ts
+++ b/src/lib/types/OpenID4VPRelyingPartyState.ts
@@ -1,19 +1,11 @@
-import { JWK } from "jose";
 import { DcqlQueryType } from "./dcqlQuery.type";
 import * as z from 'zod';
-import { OpenID4VPResponseMode } from "wallet-common";
+import { OpenID4VPClientMetadata, OpenID4VPResponseMode } from "wallet-common";
 
 export { OpenID4VPResponseMode as ResponseMode };
 
 export const ResponseModeSchema = z.nativeEnum(OpenID4VPResponseMode);
 
-type ClientMetadata = {
-	jwks?: { keys: JWK[] };
-	jwks_uri?: string;
-	authorization_encrypted_response_alg?: string;
-	authorization_encrypted_response_enc?: string;
-	vp_formats: any;
-}
 /**
  * serializable
  */
@@ -24,7 +16,7 @@ export class OpenID4VPRelyingPartyState {
 		public response_uri: string,
 		public client_id: string,
 		public state: string,
-		public client_metadata: ClientMetadata,
+		public client_metadata: OpenID4VPClientMetadata,
 		public response_mode: OpenID4VPResponseMode,
 		public transaction_data: string[],
 		public dcql_query: DcqlQueryType

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -91,7 +91,7 @@ export interface LocalStorageKeystore {
 		CommitCallback,
 	]>,
 
-	generateDeviceResponse(mdocCredential: MDoc, presentationDefinition: any, mdocGeneratedNonce: string, verifierGeneratedNonce: string, clientId: string, responseUri: string, verifierEncryptionJwk?: JsonWebKey | Record<string, unknown>, handoverType?: "redirect" | "dc_api", dcApiOrigin?: string): Promise<{ deviceResponseMDoc: MDoc }>,
+	generateDeviceResponse(mdocCredential: MDoc, presentationDefinition: any, nonce: string, clientId: string, responseUri: string, verifierEncryptionJwk?: JsonWebKey | Record<string, unknown>, handoverType?: "redirect" | "dc_api", dcApiOrigin?: string): Promise<{ deviceResponseMDoc: MDoc }>,
 	generateDeviceResponseWithProximity(mdocCredential: MDoc, presentationDefinition: any, sessionTranscriptBytes: any): Promise<{ deviceResponseMDoc: MDoc }>,
 
 	getCalculatedWalletState(): WalletState | null,
@@ -587,8 +587,8 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 	);
 
 	const generateDeviceResponse = useCallback(
-		async (mdocCredential: MDoc, presentationDefinition: any, mdocGeneratedNonce: string, verifierGeneratedNonce: string, clientId: string, responseUri: string, verifierEncryptionJwk?: JsonWebKey | Record<string, unknown>, handoverType?: "redirect" | "dc_api", dcApiOrigin?: string): Promise<{ deviceResponseMDoc: MDoc }> => (
-			await keystore.generateDeviceResponse(await openPrivateData(), mdocCredential as any, presentationDefinition, mdocGeneratedNonce, verifierGeneratedNonce, clientId, responseUri, verifierEncryptionJwk, handoverType, dcApiOrigin) as unknown as { deviceResponseMDoc: MDoc }
+		async (mdocCredential: MDoc, presentationDefinition: any, nonce: string, clientId: string, responseUri: string, verifierEncryptionJwk?: JsonWebKey | Record<string, unknown>, handoverType?: "redirect" | "dc_api", dcApiOrigin?: string): Promise<{ deviceResponseMDoc: MDoc }> => (
+			await keystore.generateDeviceResponse(await openPrivateData(), mdocCredential as any, presentationDefinition, nonce, clientId, responseUri, verifierEncryptionJwk, handoverType, dcApiOrigin) as unknown as { deviceResponseMDoc: MDoc }
 		),
 		[openPrivateData]
 	);

--- a/src/services/keystore.ts
+++ b/src/services/keystore.ts
@@ -1077,7 +1077,17 @@ export async function generateKeypairs(
 	return [{ keypairs }, newPrivateData];
 }
 
-export async function generateDeviceResponse([privateData, mainKey, calculatedState]: [PrivateData, CryptoKey, WalletState], mdocCredential: MDoc, presentationDefinition: any, mdocGeneratedNonce: string, verifierGeneratedNonce: string, clientId: string, responseUri: string, verifierEncryptionJwk?: JsonWebKey | Record<string, unknown>, handoverType: "redirect" | "dc_api" = "redirect", dcApiOrigin?: string): Promise<{ deviceResponseMDoc: MDoc }> {
+export async function generateDeviceResponse(
+	[privateData, mainKey, calculatedState]: [PrivateData, CryptoKey, WalletState],
+	mdocCredential: MDoc,
+	presentationDefinition: any,
+	nonce: string,
+	clientId: string,
+	responseUri: string,
+	verifierEncryptionJwk?: JsonWebKey | Record<string, unknown>,
+	handoverType: "redirect" | "dc_api" = "redirect",
+	dcApiOrigin?: string
+): Promise<{ deviceResponseMDoc: MDoc }> {
 	const devicePublicKeyJwk = extractDevicePublicKeyJwkFromMdoc(mdocCredential);
 	const kid = await jose.calculateJwkThumbprint(devicePublicKeyJwk, "sha256");
 	console.log("KID = ", kid)
@@ -1091,8 +1101,7 @@ export async function generateDeviceResponse([privateData, mainKey, calculatedSt
 	const { alg, privateKey } = keypair.keypair;
 	const privateKeyJwk = privateKey;
 
-	console.log("mdocGeneratedNonce = ", mdocGeneratedNonce);
-	console.log("verifierGeneratedNonce = ", verifierGeneratedNonce);
+	console.log("nonce = ", nonce);
 	console.log("clientId = ", clientId);
 	console.log("responseUri = ", responseUri);
 	console.log("handoverType = ", handoverType);
@@ -1106,7 +1115,7 @@ export async function generateDeviceResponse([privateData, mainKey, calculatedSt
 		handoverType,
 		clientId,
 		responseUri,
-		nonce: verifierGeneratedNonce,
+		nonce: nonce,
 		dcApiOrigin: resolvedDcApiOrigin,
 		verifierEncryptionJwk,
 	});
@@ -1125,7 +1134,12 @@ export async function generateDeviceResponse([privateData, mainKey, calculatedSt
 	return { deviceResponseMDoc };
 }
 
-export async function generateDeviceResponseWithProximity([privateData, mainKey, calculatedState]: [PrivateData, CryptoKey, WalletState], mdocCredential: MDoc, presentationDefinition: any, sessionTranscriptBytes: any): Promise<{ deviceResponseMDoc: MDoc }> {
+export async function generateDeviceResponseWithProximity(
+	[privateData, mainKey, calculatedState]: [PrivateData, CryptoKey, WalletState],
+	mdocCredential: MDoc,
+	presentationDefinition: any,
+	sessionTranscriptBytes: any
+): Promise<{ deviceResponseMDoc: MDoc }> {
 	const devicePublicKeyJwk = extractDevicePublicKeyJwkFromMdoc(mdocCredential);
 	const kid = await jose.calculateJwkThumbprint(devicePublicKeyJwk, "sha256");
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7101,9 +7101,9 @@ w3c-xmlserializer@^5.0.0:
   dependencies:
     xml-name-validator "^5.0.0"
 
-"wallet-common@git+https://github.com/wwWallet/wallet-common.git#1acfaa26cf37bb1ba834931d95f4353b9f91c9bd":
+"wallet-common@git+https://github.com/wwWallet/wallet-common.git#dce9ea74749417e15497718439cb73de32e17090":
   version "0.0.1"
-  resolved "git+https://github.com/wwWallet/wallet-common.git#1acfaa26cf37bb1ba834931d95f4353b9f91c9bd"
+  resolved "git+https://github.com/wwWallet/wallet-common.git#dce9ea74749417e15497718439cb73de32e17090"
   dependencies:
     "@noble/curves" "^2.2.0"
     "@owf/mdoc" "^0.6.0"


### PR DESCRIPTION
Replace mdoc and verifier nonces with one nonce in keystore generateDeviceResponse, as per OID4VP1.0.

Depends on https://github.com/wwWallet/wallet-common/pull/111