### PR TITLE
Fix stale runtime index cache SW

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -34,6 +34,7 @@ const SPA_ROUTE_ALLOWLIST = [
 
 const appShellStrategy = new NetworkFirst({
 	cacheName: appShellCacheName,
+	networkTimeoutSeconds: 3,
 });
 
 registerRoute(
@@ -48,20 +49,15 @@ registerRoute(
 	},
 	async ({ event }) => {
 		const appShellUrl = new URL(`${basePath}index.html`, self.location.origin);
+		const appShellRequest = new Request(appShellUrl, {
+			credentials: "same-origin",
+			cache: "reload",
+		});
 
-		try {
-			const response = await appShellStrategy.handle({
-				event,
-				request: new Request(appShellUrl, {
-					credentials: "same-origin",
-					cache: "reload",
-				}),
-			});
-
-			if (response) {
-				return response;
-			}
-		} catch {}
+		return appShellStrategy.handle({
+			event,
+			request: appShellRequest,
+		});
 	}
 );
 

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -2,11 +2,12 @@
 
 import { clientsClaim } from "workbox-core";
 import { ExpirationPlugin } from "workbox-expiration";
-import { precacheAndRoute, cleanupOutdatedCaches, createHandlerBoundToURL, } from "workbox-precaching";
+import { precacheAndRoute, cleanupOutdatedCaches } from "workbox-precaching";
 import { registerRoute } from "workbox-routing";
 import { StaleWhileRevalidate, CacheFirst, NetworkFirst } from "workbox-strategies";
 
 const basePath = new URL(self.registration.scope).pathname.replace(/\/?$/, '/') || '/';
+const appShellCacheName = `app-shell:${basePath}`;
 
 clientsClaim();
 
@@ -31,10 +32,8 @@ const SPA_ROUTE_ALLOWLIST = [
 	/^\/history\/[^/]+$/,                // History detail
 ];
 
-const appShellHandler = createHandlerBoundToURL(`${basePath}index.html`);
 const appShellStrategy = new NetworkFirst({
-	cacheName: "app-shell",
-	networkTimeoutSeconds: 3,
+	cacheName: appShellCacheName,
 });
 
 registerRoute(
@@ -55,6 +54,7 @@ registerRoute(
 				event,
 				request: new Request(appShellUrl, {
 					credentials: "same-origin",
+					cache: "reload",
 				}),
 			});
 
@@ -62,8 +62,6 @@ registerRoute(
 				return response;
 			}
 		} catch {}
-
-		return appShellHandler({ event });
 	}
 );
 
@@ -124,11 +122,11 @@ self.addEventListener("activate", (event) => {
 			// Clean old Workbox precache caches
 			await cleanupOutdatedCaches();
 
-			// Delete runtime image cache
+			// Delete the old unscoped app shell cache.
 			const cacheNames = await caches.keys();
 			await Promise.all(
 				cacheNames
-					.filter((name) => name === "images")
+					.filter((name) => name === "app-shell")
 					.map((name) => caches.delete(name))
 			);
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -80,7 +80,7 @@ export default defineConfig(async ({ mode }) => {
 				manifest: false, // Vite will use `public/manifest.json` automatically
 				injectManifest: {
 					maximumFileSizeToCacheInBytes: env.GENERATE_SOURCEMAP === 'true' ? 12 * 1024 * 1024 : 4 * 1024 * 1024,
-					globIgnores: ['theme.css'],
+					globIgnores: ['theme.css', 'index.html'],
 					additionalManifestEntries: [
 						{ url: './manifest.json', revision: manifestRevision },
 					],


### PR DESCRIPTION
Fixes stale runtime-injected config being served from the service worker.

## Changes

- Exclude `index.html` from the Workbox precache.
- Fetch `index.html` from network while online using the runtime app-shell cache.
- Scope the app-shell cache by `BASE_PATH`.
- Stop deleting the image cache during SW activation so offline assets remain available.
