### PR TITLE
Do not show redirect popup during preauth issuance

### DIFF
--- a/src/hocs/UriHandlerProvider.tsx
+++ b/src/hocs/UriHandlerProvider.tsx
@@ -250,17 +250,17 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 					if (!metadataResult?.metadata) {
 						throw new Error('Could not resolve issuer metadata for credential offer');
 					}
-					const popupContent = popupContentFromIssuerMetadata(metadataResult.metadata, selectedCredentialConfigurationId);
-					const userApproved = await requestRedirectConsent({
-						title: popupContent.title,
-						message: popupContent.message,
-					});
-					if (!userApproved) {
-						return null;
-					}
 
 					console.log("Generating authorization request...");
 					if (!preAuthorizedCode) {
+						const popupContent = popupContentFromIssuerMetadata(metadataResult.metadata, selectedCredentialConfigurationId);
+						const userApproved = await requestRedirectConsent({
+							title: popupContent.title,
+							message: popupContent.message,
+						});
+						if (!userApproved) {
+							return null;
+						}
 						return generateAuthorizationRequest(credentialIssuer, selectedCredentialConfigurationId, issuer_state);
 					} else if (usedPreAuthorizedCodes.current.includes(preAuthorizedCode)) {
 						throw new Error("Already used pre-authorized code");

--- a/translation_coverage/coverage_el.json
+++ b/translation_coverage/coverage_el.json
@@ -1,6 +1,6 @@
 {
 	"schemaVersion": 1,
 	"label": "EL Coverage",
-	"message": "80.73%",
+	"message": "80.79%",
 	"color": "yellow"
 }

--- a/translation_coverage/coverage_pt.json
+++ b/translation_coverage/coverage_pt.json
@@ -1,6 +1,6 @@
 {
 	"schemaVersion": 1,
 	"label": "PT Coverage",
-	"message": "74.75%",
+	"message": "74.83%",
 	"color": "red"
 }


### PR DESCRIPTION
The "You will be redirected to the Issuer" popup is misleading during Pre-Auth issuance since there is no redirect.
This PR removes it from this flow.