### PR TITLE
Fix: Page becomes unscrollable after closing a popup with a loading state

### DIFF
--- a/src/components/Popups/PopupLayout.jsx
+++ b/src/components/Popups/PopupLayout.jsx
@@ -30,6 +30,7 @@ const PopupLayout = ({ isOpen, onClose, loading = false, showLoadingAfterMs = 0,
 				isOpen={true}
 				className="absolute inset-0 flex items-center justify-center"
 				overlayClassName="fixed inset-0 bg-lm-gray-900/50 dark:bg-dm-gray-500/50 flex items-center justify-center z-50"
+				bodyOpenClassName="overflow-hidden"
 			>
 				<Spinner />
 			</Modal>


### PR DESCRIPTION
### Issue
After a popup shows a loading spinner and then closes (e.g. confirming credential deletion), the page stays unscrollable, `overflow-hidden` remains stuck on `<body>`.

### Cause
`PopupLayout` switches between two `<Modal>` variants with different `bodyOpenClassName` values. React updates the existing instance instead of remounting, so `react-modal` never removes the original `overflow-hidden` class from `<body>`.

### Fix
Use the same `bodyOpenClassName="overflow-hidden"` for both variants so it's added/removed consistently.

### Test
Delete a credential, confirm the page scrolls normally afterward.