### PR TITLE
Hide credential dataset behind dev mode

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -35,6 +35,7 @@ VCT_REGISTRY_URLS=http://localhost:8097/type-metadata
 POLICY_LINKS=""
 SHOW_PWA_INSTALL_PROMPT=false
 DISPLAY_CREDENTIAL_USAGES=false
+DEV_MODE=false
 
 # Used to generate well-known files at startup
 WELLKNOWN_APPLE_APPIDS=""

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Our Web Wallet provides a range of features tailored to enhance the credential m
   - `POLICY_LINKS`: Links to any TOS or other policies. This should be in the format `"<LABEL>::<URL>,<LABEL>::<URL>,<LABEL>::<URL>,..."` Can be left blank.
   - `SHOW_PWA_INSTALL_PROMPT`: Hide or show the PWA installation prompt on the login screen. Defaults to false if left blank or invalid.
   - `DISPLAY_CREDENTIAL_USAGES`: Hide or show the credential usage ribbon and usage count on credential cards/details. Defaults to false (hidden) if left blank or invalid.
+  - `DEV_MODE`: Show development-only wallet UI, including the credential dataset view. Defaults to false (hidden) if left blank or invalid.
 
   **Well-known file generation:**
   - `WELLKNOWN_APPLE_APPIDS`: Used to generate the `.well-known/apple-app-site-association` file, used for IOS wrappers. This should be in the format `"<APP_ID>,<APP_ID>,<APP_ID>,..."` Can be left blank.

--- a/config/config.ts
+++ b/config/config.ts
@@ -50,6 +50,7 @@ export const ClientEnvConfigSchema = z.object({
 	POLICY_LINKS: z.string().optional(),
 	SHOW_PWA_INSTALL_PROMPT: z.string().optional(),
 	DISPLAY_CREDENTIAL_USAGES: z.string().optional(),
+	DEV_MODE: z.string().optional(),
 });
 export type ClientEnvConfig = z.infer<typeof ClientEnvConfigSchema>;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,7 @@ export const VCT_REGISTRY_URLS: string[] = config.vct_registry_urls
 export const POLICY_LINKS = config.policy_links;
 export const SHOW_PWA_INSTALL_PROMPT = config.show_pwa_install_prompt ? config.show_pwa_install_prompt === 'true' : false;
 export const DISPLAY_CREDENTIAL_USAGES = config.display_credential_usages ? config.display_credential_usages === 'true' : false;
+export const DEV_MODE = config.dev_mode ? config.dev_mode === 'true' : false;
 export const BRANDING = {
 	LOGO_LIGHT: config.branding?.logo_light || '/logo_light.svg',
 	LOGO_DARK: config.branding?.logo_dark || '/logo_dark.svg',

--- a/src/pages/Home/Credential.jsx
+++ b/src/pages/Home/Credential.jsx
@@ -26,6 +26,7 @@ import CredentialLayout from '../../components/Credentials/CredentialLayout';
 import PopupLayout from '../../components/Popups/PopupLayout';
 import CredentialImage from '../../components/Credentials/CredentialImage';
 import CredentialTabsPanel from '@/components/Credentials/CredentialTabsPanel';
+import { H2 } from '@/components/Shared/Heading';
 
 import { useMdocAppCommunication } from '@/lib/services/MdocAppCommunication';
 import { BookCheck, QrCode } from 'lucide-react';
@@ -155,49 +156,52 @@ const Credential = () => {
 		}
 	}, [vcEntity]);
 
-	const infoTabs = [
+	const presentationsContent = (
+		<>
+			{history.length === 0 ? (
+				<p className="text-lm-gray-900 dark:text-white">
+					{t('pageHistory.noFound')}
+				</p>
+			) : (
+				<div className="max-h-[45vh] overflow-y-auto custom-scrollbar pr-2">
+					<HistoryList batchId={batchId} history={history} />
+				</div>
+			)}
+		</>
+	);
+
+	const infoTabs = DEV_MODE ? [
 		{
 			label: t('pageCredentials.presentationsTitle'),
-			component:
-				<>
-					{history.length === 0 ? (
-						<p className="text-lm-gray-900 dark:text-white">
-							{t('pageHistory.noFound')}
-						</p>
-					) : (
-						<div className="max-h-[45vh] overflow-y-auto custom-scrollbar px-2">
-							<HistoryList batchId={batchId} history={history} />
-						</div>
-					)}
-				</>
+			component: presentationsContent
 		},
-		...(DEV_MODE ? [{
+		{
 			label: t('pageCredentials.datasetTitle'),
 			component:
 				<CredentialJson
 					parsedCredential={vcEntity?.parsedCredential}
 				/>
-		}] : [])
-	];
+		}
+	] : [];
 
 	return (
 
 		<CredentialLayout title={credentialName} fixedRatioImage={false} displayCredentialInfo={vcEntity && <CredentialInfo parsedCredential={vcEntity.parsedCredential} />}>
 			<>
 				<div className="w-full pt-2">
-					{screenType !== 'mobile' ? (
-						<CredentialTabsPanel tabs={infoTabs} />
-					) : (
-						<>
-							<Button
-								id="navigate-credential-history"
-								variant="primary"
-								onClick={() => navigate(`/credential/${batchId}/history`)}
-								additionalClassName='w-full my-2'
-							>
-								{t('pageCredentials.presentationsTitle')}
-							</Button>
-							{DEV_MODE && (
+					{DEV_MODE ? (
+						screenType !== 'mobile' ? (
+							<CredentialTabsPanel tabs={infoTabs} />
+						) : (
+							<>
+								<Button
+									id="navigate-credential-history"
+									variant="primary"
+									onClick={() => navigate(`/credential/${batchId}/history`)}
+									additionalClassName='w-full my-2'
+								>
+									{t('pageCredentials.presentationsTitle')}
+								</Button>
 								<Button
 									id="navigate-credential-details"
 									variant="primary"
@@ -206,7 +210,12 @@ const Credential = () => {
 								>
 									{t('pageCredentials.datasetTitle')}
 								</Button>
-							)}
+							</>
+						)
+					) : (
+						<>
+							<H2 heading={t('pageCredentials.presentationsTitle')} />
+							{presentationsContent}
 						</>
 					)}
 				</div>

--- a/src/pages/Home/Credential.jsx
+++ b/src/pages/Home/Credential.jsx
@@ -29,6 +29,7 @@ import CredentialTabsPanel from '@/components/Credentials/CredentialTabsPanel';
 
 import { useMdocAppCommunication } from '@/lib/services/MdocAppCommunication';
 import { BookCheck, QrCode } from 'lucide-react';
+import { DEV_MODE } from '@/config';
 
 const Credential = () => {
 	const { batchId } = useParams();
@@ -170,13 +171,13 @@ const Credential = () => {
 					)}
 				</>
 		},
-		{
+		...(DEV_MODE ? [{
 			label: t('pageCredentials.datasetTitle'),
 			component:
 				<CredentialJson
 					parsedCredential={vcEntity?.parsedCredential}
 				/>
-		}
+		}] : [])
 	];
 
 	return (
@@ -196,14 +197,16 @@ const Credential = () => {
 							>
 								{t('pageCredentials.presentationsTitle')}
 							</Button>
-							<Button
-								id="navigate-credential-details"
-								variant="primary"
-								onClick={() => navigate(`/credential/${batchId}/details`)}
-								additionalClassName='w-full my-2'
-							>
-								{t('pageCredentials.datasetTitle')}
-							</Button>
+							{DEV_MODE && (
+								<Button
+									id="navigate-credential-details"
+									variant="primary"
+									onClick={() => navigate(`/credential/${batchId}/details`)}
+									additionalClassName='w-full my-2'
+								>
+									{t('pageCredentials.datasetTitle')}
+								</Button>
+							)}
 						</>
 					)}
 				</div>

--- a/src/pages/Home/CredentialDetails.jsx
+++ b/src/pages/Home/CredentialDetails.jsx
@@ -1,6 +1,6 @@
 // External libraries
 import React, { useContext } from 'react';
-import { useParams } from 'react-router-dom';
+import { Navigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 // Hooks
@@ -12,6 +12,7 @@ import CredentialsContext from '@/context/CredentialsContext';
 // Components
 import CredentialLayout from '../../components/Credentials/CredentialLayout';
 import CredentialJson from '../../components/Credentials/CredentialJson';
+import { DEV_MODE } from '@/config';
 
 const CredentialDetails = () => {
 	const { batchId } = useParams();
@@ -19,6 +20,10 @@ const CredentialDetails = () => {
 
 	const { vcEntityList, fetchVcData } = useContext(CredentialsContext);
 	const vcEntity  = useVcEntity(fetchVcData, vcEntityList, batchId);
+
+	if (!DEV_MODE) {
+		return <Navigate to={`/credential/${batchId}`} replace />;
+	}
 
 	return (
 		<>


### PR DESCRIPTION
This PR adds a `DEV_MODE` frontend configuration flag, defaulting to `false`, and uses it to hide the credential dataset view from normal wallet users.

## Changes

- Add `DEV_MODE` to frontend config, `.env.template`, and README docs.
- Show the credential dataset tab/details page only when `DEV_MODE=true`.
- Redirect direct dataset route access back to the credential page when dev mode is disabled.
- Simplify the credential page in normal mode by rendering presentations directly with a section title instead of showing a single-tab UI.
