### PR TITLE
Optional local Vite overrides config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,6 @@ ssl_keys/*
 .npmrc
 
 variables.vars
+vite.config.local.ts
 
 public/

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Welcome to wwWallet Frontend repository! This application is a user-friendly web
 - 📦 [Installation](#installation)
 - ✅ [Pre-commit Hook](#pre-commit-hook)
 - 🚀 [Usage](#usage)
+- ⚙️ [Local Vite Config](#local-vite-config)
 - 🔐 [PRF Compatibility](#prf-compatibility)
 - 🎨 [Tailwind CSS](#tailwind-css)
 - 💡 [Contributing](#contributing)
@@ -142,6 +143,28 @@ git add -A
 ## 🚀Usage
 
 Once the development server is running, you can access the app by visiting http://localhost:3000 in your web browser. The app provides various pages and components that you can interact with. Explore the features and enjoy using the Wallet Frontend!
+
+## ⚙️Local Vite Config
+
+For local development, you can create an optional `vite.config.local.ts` file in the project root. This file is ignored by git and is merged into the main Vite config when present.
+
+This is useful for machine-specific settings, such as custom dev server proxy rules, without editing the committed `vite.config.ts`.
+
+Example:
+
+```ts
+import type { UserConfig } from 'vite';
+
+export const localViteConfig: Partial<UserConfig> = {
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3000',
+    },
+  },
+};
+```
+
+If `vite.config.local.ts` does not exist, the app uses the default Vite config unchanged.
 
 ## 🔐PRF Compatibility
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,8 @@
-import { mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { defineConfig, loadEnv } from 'vite';
+import type { UserConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 import checker from 'vite-plugin-checker';
@@ -10,8 +12,42 @@ import { InjectConfigPlugin } from './vite-plugins';
 import { getManifestRevision } from './config/files/manifest';
 import { getBrandingHash } from './config/branding';
 
+type LocalViteConfig = Partial<UserConfig>;
+
+const loadLocalViteConfig = async (): Promise<LocalViteConfig> => {
+	const localConfigPath = resolve('vite.config.local.ts');
+
+	if (!existsSync(localConfigPath)) {
+		return {};
+	}
+
+	const localConfigModule = await import(pathToFileURL(localConfigPath).href);
+	return (localConfigModule.localViteConfig ?? localConfigModule.default ?? {}) as LocalViteConfig;
+};
+
+const mergeViteConfig = (baseConfig: UserConfig, localConfig: LocalViteConfig): UserConfig => {
+	const baseServer = baseConfig.server ?? {};
+	const localServer = localConfig.server ?? {};
+	const baseProxy = typeof baseServer === 'object' ? baseServer.proxy : undefined;
+	const localProxy = typeof localServer === 'object' ? localServer.proxy : undefined;
+
+	return {
+		...baseConfig,
+		...localConfig,
+		server: {
+			...(typeof baseServer === 'object' ? baseServer : {}),
+			...(typeof localServer === 'object' ? localServer : {}),
+			proxy: {
+				...(baseProxy && typeof baseProxy === 'object' ? baseProxy : {}),
+				...(localProxy && typeof localProxy === 'object' ? localProxy : {}),
+			},
+		},
+	};
+};
+
 export default defineConfig(async ({ mode }) => {
 	const env = loadEnv(mode, process.cwd(), '');
+	const localViteConfig = await loadLocalViteConfig();
 	const brandingHash = getBrandingHash(resolve('branding'));
 	const manifestRevision = getManifestRevision({
 		brandingHash,
@@ -20,7 +56,7 @@ export default defineConfig(async ({ mode }) => {
 
 	mkdirSync(resolve('public'), { recursive: true });
 
-	return {
+	const baseConfig: UserConfig = {
 		base: './',
 		define: {
 			'import.meta.env.VITE_APP_VERSION': JSON.stringify(process.env.npm_package_version),
@@ -75,5 +111,7 @@ export default defineConfig(async ({ mode }) => {
 			sourcemap: env.GENERATE_SOURCEMAP === 'true',
 			minify: env.GENERATE_SOURCEMAP !== 'true'
 		},
-	}
+	};
+
+	return mergeViteConfig(baseConfig, localViteConfig);
 });


### PR DESCRIPTION
Adds support for an optional `vite.config.local.ts` file in `wallet-frontend`.

This lets developers keep local Vite overrides outside the committed config, for example custom dev server proxy rules or machine-specific settings.

**How to use**

Create a `vite.config.local.ts` file in the `wallet-frontend` root:

```ts
import type { UserConfig } from 'vite';

export const localViteConfig: Partial<UserConfig> = {
  server: {
    proxy: {
      '/api': 'http://localhost:3000',
    },
  },
};