### PR TITLE
Fix: log instead of throw when VC entity not found

### DIFF
--- a/src/hooks/useVcEntity.js
+++ b/src/hooks/useVcEntity.js
@@ -10,7 +10,9 @@ export const useVcEntity = (fetchVcData, vcEntityList, batchId) => {
 					(vcEntity) => vcEntity.batchId === parseInt(batchId)
 				);
 				if (!vcEntity) {
-					throw new Error("Credential not found");
+					console.log("Credential not found");
+					setVcEntity(undefined);
+					return;
 				}
 
 				setVcEntity(vcEntity);


### PR DESCRIPTION
Avoid throwing when a credential is not found in `vcEntityList`; log it instead and clear the entity state.