### PR TITLE
Fix/credential offer validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typescript": "^5.1.6",
     "uuid": "^9.0.0",
     "vite-plugin-pwa": "^0.21.1",
-    "wallet-common": "git+https://github.com/wwWallet/wallet-common.git#dce9ea74749417e15497718439cb73de32e17090",
+    "wallet-common": "git+https://github.com/wwWallet/wallet-common.git#c7b487b4bd99a5ee2800b330bfe077d7896d1ac9",
     "web-vitals": "^2.1.4",
     "workbox-core": "^7.3.0",
     "workbox-expiration": "^7.3.0",

--- a/src/lib/services/OpenID4VCI/OpenID4VCI.ts
+++ b/src/lib/services/OpenID4VCI/OpenID4VCI.ts
@@ -580,7 +580,7 @@ export function useOpenID4VCI({ errorCallback, showPopupConsent, showMessagePopu
 			} else {
 				try {
 					let response = await httpProxy.get(parsedUrl.searchParams.get("credential_offer_uri"), {})
-					offer = response.data;
+					offer = CredentialOfferSchema.parse(response.data);
 				}
 				catch (err) {
 					console.error(err);

--- a/src/lib/services/OpenID4VCI/OpenID4VCI.ts
+++ b/src/lib/services/OpenID4VCI/OpenID4VCI.ts
@@ -574,18 +574,25 @@ export function useOpenID4VCI({ errorCallback, showPopupConsent, showMessagePopu
 	const handleCredentialOffer = useCallback(
 		async (credentialOfferURL: string): Promise<{ credentialIssuer: string, selectedCredentialConfigurationId: string; issuer_state?: string; txCode?: { inputMode?: string; length?: number; description?: string; }; preAuthorizedCode?: string; }> => {
 			const parsedUrl = new URL(credentialOfferURL);
+			const credentialOffer = parsedUrl.searchParams.get("credential_offer");
+			const credentialOfferUri = parsedUrl.searchParams.get("credential_offer_uri");
 			let offer;
-			if (parsedUrl.searchParams.get("credential_offer")) {
-				offer = CredentialOfferSchema.parse(JSON.parse(parsedUrl.searchParams.get("credential_offer")));
-			} else {
+			if (credentialOffer && credentialOfferUri) {
+				throw new Error("Credential offer must not contain both credential_offer and credential_offer_uri");
+			}
+			if (credentialOffer) {
+				offer = CredentialOfferSchema.parse(JSON.parse(credentialOffer));
+			} else if (credentialOfferUri) {
 				try {
-					let response = await httpProxy.get(parsedUrl.searchParams.get("credential_offer_uri"), {})
+					let response = await httpProxy.get(credentialOfferUri, {})
 					offer = CredentialOfferSchema.parse(response.data);
 				}
 				catch (err) {
 					console.error(err);
 					return;
 				}
+			} else {
+				throw new Error("Credential offer must contain credential_offer or credential_offer_uri");
 			}
 
 
@@ -599,8 +606,8 @@ export function useOpenID4VCI({ errorCallback, showPopupConsent, showMessagePopu
 				throw new Error("Credential configuration not found");
 			}
 
-			if (GrantType.PRE_AUTHORIZED_CODE in offer.grants) {
-				const preAuthorizedCodeObject = offer.grants[GrantType.PRE_AUTHORIZED_CODE];
+			const preAuthorizedCodeObject = offer.grants?.[GrantType.PRE_AUTHORIZED_CODE];
+			if (preAuthorizedCodeObject) {
 				const preAuthorizedCode = preAuthorizedCodeObject["pre-authorized_code"];
 				const txCode = preAuthorizedCodeObject["tx_code"];
 				return { credentialIssuer: offer.credential_issuer, selectedCredentialConfigurationId: selectedConfigurationId, txCode, preAuthorizedCode };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7101,9 +7101,9 @@ w3c-xmlserializer@^5.0.0:
   dependencies:
     xml-name-validator "^5.0.0"
 
-"wallet-common@git+https://github.com/wwWallet/wallet-common.git#dce9ea74749417e15497718439cb73de32e17090":
+"wallet-common@git+https://github.com/wwWallet/wallet-common.git#c7b487b4bd99a5ee2800b330bfe077d7896d1ac9":
   version "0.0.1"
-  resolved "git+https://github.com/wwWallet/wallet-common.git#dce9ea74749417e15497718439cb73de32e17090"
+  resolved "git+https://github.com/wwWallet/wallet-common.git#c7b487b4bd99a5ee2800b330bfe077d7896d1ac9"
   dependencies:
     "@noble/curves" "^2.2.0"
     "@owf/mdoc" "^0.6.0"


### PR DESCRIPTION
Improves OID4VCI credential offer parsing and validation for fetched credential offers.

### Changes

- Updates `wallet-common` so `CredentialOfferSchema` supports pre-authorized grants.
- Parses fetched `credential_offer_uri` responses with `CredentialOfferSchema`.
- Rejects credential offer URLs that include both `credential_offer` and `credential_offer_uri`.
- Rejects credential offer URLs that include neither parameter.
- Handles missing `grants` without crashing.