### PR TITLE
Fix CredentialImage rendering glitches

### DIFF
--- a/src/components/Credentials/CredentialImage.jsx
+++ b/src/components/Credentials/CredentialImage.jsx
@@ -6,6 +6,17 @@ import { CredentialCardSkeleton } from '../Skeletons';
 import { useTranslation } from 'react-i18next';
 import { DISPLAY_CREDENTIAL_USAGES } from '@/config';
 
+// Shared across all instances so e.g. the thumbnail and fullscreen popup reuse one resolution.
+const resolvedImageCache = new Map();
+const pendingImageRequests = new Map();
+
+function getCacheKey(vcEntity, filter, preferredLangs, preferredOrientation) {
+	const batchId = vcEntity?.batchId;
+	if (batchId === undefined || batchId === null) return null;
+	const filterKey = filter ? JSON.stringify(filter) : '';
+	return `${batchId}|${filterKey}|${preferredLangs.join(',')}|${preferredOrientation}`;
+}
+
 const CredentialImage = ({
 	vcEntity,
 	className,
@@ -18,46 +29,66 @@ const CredentialImage = ({
 	fixedRatio = true,
 	preferredOrientation = fixedRatio ? 'landscape' : 'portrait',
 }) => {
-	const [imageSrc, setImageSrc] = useState(undefined);
 	const { i18n } = useTranslation();
 	const preferredLangs = i18n.languages;
+
+	const imageFn = vcEntity?.parsedCredential?.metadata?.credential?.image?.dataUri;
+	const cacheKey = imageFn ? getCacheKey(vcEntity, filter, preferredLangs, preferredOrientation) : null;
+	const computeSrc = () => (!imageFn ? DefaultCred : (cacheKey ? resolvedImageCache.get(cacheKey) : undefined));
+
+	const [resolved, setResolved] = useState(() => ({ key: cacheKey, src: computeSrc() }));
+
+	// Resync during render (not in the effect) so a credential switch never shows the old image with the new ribbons.
+	if (resolved.key !== cacheKey) {
+		setResolved({ key: cacheKey, src: computeSrc() });
+	}
 
 	useEffect(() => {
 		let isMounted = true;
 
-		const svgPreference = {
-			orientation: preferredOrientation,
-		};
+		if (!imageFn) {
+			onLoad?.();
+			return;
+		}
 
-		async function loadImage() {
-			const imageFn = vcEntity?.parsedCredential?.metadata?.credential?.image?.dataUri;
-			if (!imageFn) {
-				setImageSrc(DefaultCred);
-				onLoad?.();
-				return;
-			}
+		if (cacheKey && resolvedImageCache.has(cacheKey)) {
+			onLoad?.();
+			return;
+		}
 
-			try {
-				const uri = await imageFn(filter ?? undefined, preferredLangs, svgPreference);
-				if (isMounted && uri) {
-					setImageSrc(uri);
-					onLoad?.();
-				} else {
-					setImageSrc(DefaultCred);
+		let request = cacheKey ? pendingImageRequests.get(cacheKey) : undefined;
+		if (!request) {
+			const svgPreference = { orientation: preferredOrientation };
+			request = (async () => {
+				try {
+					const uri = await imageFn(filter ?? undefined, preferredLangs, svgPreference);
+					return uri || DefaultCred;
+				} catch (error) {
+					console.warn('Failed to load credential image:', error);
+					return DefaultCred;
 				}
-			} catch (error) {
-				console.warn('Failed to load credential image:', error);
-				if (isMounted) {
-					setImageSrc(DefaultCred);
-					onLoad?.();
-				}
+			})();
+
+			if (cacheKey) {
+				pendingImageRequests.set(cacheKey, request);
+				request.then((uri) => {
+					resolvedImageCache.set(cacheKey, uri);
+					pendingImageRequests.delete(cacheKey);
+				});
 			}
 		}
 
-		loadImage();
+		request.then((uri) => {
+			if (isMounted) {
+				setResolved({ key: cacheKey, src: uri });
+				onLoad?.();
+			}
+		});
 
 		return () => { isMounted = false };
-	}, [vcEntity, filter, fixedRatio, onLoad, preferredLangs, preferredOrientation]);
+	}, [imageFn, cacheKey, filter, preferredLangs, preferredOrientation, onLoad]);
+
+	const imageSrc = resolved.key === cacheKey ? resolved.src : undefined;
 
 	return (
 		<>
@@ -67,7 +98,7 @@ const CredentialImage = ({
 						<img
 							src={imageSrc}
 							alt="Credential"
-							className={`w-full h-full w-full h-full object-cover object-top ${className ?? ''}`}
+							className={`w-full h-full object-cover object-top ${className ?? ''}`}
 							onClick={onClick}
 						/>
 						{showRibbon &&

--- a/src/components/Popups/SelectCredentialsPopup.jsx
+++ b/src/components/Popups/SelectCredentialsPopup.jsx
@@ -173,8 +173,10 @@ function SelectCredentialsPopup({ popupState, setPopupState, showPopup, hidePopu
 				setActiveSlideIndexByKey(prev => ({ ...prev, [currentKey]: idx + 1 }));
 			}
 		}
-		// run when step or its vcEntities change
-	}, [currentKey, vcEntities, currentSelectionMap, activeSlideIndexByKey]);
+		// run when step or its selection changes — NOT when activeSlideIndexByKey
+		// changes, otherwise swiping away from the selected card snaps right back.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [currentKey, vcEntities, currentSelectionMap]);
 
 	const requestedFieldsPerCredential = useMemo(() => {
 
@@ -227,7 +229,6 @@ function SelectCredentialsPopup({ popupState, setPopupState, showPopup, hidePopu
 		};
 
 		if (popupState?.options && vcEntityList) {
-			console.log("opts = ", popupState.options)
 			getData();
 		}
 	}, [

--- a/src/components/Skeletons/CredentialCardSkeleton.tsx
+++ b/src/components/Skeletons/CredentialCardSkeleton.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 const CredentialCardSkeleton = () => (
-	<div className="animate-pulse bg-linear-to-tr from-lm-gray-600 via-lm-gray-700 to-lm-gray-800 text-lm-gray-100 dark:from-dm-gray-600 dark:via-dm-gray-700 dark:to-dm-gray-800 shadow rounded-xl overflow-hidden aspect-829/504 w-full">
+	<div className="animate-pulse bg-linear-to-tr from-lm-gray-600 via-lm-gray-700 to-lm-gray-800 text-lm-gray-100 dark:from-dm-gray-600 dark:via-dm-gray-700 dark:to-dm-gray-800 shadow rounded-xl overflow-hidden aspect-[1.6] w-full">
 		<div className="h-[60%] w-full bg-transparent"></div>
 		<div className="flex flex-col justify-around h-[40%] px-4 py-3 space-y-2">
 			<div className="h-[30%] w-3/4 bg-white/30 dark:bg-white/15 rounded"></div>


### PR DESCRIPTION
- `CredentialImage` now caches resolved data URIs per credential (keyed by batchId + filter + language + orientation) and dedupes concurrent requests, so the thumbnail and fullscreen popup reuse one resolution instead of each re-rendering the same SVG from scratch on every popup open or unrelated credential list refresh.
- The displayed image is resynced during render (not in the effect), so navigating directly between two credentials' detail pages (same route, no remount) no longer shows the previous credential's image alongside the new one's ribbons.
- Fixed `CredentialCardSkeleton`'s aspect ratio (`aspect-829/504` → `aspect-[1.6]`) to match the actual image container, removing a layout shift when the real image replaces the skeleton.
- Fixed the usage ribbon in `SelectCredentialsPopup` getting stuck on the selected credential card: the slide-centering effect listed `activeSlideIndexByKey` as a dependency while also writing to it, so swiping away from the selected card immediately snapped the slider back. The ribbon now correctly follows whichever card is active/swiped-to, independent of selection.
- Minor cleanup: removed a duplicated Tailwind class, an unused effect dependency, and leftover debug `console.log`s; the "resolver returned no image" fallback now also fires `onLoad` so dependents like `SelectCredentialsPopup`'s selection overlay aren't left stuck.
