### PR TITLE
Fix passkey retry prompt getting stuck disabled after Cancel

### DIFF
--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -113,12 +113,14 @@ const WebauthnSignupLogin = ({
 
 	const promptForPrfRetry = async (): Promise<boolean> => {
 		setNeedPrfRetry(true);
+		setPrfRetryAccepted(false);
 		return new Promise((resolve: (accept: boolean) => void, _reject) => {
 			setResolvePrfRetryPrompt(() => resolve);
-		}).finally(() => {
+		}).then((accept) => {
 			setNeedPrfRetry(false);
-			setPrfRetryAccepted(true);
 			setResolvePrfRetryPrompt(null);
+			setPrfRetryAccepted(accept); // only true if the user clicked Continue
+			return accept;
 		});
 	};
 


### PR DESCRIPTION
Fix `promptForPrfRetry` always marking the PRF retry prompt as "accepted" once it resolved, even when the user clicked Cancel. This left the Continue button permanently disabled (and the wrong message showing) on every later retry prompt, recoverable only by reloading the page.
