### PR TITLE
Use PIN popup for pre-authorized tx_code input

### DIFF
--- a/src/components/Popups/PinInput.jsx
+++ b/src/components/Popups/PinInput.jsx
@@ -3,102 +3,62 @@ import React, { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import Button from '../Buttons/Button';
 import PopupLayout from './PopupLayout';
-import { last } from '@/util';
 import { Lock } from 'lucide-react';
 
-function PinInput({ isOpen, setIsOpen, onSubmit, onCancel }) {
+function PinInput({ isOpen, setIsOpen, onSubmit, onCancel, length, input_mode = 'numeric', description }) {
 	const [errMessage, setErrMessage] = useState('');
-	const [pin, setPin] = useState(['', '', '', '']);
+	const parsedLength = Number(length);
+	const expectedLength = Number.isInteger(parsedLength) && parsedLength > 0 ? parsedLength : null;
+	const normalizedInputMode = input_mode === 'text' ? 'text' : 'numeric';
+	const [pin, setPin] = useState(['']);
+	const [isSubmitting, setSubmitting] = useState(false);
 	const { t } = useTranslation();
 
-	const inputRefs = [
-		useRef(null),
-		useRef(null),
-		useRef(null),
-		useRef(null)
-	];
-	const firstInputRef = inputRefs[0];
+	const inputRefs = useRef([]);
 
 	useEffect(() => {
-		if (firstInputRef.current) {
-			firstInputRef.current.focus();
+		if (!isOpen) {
+			return;
 		}
-	}, [firstInputRef]);
+
+		setErrMessage('');
+		setPin(Array(expectedLength ?? 1).fill(''));
+		setSubmitting(false);
+		inputRefs.current = inputRefs.current.slice(0, expectedLength ?? 1);
+		inputRefs.current[0]?.focus();
+	}, [isOpen, expectedLength]);
 
 	const handleCancel = () => {
 		setIsOpen(false);
 		onCancel?.();
 	};
 
+	const sanitizeCode = (value) => {
+		const sanitizedValue = normalizedInputMode === 'numeric'
+			? value.replace(/\D/g, '')
+			: value;
+		return expectedLength ? Array.from(sanitizedValue).slice(0, expectedLength).join('') : sanitizedValue;
+	};
+
 	const handleSubmit = async () => {
+		if (isSubmitting) {
+			return;
+		}
+
 		try {
 			const userPin = pin.join('');
+			if (!userPin || (expectedLength && pin.some((digit) => digit === ''))) {
+				setErrMessage(`${t('PinInputPopup.errMessage')}`);
+				return;
+			}
+
+			setSubmitting(true);
 			await onSubmit?.(userPin);
 			setIsOpen(false);
 		} catch (err) {
 			setErrMessage(`${t('PinInputPopup.errMessage')}`);
-		}
-	};
-
-	const handleInputChange = (index, value) => {
-		setErrMessage('');
-		if (/^\d*$/.test(value) && value.length <= 1) {
-			const newPin = [...pin];
-			newPin[index] = value;
-
-			setPin(newPin);
-
-			if (value === '' && index > 0) {
-				// Move focus to the previous input field and clear it if the value is cleared
-				inputRefs[index - 1].current.focus();
-				newPin[index - 1] = '';
-			} else if (value !== '' && index < 3) {
-				// Move focus to the next input and clean it
-				const nextInput = inputRefs[index + 1].current;
-				newPin[index + 1] = '';
-				setPin(newPin);
-				nextInput.focus();
-				nextInput.select();
-			} else if (value !== '' && index === 3) {
-				// Clear next input fields if you are in the last input
-				for (let i = index + 1; i < newPin.length; i++) {
-					newPin[i] = '';
-				}
-				setPin(newPin);
-			}
-		}
-	};
-
-	const handleInputKeyDown = (index, event) => {
-		setErrMessage('');
-		if (event.key === 'Backspace' && pin[index] === '' && index > 0) {
-			inputRefs[index - 1].current.focus();
-			const newPin = [...pin];
-			newPin[index - 1] = '';
-			setPin(newPin);
-		}
-	};
-
-	const handleInputClick = (index) => {
-		setErrMessage('');
-		const newPin = [...pin];
-		newPin[index] = '';
-		setPin(newPin);
-
-	};
-
-	const handleInputPaste = (pastedValue) => {
-		setErrMessage('');
-		if (/^\d{1,4}$/.test(pastedValue)) {
-			const newPin = Array.from(pastedValue, (char) => char);
-
-			const updatedPin = [...newPin];
-			while (updatedPin.length < pin.length) {
-				updatedPin.push('');
-			}
-			setPin(updatedPin);
-
-			last(inputRefs).current.focus();
+		} finally {
+			setSubmitting(false);
 		}
 	};
 
@@ -106,10 +66,56 @@ function PinInput({ isOpen, setIsOpen, onSubmit, onCancel }) {
 		return null;
 	}
 
-	const handleInputKeyPress = (event) => {
+	const handleInputKeyDownSubmit = (event) => {
 		if (event.key === 'Enter') {
 			handleSubmit();
 		}
+	};
+
+	const handleInputChange = (value) => {
+		setErrMessage('');
+		setPin([sanitizeCode(value)]);
+	};
+
+	const handlePinDigitChange = (index, value) => {
+		setErrMessage('');
+		const sanitizedValue = sanitizeCode(value);
+		const newPin = [...pin];
+
+		if (sanitizedValue.length > 1) {
+			const pastedPin = Array.from(sanitizedValue);
+			setPin([
+				...pastedPin,
+				...Array(expectedLength - pastedPin.length).fill('')
+			]);
+			inputRefs.current[Math.min(pastedPin.length, expectedLength - 1)]?.focus();
+			return;
+		}
+
+		newPin[index] = sanitizedValue;
+		setPin(newPin);
+
+		if (sanitizedValue && index < expectedLength - 1) {
+			inputRefs.current[index + 1]?.focus();
+		}
+	};
+
+	const handlePinDigitPaste = (index, event) => {
+		event.preventDefault();
+		setErrMessage('');
+		const pastedPin = Array.from(sanitizeCode(event.clipboardData.getData('Text')));
+		if (pastedPin.length === 0) {
+			return;
+		}
+
+		const newPin = [...pin];
+		pastedPin.forEach((digit, offset) => {
+			if (index + offset < expectedLength) {
+				newPin[index + offset] = digit;
+			}
+		});
+		setPin(newPin);
+		inputRefs.current[Math.min(index + pastedPin.length, expectedLength - 1)]?.focus();
 	};
 
 	return (
@@ -120,28 +126,50 @@ function PinInput({ isOpen, setIsOpen, onSubmit, onCancel }) {
 			</h2>
 			<hr className="mb-2 border-t border-lm-gray-400 dark:border-dm-gray-600" />
 			<p className="italic pd-2 text-lm-gray-800 dark:text-dm-gray-200">
-				{t('PinInputPopup.description')}
+				{description || t('PinInputPopup.description')}
 			</p>
 
 			{errMessage && (
-				<p className='text-sm text-lm-red dark:text-dm-red'>aaa{errMessage}</p>
+				<p className='text-sm text-lm-red dark:text-dm-red'>{errMessage}</p>
 			)}
-			<div className='mt-2 flex flex-wrap justify-center overflow-y-auto max-h-[50vh]'>
-				{pin.map((digit, index) => (
+			{expectedLength ? (
+				<div className='mt-2 flex flex-wrap justify-center overflow-y-auto max-h-[50vh]'>
+					{Array.from({ length: expectedLength }).map((_, index) => (
+						<input
+							type="text"
+							key={index}
+							value={pin[index] ?? ''}
+							onChange={(e) => handlePinDigitChange(index, e.target.value)}
+							onPaste={(e) => handlePinDigitPaste(index, e)}
+							onKeyDown={handleInputKeyDownSubmit}
+							inputMode={normalizedInputMode}
+							pattern={normalizedInputMode === 'numeric' ? '[0-9]*' : undefined}
+							maxLength={1}
+							autoComplete="one-time-code"
+							className="w-10 px-3 mx-1 my-2 py-2 bg-lm-gray-200 dark:bg-dm-gray-800 border border-lm-gray-400 dark:border-dm-gray-600 rounded-md focus:outline-none"
+							ref={(element) => {
+								inputRefs.current[index] = element;
+							}}
+						/>
+					))}
+				</div>
+			) : (
+				<div className='mt-4'>
 					<input
 						type="text"
-						key={index}
-						value={digit}
-						onChange={(e) => handleInputChange(index, e.target.value)}
-						onKeyDown={(e) => handleInputKeyDown(index, e)}
-						onClick={() => handleInputClick(index)}
-						onPaste={(e) => handleInputPaste(e.clipboardData.getData('Text'))}
-						onKeyPress={(e) => handleInputKeyPress(e)}
-						className="w-10 px-3 mx-1 my-2 py-2 bg-lm-gray-200 dark:bg-dm-gray-800 border border-lm-gray-400 dark:border-dm-gray-600 rounded-md focus:outline-none"
-						ref={inputRefs[index]}
+						value={pin[0] ?? ''}
+						onChange={(e) => handleInputChange(e.target.value)}
+						onKeyDown={handleInputKeyDownSubmit}
+						inputMode={normalizedInputMode}
+						pattern={normalizedInputMode === 'numeric' ? '[0-9]*' : undefined}
+						autoComplete="one-time-code"
+						className="w-full px-3 py-2 bg-lm-gray-200 dark:bg-dm-gray-800 border border-lm-gray-400 dark:border-dm-gray-600 rounded-md focus:outline-none"
+						ref={(element) => {
+							inputRefs.current[0] = element;
+						}}
 					/>
-				))}
-			</div>
+				</div>
+			)}
 
 			<div className="flex justify-end space-x-2 pt-4">
 				<Button
@@ -154,6 +182,7 @@ function PinInput({ isOpen, setIsOpen, onSubmit, onCancel }) {
 					id="submit-pin-input"
 					variant="primary"
 					onClick={handleSubmit}
+					disabled={isSubmitting}
 				>
 					{t('common.submit')}
 				</Button>

--- a/src/components/Popups/PinInput.jsx
+++ b/src/components/Popups/PinInput.jsx
@@ -1,16 +1,12 @@
 // PinInput.js
-import React, { useState, useRef, useEffect, useContext } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import Button from '../Buttons/Button';
-import SessionContext from '@/context/SessionContext';
 import PopupLayout from './PopupLayout';
 import { last } from '@/util';
 import { Lock } from 'lucide-react';
 
-function PinInput({ isOpen, setIsOpen }) {
-	const { api } = useContext(SessionContext);
-	const navigate = useNavigate();
+function PinInput({ isOpen, setIsOpen, onSubmit, onCancel }) {
 	const [errMessage, setErrMessage] = useState('');
 	const [pin, setPin] = useState(['', '', '', '']);
 	const { t } = useTranslation();
@@ -31,13 +27,13 @@ function PinInput({ isOpen, setIsOpen }) {
 
 	const handleCancel = () => {
 		setIsOpen(false);
-		navigate('/');
+		onCancel?.();
 	};
 
 	const handleSubmit = async () => {
 		try {
 			const userPin = pin.join('');
-			await api.post('/communication/handle', { user_pin: userPin });
+			await onSubmit?.(userPin);
 			setIsOpen(false);
 		} catch (err) {
 			setErrMessage(`${t('PinInputPopup.errMessage')}`);

--- a/src/components/Popups/PinInput.jsx
+++ b/src/components/Popups/PinInput.jsx
@@ -119,7 +119,7 @@ function PinInput({ isOpen, setIsOpen, onSubmit, onCancel, length, input_mode = 
 	};
 
 	return (
-		<PopupLayout isOpen={isOpen} onClose={false}>
+		<PopupLayout isOpen={isOpen} onClose={() => { }} shouldCloseOnOverlayClick={false}>
 			<h2 className="text-lg font-bold mb-2 text-lm-gray-900 dark:text-dm-gray-100">
 				<Lock size={20} className="inline mr-1 mb-1" />
 				{t('PinInputPopup.title')}

--- a/src/components/Popups/PinInput.jsx
+++ b/src/components/Popups/PinInput.jsx
@@ -16,6 +16,18 @@ function PinInput({ isOpen, setIsOpen, onSubmit, onCancel, length, input_mode = 
 
 	const inputRefs = useRef([]);
 
+	const trimExtraEmptyDigits = (digits) => {
+		if (!expectedLength) {
+			return digits;
+		}
+
+		const trimmedDigits = [...digits];
+		while (trimmedDigits.length > expectedLength && trimmedDigits[trimmedDigits.length - 1] === '') {
+			trimmedDigits.pop();
+		}
+		return trimmedDigits;
+	};
+
 	useEffect(() => {
 		if (!isOpen) {
 			return;
@@ -33,13 +45,6 @@ function PinInput({ isOpen, setIsOpen, onSubmit, onCancel, length, input_mode = 
 		onCancel?.();
 	};
 
-	const sanitizeCode = (value) => {
-		const sanitizedValue = normalizedInputMode === 'numeric'
-			? value.replace(/\D/g, '')
-			: value;
-		return expectedLength ? Array.from(sanitizedValue).slice(0, expectedLength).join('') : sanitizedValue;
-	};
-
 	const handleSubmit = async () => {
 		if (isSubmitting) {
 			return;
@@ -47,7 +52,7 @@ function PinInput({ isOpen, setIsOpen, onSubmit, onCancel, length, input_mode = 
 
 		try {
 			const userPin = pin.join('');
-			if (!userPin || (expectedLength && pin.some((digit) => digit === ''))) {
+			if (!userPin || (expectedLength && pin.slice(0, expectedLength).some((digit) => digit === ''))) {
 				setErrMessage(`${t('PinInputPopup.errMessage')}`);
 				return;
 			}
@@ -74,28 +79,29 @@ function PinInput({ isOpen, setIsOpen, onSubmit, onCancel, length, input_mode = 
 
 	const handleInputChange = (value) => {
 		setErrMessage('');
-		setPin([sanitizeCode(value)]);
+		setPin([value]);
 	};
 
 	const handlePinDigitChange = (index, value) => {
 		setErrMessage('');
-		const sanitizedValue = sanitizeCode(value);
 		const newPin = [...pin];
 
-		if (sanitizedValue.length > 1) {
-			const pastedPin = Array.from(sanitizedValue);
-			setPin([
+		if (value.length > 1) {
+			const pastedPin = Array.from(value);
+			const nextPin = trimExtraEmptyDigits([
 				...pastedPin,
-				...Array(expectedLength - pastedPin.length).fill('')
+				...Array(Math.max(expectedLength - pastedPin.length, 0)).fill('')
 			]);
-			inputRefs.current[Math.min(pastedPin.length, expectedLength - 1)]?.focus();
+			setPin(nextPin);
+			inputRefs.current[Math.min(pastedPin.length, Math.max(expectedLength, nextPin.length) - 1)]?.focus();
 			return;
 		}
 
-		newPin[index] = sanitizedValue;
-		setPin(newPin);
+		newPin[index] = value;
+		const nextPin = trimExtraEmptyDigits(newPin);
+		setPin(nextPin);
 
-		if (sanitizedValue && index < expectedLength - 1) {
+		if (value && index < Math.max(expectedLength, nextPin.length) - 1) {
 			inputRefs.current[index + 1]?.focus();
 		}
 	};
@@ -103,20 +109,21 @@ function PinInput({ isOpen, setIsOpen, onSubmit, onCancel, length, input_mode = 
 	const handlePinDigitPaste = (index, event) => {
 		event.preventDefault();
 		setErrMessage('');
-		const pastedPin = Array.from(sanitizeCode(event.clipboardData.getData('Text')));
+		const pastedPin = Array.from(event.clipboardData.getData('Text'));
 		if (pastedPin.length === 0) {
 			return;
 		}
 
 		const newPin = [...pin];
 		pastedPin.forEach((digit, offset) => {
-			if (index + offset < expectedLength) {
-				newPin[index + offset] = digit;
-			}
+			newPin[index + offset] = digit;
 		});
-		setPin(newPin);
-		inputRefs.current[Math.min(index + pastedPin.length, expectedLength - 1)]?.focus();
+		const nextPin = trimExtraEmptyDigits(newPin);
+		setPin(nextPin);
+		inputRefs.current[Math.min(index + pastedPin.length, Math.max(expectedLength, nextPin.length) - 1)]?.focus();
 	};
+
+	const inputCount = expectedLength ? Math.max(expectedLength, pin.length) : 0;
 
 	return (
 		<PopupLayout isOpen={isOpen} onClose={() => { }} shouldCloseOnOverlayClick={false}>
@@ -134,7 +141,7 @@ function PinInput({ isOpen, setIsOpen, onSubmit, onCancel, length, input_mode = 
 			)}
 			{expectedLength ? (
 				<div className='mt-2 flex flex-wrap justify-center overflow-y-auto max-h-[50vh]'>
-					{Array.from({ length: expectedLength }).map((_, index) => (
+					{Array.from({ length: inputCount }).map((_, index) => (
 						<input
 							type="text"
 							key={index}

--- a/src/hocs/UriHandlerProvider.tsx
+++ b/src/hocs/UriHandlerProvider.tsx
@@ -16,6 +16,7 @@ import useFilterItemByLang from "@/hooks/useFilterItemByLang";
 import { useOpenID4VCIHelper } from "@/lib/services/OpenID4VCIHelper";
 import { getAuthorizationRequestErrorMessageKey } from "@/lib/services/OpenID4VP/authorizationRequestErrorMessageKey";
 import { getAuthorizationResponseErrorMessageKey } from "@/lib/services/OpenID4VCI/authorizationResponseErrorMessageKey";
+import type { TxCodeInputMetadata } from "@/lib/interfaces/IOpenID4VCI";
 
 const MessagePopup = React.lazy(() => import('../components/Popups/MessagePopup'));
 const PinInputPopup = React.lazy(() => import('../components/Popups/PinInput'));
@@ -44,6 +45,7 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 
 	const [showPinInputPopup, setShowPinInputPopup] = useState<boolean>(false);
 	const txCodeResolverRef = useRef<((value: string | null) => void) | null>(null);
+	const [txCodeInputOptions, setTxCodeInputOptions] = useState<TxCodeInputMetadata | null>(null);
 
 	const [showSyncPopup, setSyncPopup] = useState<boolean>(false);
 	const [textSyncPopup, setTextSyncPopup] = useState<{ description: string }>({ description: "" });
@@ -167,11 +169,18 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 		});
 	}, []);
 
-	const requestTxCodeInput = useCallback(() => {
+	const requestTxCodeInput = useCallback((txCode: TxCodeInputMetadata) => {
 		return new Promise<string | null>((resolve) => {
+			setTxCodeInputOptions(txCode ?? null);
 			txCodeResolverRef.current = resolve;
 			setShowPinInputPopup(true);
 		});
+	}, []);
+
+	const cancelTxCodeInput = useCallback(() => {
+		txCodeResolverRef.current?.(null);
+		txCodeResolverRef.current = null;
+		setTxCodeInputOptions(null);
 	}, []);
 
 	const popupContentFromIssuerMetadata = useCallback((
@@ -258,9 +267,10 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 					}
 
 					let userInput: string | undefined = undefined;
-					if (txCode) {
-						const pin = await requestTxCodeInput();
+					if (txCode !== undefined) {
+						const pin = await requestTxCodeInput(txCode);
 						if (pin === null) {
+							cleanCurrentUrl();
 							return null;
 						}
 						userInput = pin;
@@ -387,8 +397,15 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 					<PinInputPopup
 						isOpen={showPinInputPopup}
 						setIsOpen={setShowPinInputPopup}
-						onSubmit={(pin: string) => { txCodeResolverRef.current?.(pin); txCodeResolverRef.current = null; }}
-						onCancel={() => { txCodeResolverRef.current?.(null); txCodeResolverRef.current = null; }}
+						length={txCodeInputOptions?.length}
+						input_mode={txCodeInputOptions?.input_mode}
+						description={txCodeInputOptions?.description}
+						onSubmit={(pin: string) => {
+							txCodeResolverRef.current?.(pin);
+							txCodeResolverRef.current = null;
+							setTxCodeInputOptions(null);
+						}}
+						onCancel={cancelTxCodeInput}
 					/>
 				}
 				{isMessagePopupOpen &&

--- a/src/hocs/UriHandlerProvider.tsx
+++ b/src/hocs/UriHandlerProvider.tsx
@@ -43,6 +43,7 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 	const { handleAuthorizationRequest, promptForCredentialSelection, sendAuthorizationResponse } = openID4VP;
 
 	const [showPinInputPopup, setShowPinInputPopup] = useState<boolean>(false);
+	const txCodeResolverRef = useRef<((value: string | null) => void) | null>(null);
 
 	const [showSyncPopup, setSyncPopup] = useState<boolean>(false);
 	const [textSyncPopup, setTextSyncPopup] = useState<{ description: string }>({ description: "" });
@@ -166,6 +167,13 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 		});
 	}, []);
 
+	const requestTxCodeInput = useCallback(() => {
+		return new Promise<string | null>((resolve) => {
+			txCodeResolverRef.current = resolve;
+			setShowPinInputPopup(true);
+		});
+	}, []);
+
 	const popupContentFromIssuerMetadata = useCallback((
 		issuerMetadata: OpenidCredentialIssuerMetadata,
 		credentialConfigurationId: string
@@ -251,15 +259,11 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 
 					let userInput: string | undefined = undefined;
 					if (txCode) {
-						while (1) {
-							userInput = prompt(txCode.description ?? "Input Transaction Code displayed on your screen")
-							if (txCode.length && txCode.length === userInput.length) {
-								break;
-							}
-							else if (txCode.length) {
-								alert(`Length of transaction code must be ${txCode.length}`);
-							}
+						const pin = await requestTxCodeInput();
+						if (pin === null) {
+							return null;
 						}
+						userInput = pin;
 					}
 					usedPreAuthorizedCodes.current.push(preAuthorizedCode);
 					return requestCredentialsWithPreAuthorization(credentialIssuer, selectedCredentialConfigurationId, preAuthorizedCode, userInput);
@@ -349,6 +353,7 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 		// depend on methods, not whole context objects
 		popupContentFromIssuerMetadata,
 		requestRedirectConsent,
+		requestTxCodeInput,
 		showMessagePopup,
 		handleCredentialOffer,
 		generateAuthorizationRequest,
@@ -379,7 +384,12 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 			{children}
 			<Suspense fallback={null}>
 				{showPinInputPopup &&
-					<PinInputPopup isOpen={showPinInputPopup} setIsOpen={setShowPinInputPopup} />
+					<PinInputPopup
+						isOpen={showPinInputPopup}
+						setIsOpen={setShowPinInputPopup}
+						onSubmit={(pin: string) => { txCodeResolverRef.current?.(pin); txCodeResolverRef.current = null; }}
+						onCancel={() => { txCodeResolverRef.current?.(null); txCodeResolverRef.current = null; }}
+					/>
 				}
 				{isMessagePopupOpen &&
 					<MessagePopup type={typeMessagePopup} message={textMessagePopup} onClose={() => setMessagePopup(false)} />

--- a/src/lib/interfaces/IOpenID4VCI.ts
+++ b/src/lib/interfaces/IOpenID4VCI.ts
@@ -1,8 +1,13 @@
 import type { CredentialConfigurationSupported, OpenidCredentialIssuerMetadata } from "wallet-common";
 
+export type TxCodeInputMetadata = {
+	input_mode?: 'numeric' | 'text';
+	length?: number;
+	description?: string;
+};
 
 export interface IOpenID4VCI {
-	handleCredentialOffer(credentialOfferURL: string): Promise<{ credentialIssuer: string, selectedCredentialConfigurationId: string; issuer_state?: string; txCode?: { inputMode?: string; length?: number; description?: string; }; preAuthorizedCode?: string; }>;
+	handleCredentialOffer(credentialOfferURL: string): Promise<{ credentialIssuer: string, selectedCredentialConfigurationId: string; issuer_state?: string; txCode?: TxCodeInputMetadata; preAuthorizedCode?: string; }>;
 	getAvailableCredentialConfigurations(credentialIssuerIdentifier: string): Promise<Record<string, CredentialConfigurationSupported>>;
 	generateAuthorizationRequest(credentialIssuerIdentifier: string, credentialConfigurationId: string, issuer_state?: string): Promise<{ url?: string; issuerMetadata?: OpenidCredentialIssuerMetadata; credentialConfigurationId?: string }>;
 	handleAuthorizationResponse(url: string, dpopNonceHeader?: string): Promise<void>;

--- a/src/lib/services/OpenID4VCI/OpenID4VCI.ts
+++ b/src/lib/services/OpenID4VCI/OpenID4VCI.ts
@@ -1,4 +1,4 @@
-import { IOpenID4VCI } from '../../interfaces/IOpenID4VCI';
+import { IOpenID4VCI, TxCodeInputMetadata } from '../../interfaces/IOpenID4VCI';
 import * as jose from 'jose';
 import { generateRandomIdentifier } from '../../utils/generateRandomIdentifier';
 import * as config from '../../../config';
@@ -572,7 +572,7 @@ export function useOpenID4VCI({ errorCallback, showPopupConsent, showMessagePopu
  */
 
 	const handleCredentialOffer = useCallback(
-		async (credentialOfferURL: string): Promise<{ credentialIssuer: string, selectedCredentialConfigurationId: string; issuer_state?: string; txCode?: { inputMode?: string; length?: number; description?: string; }; preAuthorizedCode?: string; }> => {
+		async (credentialOfferURL: string): Promise<{ credentialIssuer: string, selectedCredentialConfigurationId: string; issuer_state?: string; txCode?: TxCodeInputMetadata; preAuthorizedCode?: string; }> => {
 			const parsedUrl = new URL(credentialOfferURL);
 			let offer;
 			if (parsedUrl.searchParams.get("credential_offer")) {
@@ -602,7 +602,9 @@ export function useOpenID4VCI({ errorCallback, showPopupConsent, showMessagePopu
 			if (GrantType.PRE_AUTHORIZED_CODE in offer.grants) {
 				const preAuthorizedCodeObject = offer.grants[GrantType.PRE_AUTHORIZED_CODE];
 				const preAuthorizedCode = preAuthorizedCodeObject["pre-authorized_code"];
-				const txCode = preAuthorizedCodeObject["tx_code"];
+				const txCode = "tx_code" in preAuthorizedCodeObject
+					? preAuthorizedCodeObject["tx_code"] ?? {}
+					: undefined;
 				return { credentialIssuer: offer.credential_issuer, selectedCredentialConfigurationId: selectedConfigurationId, txCode, preAuthorizedCode };
 			}
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -11,10 +11,10 @@
 		"status": "Connection status:"
 	},
 	"PinInputPopup": {
-		"description": "Please enter the PIN which was displayed from the issuer",
-		"errMessage": "You have entered an incorrect pin",
-		"inputPlaceholder": "Pin",
-		"title": "Enter the Pin"
+		"description": "Please enter the PIN provided by the issuer",
+		"errMessage": "You have entered an incorrect PIN",
+		"inputPlaceholder": "PIN",
+		"title": "Enter the PIN"
 	},
 	"common": {
 		"and": "and",


### PR DESCRIPTION
Replaces the browser prompt used for OID4VCI pre-authorized `tx_code` input with the wallet PIN popup.

### Changes

- Uses the PIN input popup when a pre-authorized credential offer includes `tx_code`.
- Passes issuer-provided `length`, `input_mode`, and `description` into the popup.
- Preserves the user-entered transaction code value.
- Keeps empty `tx_code` objects meaningful, since presence means the wallet should ask for a code.
- Fixes the PIN popup modal close handler warning by passing a function to `PopupLayout`.
