### PR TITLE
Fix service worker registration error on the dev server

### DIFF
--- a/src/sw-register.js
+++ b/src/sw-register.js
@@ -1,4 +1,4 @@
-import { BASE_PATH, MODE } from './config';
+import { BASE_PATH } from './config';
 
 const swScope = BASE_PATH.replace(/\/?$/, '/');
 const swPath = `${swScope}service-worker.js`;
@@ -16,8 +16,19 @@ const swPolicy = tt
 	})
 	: null;
 
-if (MODE === 'production' && 'serviceWorker' in navigator) {
-	window.addEventListener('load', () => {
+if ('serviceWorker' in navigator) {
+	window.addEventListener('load', async () => {
+		// Only exists after a build; the dev server serves index.html instead.
+		try {
+			const res = await fetch(swPath, { method: 'HEAD' });
+			const contentType = res.headers.get('content-type') || '';
+			if (!res.ok || !contentType.includes('javascript')) {
+				return;
+			}
+		} catch {
+			return;
+		}
+
 		const trustedSwUrl = swPolicy ? swPolicy.createScriptURL(swPath) : swPath;
 		navigator.serviceWorker
 			.register(trustedSwUrl, { scope: swScope })


### PR DESCRIPTION
### Problem
The `MODE === 'production'` gate on service worker registration was removed so a `--mode development` build still registers one. But that gate was also the only thing stopping registration on the plain Vite dev server, which has no built `service-worker.js` at all — so it now failed with a MIME type error, since the request falls through to `index.html` instead.

### Fix
Check the response is actually a script before registering, instead of gating on `MODE`.

### Test plan
- [x] Dev server: no error, no registration
- [x] Build + preview: registers successfully
