### PR TITLE
Fix issue wwwallet/wwwallet#52

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -43,6 +43,8 @@ export type WebauthnCredential = {
 	lastUseTime: string,
 	nickname?: string,
 	prfCapable: boolean,
+	backupEligibility: boolean,
+	backupState: boolean,
 }
 
 export type UserSettings = {

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -198,7 +198,11 @@
 			"rename": "Μετονομασία",
 			"renameAriaLabel": "Μετονομασία κλειδιού πρόσβασης {{passkeyLabel}}",
 			"saveChangesAriaLabel": "Αποθήκευση αλλαγών στο κλειδί πρόσβασης {{passkeyLabel}}",
-			"unnamed": "Χωρίς Όνομα κλειδί πρόσβασης"
+			"unnamed": "Χωρίς Όνομα κλειδί πρόσβασης",
+			"syncable": "Συγχρονισμένο",
+			"syncableYes": "Ναι",
+			"syncableAvailable": "Υποστηρίζεται Συγχρονισμός",
+			"syncableNo": "Όχι"
 		},
 		"rememberIssuer": {
 			"description": "Ορίστε τη διάρκεια πρόσβασης σε issuers χωρίς νέα αυθεντικοποίηση (σύμφωνα με την πολιτική του issuer)",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -264,7 +264,11 @@
 			"rename": "Rename",
 			"renameAriaLabel": "Rename passkey {{passkeyLabel}}",
 			"saveChangesAriaLabel": "Save changes to passkey {{passkeyLabel}}",
-			"unnamed": "Unnamed passkey"
+			"unnamed": "Unnamed passkey",
+			"syncable": "Synced",
+			"syncableYes": "Yes",
+			"syncableAvailable": "Available",
+			"syncableNo": "No"
 		},
 		"rememberIssuer": {
 			"description": "Set the duration for accessing issuers without re-authenticating (subject to issuer policy)",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -192,7 +192,11 @@
 			"rename": "Renomear",
 			"renameAriaLabel": "Renomear chave de acesso {{passkeyLabel}}",
 			"saveChangesAriaLabel": "Guardar alterações para chave de acesso {{passkeyLabel}}",
-			"unnamed": "Chave de acesso sem nome"
+			"unnamed": "Chave de acesso sem nome",
+			"syncable": "Sincronizado",
+			"syncableYes": "Sim",
+			"syncableAvailable": "Disponível",
+			"syncableNo": "Não"
 		},
 		"rememberIssuer": {
 			"description": "Defina a duração de acesso aos issuers sem ser necessário nova autenticação (de acordo com a política do issuer)",

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -546,6 +546,18 @@ const WebauthnCredentialItem = ({
 						&& <span className="py-1 px-2 rounded bg-lm-orange dark:bg-dm-orange text-lm-gray-900 font-bold">{t('pageSettings.passkeyItem.needsPrfUpgrade')}</span>
 					}
 				</p>
+				<p className='dark:text-white flex gap-3 items-center'>
+					<span className="font-semibold">
+						{t('pageSettings.passkeyItem.syncable')}:&nbsp;
+					</span>
+					{ 
+						credential.backupEligibility === true && credential.backupState === true
+  							? t("pageSettings.passkeyItem.syncableYes")
+  						: credential.backupEligibility === true && credential.backupState === false
+    						? t("pageSettings.passkeyItem.syncableAvailable")
+    					: t("pageSettings.passkeyItem.syncableNo")
+					}
+				</p>
 			</div>
 
 			<div className="items-start	flex gap-2">


### PR DESCRIPTION
Add the functionality that is described in issue wwwallet/wwwallet#52 on the frontend side.

### How to check
* Non Syncable Credentials:
1. Register using a device-bound Authenticator (i.e. Yubikey) 
2. In Settings section, in credentials you will see the following. The "synced" field must have the value "No".
<img width="1700" height="200" alt="Screenshot from 2026-06-30 17-11-52" src="https://github.com/user-attachments/assets/afefe53f-ccbb-4865-a8e1-2d645eb9db5d" />
3. If you authenticate with the same credential, you will se the same.

* Syncable Credentials:
1. Do the same using a platform Authenticator (i.e. Google Password Manager on Google Chrome). You should see the following. The value of "Synced" field must be "Yes" in both Registration and Authentication.

<img width="1700" height="200" alt="Screenshot from 2026-06-30 15-55-32" src="https://github.com/user-attachments/assets/550e8142-2c8c-4ead-84e0-25e9359e7dc9" />


