### PR TITLE
Header & heading cleanup and popup fixes

### DIFF
--- a/src/AppProvider.tsx
+++ b/src/AppProvider.tsx
@@ -28,19 +28,19 @@ const AppProvider: React.FC<RootProviderProps> = ({ children }) => {
 			<SessionContextProvider>
 				<CredentialsContextProvider>
 					<I18nextProvider i18n={i18n}>
-						<OpenID4VPContextProvider>
-							<OpenID4VCIContextProvider>
-								<UriHandlerProvider>
-									<AppSettingsProvider>
+						<AppSettingsProvider>
+							<OpenID4VPContextProvider>
+								<OpenID4VCIContextProvider>
+									<UriHandlerProvider>
 										<NotificationProvider>
 											<NativeWrapperProvider>
 												{children}
 											</NativeWrapperProvider>
 										</NotificationProvider>
-									</AppSettingsProvider>
-								</UriHandlerProvider>
-							</OpenID4VCIContextProvider>
-						</OpenID4VPContextProvider>
+									</UriHandlerProvider>
+								</OpenID4VCIContextProvider>
+							</OpenID4VPContextProvider>
+						</AppSettingsProvider>
 					</I18nextProvider>
 				</CredentialsContextProvider>
 			</SessionContextProvider>

--- a/src/components/Credentials/CredentialLayout.jsx
+++ b/src/components/Credentials/CredentialLayout.jsx
@@ -124,7 +124,7 @@ const CredentialLayout = ({ children, title = null, displayCredentialInfo = null
 
 	const MobileLayout = () => (
 		<div className="w-full flex flex-col">
-			<div className={`flex flex-row items-center gap-5 mt-2 mb-4 px-2`}>
+			<div className="flex flex-row items-center gap-5 px-2">
 				<div className='flex flex-col gap-4 w-4/5 xm:w-4/12'>
 					<CredentialImageButton showRibbon={false} fixedRatioImage={fixedRatioImage} />
 					{screenType !== 'mobile' && zeroSigCount !== null && sigTotal && (
@@ -159,32 +159,34 @@ const CredentialLayout = ({ children, title = null, displayCredentialInfo = null
 	if (!vcEntity) return null;
 
 	return (
-		<div className="px-6">
-			{screenType !== 'mobile' ? (
-				<H1
-					heading={<Link to="/">{t('common.navItemCredentials')}</Link>}
-					flexJustifyContent="start"
-					textColorClass="text-lm-gray-700 dark:text-dm-gray-300 hover:underline"
-				>					<ArrowRight size={20} className="mx-2 text-2xl mb-2 text-inherit" />
-
-					<H1 heading={credentialName} hr={false} />
-				</H1>
-			) : (
-				<div className='flex'>
-					<button
-						id="go-previous"
-						onClick={() => navigate(-1)}
-						className="mr-2 mb-2"
-						aria-label="Go back to the previous page"
+		<div className="px-6 sm:px-12 w-full">
+			<div className=' mb-4'>
+				{screenType !== 'mobile' ? (
+					<H1
+						heading={<Link to="/">{t('common.navItemCredentials')}</Link>}
+						flexJustifyContent="start"
+						textColorClass="text-lm-gray-700 dark:text-dm-gray-300 hover:underline"
 					>
-						<ArrowLeft size={20} className="text-2xl text-inherit" />
-					</button>
-					{title && <H1 heading={title} hr={false} />}
-				</div>
-			)}
-			<PageDescription description={t('pageCredentials.details.description')} />
+						<ArrowRight size={20} className="mx-2 text-2xl text-inherit" />
+						<H1 heading={credentialName} />
+					</H1>
+				) : (
+					<div className='flex flex-wrap mb-4'>
+						<button
+							id="go-previous"
+							onClick={() => navigate(-1)}
+							className="mr-2"
+							aria-label="Go back to the previous page"
+						>
+							<ArrowLeft size={20} className="text-2xl text-inherit" />
+						</button>
+						{title && <H1 heading={title} />}
+					</div>
+				)}
+				<PageDescription description={t('pageCredentials.details.description')} />
+			</div>
 
-			<div className={`w-full flex flex-col ${displayCredentialInfo && screenType === 'desktop' ? 'lg:flex-row gap-4' : ''} mt-0 lg:mt-5 px-2`}>
+			<div className={`w-full flex flex-col ${displayCredentialInfo && screenType === 'desktop' ? 'lg:flex-row gap-4' : ''} mt-0 lg:mt-5`}>
 				{(screenType === 'desktop' || !fixedRatioImage) ? <DesktopLayout /> : <MobileLayout />}
 			</div>
 			{/* Fullscreen credential Popup*/}

--- a/src/components/History/HistoryDetailContent.jsx
+++ b/src/components/History/HistoryDetailContent.jsx
@@ -26,7 +26,7 @@ const HistoryDetailContent = ({ historyItem }) => {
 	);
 
 	return (
-		<div className="py-2 w-full">
+		<div className="py-4 w-full">
 			<div className='flex items-center gap-2 px-2 mb-4'>
 				<BookCheck size={40} className="text-white bg-primary p-2 rounded-md shrink-0" />
 				<div>

--- a/src/components/History/HistoryList.jsx
+++ b/src/components/History/HistoryList.jsx
@@ -57,7 +57,7 @@ function HistoryListView({ batchId = null, title = '', limit = null, history = {
 
 	return (
 		<>
-			<div className="py-2 w-full">
+			<div className="py-2 mt-2 w-full">
 				{title && groups.length > 0 && <H3 heading={title} />}
 				<div className="space-y-2">
 					{(limit ? sorted.slice(0, limit) : sorted).map(item => (

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import ConnectionStatusIcon from './Navigation/ConnectionStatusIcon';
 import Logo from '../Logo/Logo';
 
 const Header = () => {
 	const { t } = useTranslation();
 
 	return (
-		<header className="sticky top-0 z-50 w-full bg-inherit text-inherit flex items-center justify-between md:hidden border-b border-lm-gray-400 dark:border-dm-gray-600 transition-all duration-300 p-3">
-			<ConnectionStatusIcon size='small' className="transition-all duration-300" />
+		<header className="sticky top-0 z-50 w-full bg-inherit text-inherit flex items-center md:hidden border-b border-lm-gray-400 dark:border-dm-gray-600 transition-all duration-300 py-3 px-6">
 			<div className="flex items-center">
 				<Logo aClassName='mr-2' imgClassName="cursor-pointer transition-all duration-300 w-8" />
 				<a href="/" className="text-lm-gray-900 dark:text-dm-gray-100 font-bold cursor-pointer transition-all duration-300 text-sm">

--- a/src/components/Layout/Layout.jsx
+++ b/src/components/Layout/Layout.jsx
@@ -17,7 +17,7 @@ const Layout = ({ children }) => {
 
 			<div className={`w-full md:w-3/5 ${isOpen ? "hidden md:flex" : "flex"} flex-col grow `}>
 				{/* Content */}
-				<div className="w-full grow bg-lm-gray-100 dark:bg-dm-gray-900 py-6 md:mt-0 md:pt-6">
+				<div className="w-full grow bg-lm-gray-100 dark:bg-dm-gray-900 pb-6 pt-3 md:mt-0 md:pt-6">
 					{children}
 				</div>
 			</div>

--- a/src/components/Popups/PopupLayout.jsx
+++ b/src/components/Popups/PopupLayout.jsx
@@ -48,7 +48,7 @@ const PopupLayout = ({ isOpen, onClose, loading = false, showLoadingAfterMs = 0,
 
 			<div className={`${fullScreen && 'h-full'}`}>
 				{fullScreen && <Header toggleSidebar={() => { }} />}
-				<div className={`${padding} ${fullScreen && 'px-6 pt-6 pb-20 flex flex-col justify-between'}`}>
+				<div className={`${padding} ${fullScreen && 'px-6 pt-3 pb-20 flex flex-col justify-between'}`}>
 					{children}
 				</div>
 			</div>

--- a/src/components/Popups/PopupLayout.jsx
+++ b/src/components/Popups/PopupLayout.jsx
@@ -41,13 +41,17 @@ const PopupLayout = ({ isOpen, onClose, loading = false, showLoadingAfterMs = 0,
 			isOpen={isOpen}
 			onRequestClose={onClose}
 			className={`relative overflow-y-auto overflow-x-hidden bg-lm-gray-100 dark:bg-dm-gray-900 border border-lm-gray-400 dark:border-dm-gray-600 ${fullScreen ? 'flex flex-col space-between w-full h-full' : 'w-full sm:w-1/2 md:w-5/12 lg:w-1/3 max-h-[90vh] rounded-lg shadow-lg m-4'}`}
-			overlayClassName={`fixed inset-0  flex items-center justify-center ${fullScreen ? 'z-50' : 'bg-lm-gray-900/50 dark:bg-dm-gray-500/50 backdrop-blur-xs z-50'}`}
+			overlayClassName={`fixed inset-0  flex items-center justify-center ${fullScreen ? 'z-50 bg-lm-gray-100 dark:bg-dm-gray-900' : 'bg-lm-gray-900/50 dark:bg-dm-gray-500/50 backdrop-blur-xs z-50'}`}
 			bodyOpenClassName="overflow-hidden"
 			shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
 		>
 
 			<div className={`${fullScreen && 'h-full'}`}>
-				{fullScreen && <Header toggleSidebar={() => { }} />}
+				{fullScreen &&
+					<div className='z-60'>
+						<Header toggleSidebar={() => { }} />
+					</div>
+				}
 				<div className={`${padding} ${fullScreen && 'px-6 pt-3 pb-20 flex flex-col justify-between'}`}>
 					{children}
 				</div>

--- a/src/components/QRCodeScanner/QRCodeScanner.jsx
+++ b/src/components/QRCodeScanner/QRCodeScanner.jsx
@@ -189,12 +189,12 @@ const QRScanner = ({ onClose }) => {
 								<button
 									id="close-qr-code-scanner-mobile"
 									onClick={handleClose}
-									className="mr-2 mb-2"
+									className="mr-2"
 									aria-label="Go back to the previous page"
 								>
 									<ArrowLeft size={20} className="text-2xl text-lm-gray-900 dark:text-dm-gray-100" />
 								</button>
-								<H1 heading={t('qrCodeScanner.title')} hr={false} />
+								<H1 heading={t('qrCodeScanner.title')} />
 							</div>
 						) : (
 							<div className="flex items-start justify-between border-b rounded-t border-lm-gray-400 dark:border-dm-gray-600">

--- a/src/components/Shared/Heading.tsx
+++ b/src/components/Shared/Heading.tsx
@@ -30,16 +30,13 @@ function withDefaults(defaults: DefaultableProps, Component: React.ComponentType
 }
 
 
-export const H1 = withDefaults(defaults, (props: Props) => (
-	<>
-		<div className={`flex justify-${props.flexJustifyContent} items-${props.flexAlignItems}`}>
-			<h1 className={`text-2xl mb-2 font-bold ${props.textColorClass}`}>
-				{props.heading}
-			</h1>
-			{props.children}
-		</div>
-		{props.hr && <hr className="mb-2 border-t border-lm-gray-400 dark:border-dm-gray-600" />}
-	</>
+export const H1 = withDefaults({ ...defaults, hr: false }, (props: Props) => (
+	<div className={`flex justify-${props.flexJustifyContent} items-${props.flexAlignItems}`}>
+		<h1 className={`text-2xl font-bold ${props.textColorClass}`}>
+			{props.heading}
+		</h1>
+		{props.children}
+	</div>
 ));
 
 export const H2 = withDefaults({

--- a/src/pages/History/HistoryDetail.jsx
+++ b/src/pages/History/HistoryDetail.jsx
@@ -44,7 +44,7 @@ const HistoryDetail = () => {
 					>
 						<ArrowLeft size={20} className="text-2xl text-lm-gray-900 dark:text-dm-gray-100" />
 					</button>
-					<H1 heading={t('pageHistory.presentationDetails.title')} hr={false} />
+					<H1 heading={t('pageHistory.presentationDetails.title')} />
 				</div>
 				{selectedHistoryItem.length > 0 && (
 					<HistoryDetailContent historyItem={selectedHistoryItem} />

--- a/src/pages/Home/Credential.jsx
+++ b/src/pages/Home/Credential.jsx
@@ -183,7 +183,7 @@ const Credential = () => {
 
 		<CredentialLayout title={credentialName} fixedRatioImage={false} displayCredentialInfo={vcEntity && <CredentialInfo parsedCredential={vcEntity.parsedCredential} />}>
 			<>
-				<div className="w-full pt-2 px-2">
+				<div className="w-full pt-2">
 					{screenType !== 'mobile' ? (
 						<CredentialTabsPanel tabs={infoTabs} />
 					) : (

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -51,13 +51,12 @@ const Home = () => {
 		<>
 			<div className="w-full">
 				<div className="px-6 sm:px-12">
-					<div className='flex items-center justify-between gap-3'>
+					<div className='flex items-center justify-between gap-3 mb-2'>
 						<H1 heading={t('common.navItemCredentials')} />
 						{screenType !== "desktop" && vcEntityList?.length > 1 && (
 							<ViewSelect value={mobileVcHomeView} onChange={(v) => setView(v)} />
 						)}
 					</div>
-					<hr className="mb-2 border-t border-lm-gray-400 dark:border-dm-gray-600" />
 					{(pendingTransactions?.length > 0) && (
 						<PendingTransactionsBanner
 							pendingTransactions={pendingTransactions}

--- a/src/pages/Pending/Pending.jsx
+++ b/src/pages/Pending/Pending.jsx
@@ -55,7 +55,7 @@ const Pending = () => {
 			<H1 heading={t("pagePending.title")} />
 			<PageDescription description={t("pagePending.description")} />
 
-			<div className="py-2 w-full">
+			<div className="py-4 w-full">
 				<div className="space-y-2">
 					{[...pendingTransactions]
 						.sort(reverse(compareBy(pt => pt.created)))


### PR DESCRIPTION
- Remove network indicator from mobile header and aligned logo left
- Simplify H1 (no hr, clean margins); fix spacing across pages
- Fix SelectCredentialsPopup ignoring AppSettingsContext theme
- Fix scroll bleed in fullscreen popup overlay
