### PR TITLE
Add env var to toggle credential usages visibility

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -34,6 +34,7 @@ OHTTP_RELAY=http://localhost:4001/api/relay
 VCT_REGISTRY_URLS=http://localhost:8097/type-metadata
 POLICY_LINKS=""
 SHOW_PWA_INSTALL_PROMPT=false
+DISPLAY_CREDENTIAL_USAGES=false
 
 # Used to generate well-known files at startup
 WELLKNOWN_APPLE_APPIDS=""

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Our Web Wallet provides a range of features tailored to enhance the credential m
   - `VCT_REGISTRY_URLS`: Comma-separated list of Type Metadata registry URLs for SD-JWT VC credentials.
   - `POLICY_LINKS`: Links to any TOS or other policies. This should be in the format `"<LABEL>::<URL>,<LABEL>::<URL>,<LABEL>::<URL>,..."` Can be left blank.
   - `SHOW_PWA_INSTALL_PROMPT`: Hide or show the PWA installation prompt on the login screen. Defaults to false if left blank or invalid.
+  - `DISPLAY_CREDENTIAL_USAGES`: Hide or show the credential usage ribbon and usage count on credential cards/details. Defaults to false (hidden) if left blank or invalid.
 
   **Well-known file generation:**
   - `WELLKNOWN_APPLE_APPIDS`: Used to generate the `.well-known/apple-app-site-association` file, used for IOS wrappers. This should be in the format `"<APP_ID>,<APP_ID>,<APP_ID>,..."` Can be left blank.

--- a/config/config.ts
+++ b/config/config.ts
@@ -49,6 +49,7 @@ export const ClientEnvConfigSchema = z.object({
 	VCT_REGISTRY_URLS: z.string().optional(),
 	POLICY_LINKS: z.string().optional(),
 	SHOW_PWA_INSTALL_PROMPT: z.string().optional(),
+	DISPLAY_CREDENTIAL_USAGES: z.string().optional(),
 });
 export type ClientEnvConfig = z.infer<typeof ClientEnvConfigSchema>;
 

--- a/src/components/Credentials/CredentialImage.jsx
+++ b/src/components/Credentials/CredentialImage.jsx
@@ -4,6 +4,7 @@ import UsagesRibbon from "./UsagesRibbon";
 import DefaultCred from "../../assets/images/cred.png";
 import { CredentialCardSkeleton } from '../Skeletons';
 import { useTranslation } from 'react-i18next';
+import { DISPLAY_CREDENTIAL_USAGES } from '@/config';
 
 const CredentialImage = ({
 	vcEntity,
@@ -72,7 +73,7 @@ const CredentialImage = ({
 						{showRibbon &&
 							<ExpiredRibbon vcEntity={vcEntity} borderColor={borderColor} />
 						}
-						{showRibbon &&
+						{showRibbon && DISPLAY_CREDENTIAL_USAGES &&
 							<UsagesRibbon vcEntityInstances={vcEntityInstances} borderColor={borderColor} />
 						}
 					</div>

--- a/src/components/Credentials/CredentialLayout.jsx
+++ b/src/components/Credentials/CredentialLayout.jsx
@@ -9,6 +9,9 @@ import useScreenType from '@/hooks/useScreenType';
 import { useVcEntity } from '@/hooks/useVcEntity';
 import { useCredentialName } from '@/hooks/useCredentialName';
 
+// Config
+import { DISPLAY_CREDENTIAL_USAGES } from '@/config';
+
 // Contexts
 import CredentialsContext from '@/context/CredentialsContext';
 
@@ -102,7 +105,7 @@ const CredentialLayout = ({ children, title = null, displayCredentialInfo = null
 					fixedRatioImage={screenType === 'desktop'}
 					preferredOrientation={screenType === 'desktop' ? 'landscape' : 'portrait'}
 				/>
-				{zeroSigCount !== null && sigTotal && (
+				{DISPLAY_CREDENTIAL_USAGES && zeroSigCount !== null && sigTotal && (
 					<UsageStats zeroSigCount={zeroSigCount} sigTotal={sigTotal} screenType={screenType} t={t} />
 
 				)}
@@ -127,7 +130,7 @@ const CredentialLayout = ({ children, title = null, displayCredentialInfo = null
 			<div className="flex flex-row items-center gap-5 px-2">
 				<div className='flex flex-col gap-4 w-4/5 xm:w-4/12'>
 					<CredentialImageButton showRibbon={false} fixedRatioImage={fixedRatioImage} />
-					{screenType !== 'mobile' && zeroSigCount !== null && sigTotal && (
+					{DISPLAY_CREDENTIAL_USAGES && screenType !== 'mobile' && zeroSigCount !== null && sigTotal && (
 						<UsageStats zeroSigCount={zeroSigCount} sigTotal={sigTotal} screenType={screenType} t={t} />
 
 					)}
@@ -135,8 +138,9 @@ const CredentialLayout = ({ children, title = null, displayCredentialInfo = null
 				{screenType === 'mobile' && (
 					<div className='flex flex-start flex-col gap-1'>
 						<p className='text-xl font-bold text-lm-gray-900 dark:text-dm-gray-100'>{credentialName}</p>
-						<UsageStats zeroSigCount={zeroSigCount} sigTotal={sigTotal} screenType={screenType} t={t} />
-
+						{DISPLAY_CREDENTIAL_USAGES && (
+							<UsageStats zeroSigCount={zeroSigCount} sigTotal={sigTotal} screenType={screenType} t={t} />
+						)}
 					</div>
 				)}
 			</div>

--- a/src/config.ts
+++ b/src/config.ts
@@ -53,6 +53,7 @@ export const VCT_REGISTRY_URLS: string[] = config.vct_registry_urls
 	: [];
 export const POLICY_LINKS = config.policy_links;
 export const SHOW_PWA_INSTALL_PROMPT = config.show_pwa_install_prompt ? config.show_pwa_install_prompt === 'true' : false;
+export const DISPLAY_CREDENTIAL_USAGES = config.display_credential_usages ? config.display_credential_usages === 'true' : false;
 export const BRANDING = {
 	LOGO_LIGHT: config.branding?.logo_light || '/logo_light.svg',
 	LOGO_DARK: config.branding?.logo_dark || '/logo_dark.svg',


### PR DESCRIPTION
- Add a new `DISPLAY_CREDENTIAL_USAGES` env var that gates the `UsagesRibbon` (credential card) and `UsageStats` (credential details) components.
- Defaults to `false` (hidden) when unset or invalid.
- Wired through `config/config.ts` (schema), `src/config.ts` (runtime), `.env.template`, and documented in `README.md`.
