### PR TITLE
Add WALLET_TAGLINE env var to display a tagline on the login page

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -9,6 +9,7 @@ BASE_PATH=/
 # Branding related meta tags
 STATIC_PUBLIC_URL=https://demo.wwwallet.org
 STATIC_NAME=wwWallet
+WALLET_TAGLINE=""
 I18N_WALLET_NAME_OVERRIDE=wwWallet
 OPENID4VCI_REDIRECT_URI=http://localhost:3000/
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Our Web Wallet provides a range of features tailored to enhance the credential m
   - `MULTI_LANGUAGE_DISPLAY`: Enable or disable multi-language support (`true` or `false`). If left empty, it will be handled as `false`.
   - `STATIC_PUBLIC_URL`: The installation's public url.
   - `STATIC_NAME`: The installation's public name.
+  - `WALLET_TAGLINE`: Optional tagline displayed below the wallet name on the login page.
   - `I18N_WALLET_NAME_OVERRIDE`: String to override translations of common.walletName (Optional).
   - `FOLD_EVENT_HISTORY_AFTER_SECONDS`: Fold history events older than this value in seconds (default: 2592000 = 30 days).
   - `DISPLAY_ISSUANCE_WARNINGS`: Enable or disable (`true` or `false`) the display of the issuance warnings popup.

--- a/config/config.ts
+++ b/config/config.ts
@@ -24,6 +24,7 @@ export const ClientEnvConfigSchema = z.object({
 	// If in a multi-tenancy setup, these *should* likely differ between tenants.
 	STATIC_PUBLIC_URL: z.string().optional(),
 	STATIC_NAME: z.string().optional(),
+	WALLET_TAGLINE: z.string().optional(),
 	I18N_WALLET_NAME_OVERRIDE: z.string().optional(),
 	OPENID4VCI_REDIRECT_URI: z.string().optional(),
 

--- a/src/components/Auth/LoginLayout.tsx
+++ b/src/components/Auth/LoginLayout.tsx
@@ -15,11 +15,19 @@ export default function LoginLayout({ children, heading }: { children: React.Rea
 			)}
 
 			<div className="grow flex flex-col items-center justify-center px-6 py-8">
-				<Logo aClassName='mb-6' imgClassName='w-20' />
+				<Logo aClassName='mb-2' imgClassName='w-20' />
 
-				<h1 className="text-3xl mb-8 font-bold leading-tight tracking-tight text-lm-gray-900 text-center dark:text-white">
-					{heading}
-				</h1>
+				<div className="mb-5 text-center">
+					<h1 className="text-3xl mb-2 font-bold leading-tight tracking-tight text-lm-gray-900 dark:text-white">
+						{heading}
+					</h1>
+
+					{config.WALLET_TAGLINE && (
+						<p className="text-sm mb-2 text-lm-gray-700 dark:text-dm-gray-300">
+							{config.WALLET_TAGLINE}
+						</p>
+					)}
+				</div>
 
 				<div className="relative w-full sm:max-w-md xl:p-0">
 					{children}

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,7 @@ export const OPENID4VCI_REDIRECT_URI = config.openid4vci_redirect_uri ?  config.
 export const CLOCK_TOLERANCE = config.clock_tolerance && !isNaN(parseInt(config.clock_tolerance)) ? parseInt(config.clock_tolerance) : 60;
 export const STATIC_PUBLIC_URL = config.static_public_url || 'https://demo.wwwallet.org';
 export const STATIC_NAME = config.static_name || 'wwWallet';
+export const WALLET_TAGLINE: string | undefined = config.wallet_tagline;
 export const OPENID4VCI_PROOF_TYPE_PRECEDENCE = config.openid4vci_proof_type_precedence || 'jwt';
 export const FOLD_EVENT_HISTORY_AFTER_SECONDS = config.fold_event_history_after_seconds && !isNaN(parseInt(config.fold_event_history_after_seconds)) ? parseInt(config.fold_event_history_after_seconds) : 2592000; // 30 days
 export const DISPLAY_ISSUANCE_WARNINGS: boolean = config.display_issuance_warnings ? JSON.parse(config.display_issuance_warnings) : false;


### PR DESCRIPTION
- Added `WALLET_TAGLINE` to `ClientEnvConfigSchema` and exported it from `src/config.ts` so it is injected at runtime via the `www:config` meta tag
- Rendered the tagline below the wallet name (`<h1>`) on the login page in `LoginLayout.tsx` — hidden when the variable is empty or unset
- Added `WALLET_TAGLINE=""` to `.env.template` under the branding section (next to `STATIC_NAME`)
- Documented `WALLET_TAGLINE` in `README.md`

### How to test it

1. Set `WALLET_TAGLINE="Your tagline here"` in `.env` and verify it appears below the wallet name on the login page
2. Leave `WALLET_TAGLINE=""` (or unset) and verify nothing is rendered
3. Check both light and dark mode for correct text color
