### PR TITLE
Feat: show pending deferred credential count as app icon badge

### DIFF
--- a/src/context/CredentialsContextProvider.tsx
+++ b/src/context/CredentialsContextProvider.tsx
@@ -6,6 +6,7 @@ import { useHttpProxy } from "@/lib/services/HttpProxy/HttpProxy";
 import CredentialsContext, { ExtendedVcEntity, Instance } from "./CredentialsContext";
 import { useOpenID4VCIHelper } from "@/lib/services/OpenID4VCIHelper";
 import { CurrentSchema } from '@/services/WalletStateSchema';
+import { setAppBadgeCount } from '@/utils';
 
 type WalletStateCredential = CurrentSchema.WalletStateCredential;
 
@@ -37,6 +38,10 @@ export const CredentialsContextProvider = ({ children }: React.PropsWithChildren
 		);
 		setPendingTransactions(sessionsWithTx);
 	}, [getCalculatedWalletState]);
+
+	useEffect(() => {
+		setAppBadgeCount(pendingTransactions?.length ?? 0);
+	}, [pendingTransactions]);
 
 	const initializeEngine = useCallback(async (useCache: boolean) => {
 		const trustedCertificates: string[] = [];

--- a/src/context/SessionContextProvider.tsx
+++ b/src/context/SessionContextProvider.tsx
@@ -8,6 +8,7 @@ import SessionContext, { SessionContextValue } from './SessionContext';
 import { useLocalStorage, useSessionStorage } from '@/hooks/useStorage';
 import { fetchKeyConfig, HpkeConfig } from '@/lib/utils/ohttpHelpers';
 import { OHTTP_KEY_CONFIG } from '@/config';
+import { setAppBadgeCount } from '@/utils';
 
 export const SessionContextProvider = ({ children }: React.PropsWithChildren) => {
 	const { isOnline } = useContext(StatusContext);
@@ -34,6 +35,7 @@ export const SessionContextProvider = ({ children }: React.PropsWithChildren) =>
 		window.history.replaceState({}, '', `${window.location.pathname}`);
 		console.log('[Session Context] Clear Session');
 		api.clearSession();
+		await setAppBadgeCount(0);
 	}, [api]);
 
 	// Update the ref whenever clearSession changes

--- a/src/utils/appBadge.ts
+++ b/src/utils/appBadge.ts
@@ -1,0 +1,18 @@
+/**
+ * Updates the app icon badge (https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/How_to/Display_badge_on_app_icon)
+ * with the given count, or clears it when the count is 0. No-op in browsers without Badging API support.
+ */
+export async function setAppBadgeCount(count: number): Promise<void> {
+	if (!('setAppBadge' in navigator) || !('clearAppBadge' in navigator)) {
+		return;
+	}
+	try {
+		if (count > 0) {
+			await navigator.setAppBadge(count);
+		} else {
+			await navigator.clearAppBadge();
+		}
+	} catch (err) {
+		console.warn('Failed to update app badge', err);
+	}
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { truncateByWords } from "./truncateByWords";
 export { prettyDomain } from "./prettyDomain";
+export { setAppBadgeCount } from "./appBadge";


### PR DESCRIPTION
- Add `setAppBadgeCount` util that wraps the [Badging API](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/How_to/Display_badge_on_app_icon) (`navigator.setAppBadge` / `clearAppBadge`), with feature detection and handling for unsupported browsers.
- In `CredentialsContextProvider`, update the app icon badge whenever `pendingTransactions` changes, showing the number of credential issuance sessions still waiting on a deferred `transaction_id`.
- Clear the badge on logout/session clear in `SessionContextProvider` so a stale count doesn't persist after sign-out.

### Notes
- Requires the wallet to be installed as a PWA (`display: standalone`, already set in the manifest) to be visible. The [Browser compatibility](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/setAppBadge#browser_compatibility) is is limited for now.

### Test

1. Install the wallet as a PWA on a supported platform.
2. Start a credential issuance flow that returns a deferred `transaction_id` and verify the badge appears with the correct count.
3. Verify the badge clears once the deferred credential is issued or the transaction expires/errors.
4. Verify the badge clears on logout.