### PR TITLE
Fix: Prevent stale privateData reload race in multi-tab login

### DIFF
--- a/src/context/SessionContextProvider.tsx
+++ b/src/context/SessionContextProvider.tsx
@@ -27,11 +27,15 @@ export const SessionContextProvider = ({ children }: React.PropsWithChildren) =>
 
 
 	// Use a ref to hold a stable reference to the clearSession function
-	const clearSessionRef = useRef<() => void>();
+	const clearSessionRef = useRef<(preserveUrlParams?: boolean) => void>();
 
 	// Memoize clearSession using useCallback
-	const clearSession = useCallback(async () => {
-		window.history.replaceState({}, '', `${window.location.pathname}`);
+	const clearSession = useCallback(async (preserveUrlParams: boolean = false) => {
+		// Keep search params so a pending flow can continue after a
+		// cross-tab logout; otherwise clean up the URL.
+		if (!(preserveUrlParams && window.location.search)) {
+			window.history.replaceState({}, '', window.location.pathname);
+		}
 		console.log('[Session Context] Clear Session');
 		api.clearSession();
 	}, [api]);
@@ -49,9 +53,10 @@ export const SessionContextProvider = ({ children }: React.PropsWithChildren) =>
 
 	useEffect(() => {
 		// Handler function that calls the current clearSession function
-		const handleClearSession = () => {
+		const handleClearSession = (event: Event) => {
+			const preserveUrlParams = (event as CustomEvent)?.detail?.preserveUrlParams ?? false;
 			if (clearSessionRef.current) {
-				clearSessionRef.current();
+				clearSessionRef.current(preserveUrlParams);
 			}
 		};
 
@@ -93,7 +98,8 @@ export const SessionContextProvider = ({ children }: React.PropsWithChildren) =>
 
 	useEffect(() => {
 		if (api && keystore && api.isLoggedIn() === true && keystore.isOpen() === false && ((tabId && globalTabId && tabId !== globalTabId) || (!tabId && globalTabId))) {
-			clearSession();
+			// Fallback for the initial-mount race with the event listener below.
+			clearSession(true);
 		}
 	}, [globalTabId, tabId, clearSession, api, keystore]);
 

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, useMemo } from "react";
+import { useCallback, useEffect, useState, useMemo, useRef } from "react";
 import { useNavigate } from 'react-router-dom';
 
 import * as config from "../config";
@@ -195,8 +195,8 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 	}, [writePrivateDataOnIdb]);
 
 	const closeSessionTabLocal = useCallback(
-		async (): Promise<void> => {
-			eventTarget.dispatchEvent(new CustomEvent(KeystoreEvent.CloseSessionTabLocal));
+		async (preserveUrlParams: boolean = false): Promise<void> => {
+			eventTarget.dispatchEvent(new CustomEvent(KeystoreEvent.CloseSessionTabLocal, { detail: { preserveUrlParams } }));
 			setPrivateData(null);
 			setCalculatedWalletState(null);
 			clearSessionStorage();
@@ -250,11 +250,17 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 		[closeSessionTabLocal, privateData, userHandleB64u, globalUserHandleB64u, setCachedUsers],
 	);
 
+	const isFirstTabIdCheck = useRef(true);
+
 	useEffect(
 		() => {
+			const wasInitialMount = isFirstTabIdCheck.current;
+			isFirstTabIdCheck.current = false;
 			if (tabId && globalTabId && (tabId !== globalTabId)) {
-				// When user logs in in any tab, log out in all other tabs
-				closeSessionTabLocal();
+				// When user logs in in any tab, log out in all other tabs.
+				// Preserve URL params only if discovered on initial mount
+				// (eg. returning from a redirect with a pending login).
+				closeSessionTabLocal(wasInitialMount);
 			}
 		},
 		[closeSessionTabLocal, tabId, globalTabId],

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -169,11 +169,15 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 
 	useEffect(() => {
 		if (userHandleB64u) {
+			let cancelled = false;
 			readPrivateDataFromIdb(userHandleB64u).then((val) => {
-				if (val) {
+				if (val && !cancelled) {
 					setPrivateData(val);
 				}
 			})
+			return () => {
+				cancelled = true;
+			};
 		}
 	}, [userHandleB64u, readPrivateDataFromIdb]);
 
@@ -328,7 +332,7 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 			);
 			let newEncryptedContainer: keystore.EncryptedContainer;
 
-			if (privateData) { // keystore is already opened
+			if (privateData && mainKey) { // keystore is already opened
 				const [localPrivateData, localMainKey] = await assertKeystoreOpen();
 				const [remoteContainer, remoteMainKey,] = await keystore.openPrivateData(unlockSuccess.mainKey, unlockSuccess.privateData);
 				const [localContainer, ,] = await keystore.openPrivateData(localMainKey, localPrivateData);
@@ -424,6 +428,7 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 		writePrivateDataOnIdb,
 		assertKeystoreOpen,
 		privateData,
+		mainKey
 	]);
 
 


### PR DESCRIPTION
### Problem
After a cross-tab logout, an in-flight read could repopulate `privateData` after `mainKey` was already cleared, leaving the keystore in an inconsistent state. `finishUnlock` then took the "already open" merge path and threw "Key store is closed.", breaking login until reload.

### Fix
- Cancel the async `privateData` read if the session is cleared first.
- Treat the keystore as open only when both `privateData` and `mainKey`
  are set.

### Test

1. Tab1 and Tab2 log in as the same user (Tab1 gets logged out).
2. Tab2 navigates away and back (full reload).
3. Tab1 logs back in.
4. Tab2 logs in again — succeeds without reload.