### PR TITLE
Fix: preserve login state params on cross-tab logout

### DIFF
--- a/src/context/SessionContextProvider.tsx
+++ b/src/context/SessionContextProvider.tsx
@@ -27,11 +27,15 @@ export const SessionContextProvider = ({ children }: React.PropsWithChildren) =>
 
 
 	// Use a ref to hold a stable reference to the clearSession function
-	const clearSessionRef = useRef<() => void>();
+	const clearSessionRef = useRef<(preserveUrlParams?: boolean) => void>();
 
 	// Memoize clearSession using useCallback
-	const clearSession = useCallback(async () => {
-		window.history.replaceState({}, '', `${window.location.pathname}`);
+	const clearSession = useCallback(async (preserveUrlParams: boolean = false) => {
+		// Keep search params so a pending flow can continue after a
+		// cross-tab logout; otherwise clean up the URL.
+		if (!(preserveUrlParams && window.location.search)) {
+			window.history.replaceState({}, '', window.location.pathname);
+		}
 		console.log('[Session Context] Clear Session');
 		api.clearSession();
 	}, [api]);
@@ -49,9 +53,10 @@ export const SessionContextProvider = ({ children }: React.PropsWithChildren) =>
 
 	useEffect(() => {
 		// Handler function that calls the current clearSession function
-		const handleClearSession = () => {
+		const handleClearSession = (event: Event) => {
+			const preserveUrlParams = (event as CustomEvent)?.detail?.preserveUrlParams ?? false;
 			if (clearSessionRef.current) {
-				clearSessionRef.current();
+				clearSessionRef.current(preserveUrlParams);
 			}
 		};
 
@@ -93,7 +98,8 @@ export const SessionContextProvider = ({ children }: React.PropsWithChildren) =>
 
 	useEffect(() => {
 		if (api && keystore && api.isLoggedIn() === true && keystore.isOpen() === false && ((tabId && globalTabId && tabId !== globalTabId) || (!tabId && globalTabId))) {
-			clearSession();
+			// Fallback for the initial-mount race with the event listener below.
+			clearSession(true);
 		}
 	}, [globalTabId, tabId, clearSession, api, keystore]);
 

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, useMemo } from "react";
+import { useCallback, useEffect, useState, useMemo, useRef } from "react";
 import { useNavigate } from 'react-router-dom';
 
 import * as config from "../config";
@@ -195,8 +195,8 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 	}, [writePrivateDataOnIdb]);
 
 	const closeSessionTabLocal = useCallback(
-		async (): Promise<void> => {
-			eventTarget.dispatchEvent(new CustomEvent(KeystoreEvent.CloseSessionTabLocal));
+		async (preserveUrlParams: boolean = false): Promise<void> => {
+			eventTarget.dispatchEvent(new CustomEvent(KeystoreEvent.CloseSessionTabLocal, { detail: { preserveUrlParams } }));
 			setPrivateData(null);
 			setCalculatedWalletState(null);
 			clearSessionStorage();
@@ -250,11 +250,17 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 		[closeSessionTabLocal, privateData, userHandleB64u, globalUserHandleB64u, setCachedUsers],
 	);
 
+	const isFirstTabIdCheck = useRef(true);
+
 	useEffect(
 		() => {
+			const wasInitialMount = isFirstTabIdCheck.current;
+			isFirstTabIdCheck.current = false;
 			if (tabId && globalTabId && (tabId !== globalTabId)) {
-				// When user logs in in any tab, log out in all other tabs
-				closeSessionTabLocal();
+				// When user logs in in any tab, log out in all other tabs.
+				// Preserve URL params only if discovered on initial mount
+				// (eg. returning from a redirect with a pending login).
+				closeSessionTabLocal(wasInitialMount);
 			}
 		},
 		[closeSessionTabLocal, tabId, globalTabId],


### PR DESCRIPTION
### Problem
Single-session enforcement logs out the other tab on tab-id mismatch. If that tab returned from a redirect with pending login `?...` params, they were stripped before the login flow could continue.

### Fix
- `clearSession` accepts an optional `preserveUrlParams` flag to skip clearing URL search params.
- `closeSessionTabLocal` preserves URL params only when the tab-id mismatch is found on initial mount (i.e., returning from a redirect).

## Test plan

1. Tab1 + Tab2 log in as same user (Tab2 gets logged out)
2. Tab2 navigates away and back (with `?...` params)
3. Tab1 re-logs in, triggering logout in Tab2
4. Tab2 returns with params preserved, login continues
5. Explicit logout still cleans URL in all tabs