### PR TITLE
Proritize A256GCM response encryption when available

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typescript": "^5.1.6",
     "uuid": "^9.0.0",
     "vite-plugin-pwa": "^0.21.1",
-    "wallet-common": "git+https://github.com/wwWallet/wallet-common.git#2f50827283f70668ed326b69e62046857258128a",
+    "wallet-common": "git+https://github.com/wwWallet/wallet-common.git#9df178665980ea7e7cbe2a441a3e6dbcec9dff6c",
     "web-vitals": "^2.1.4",
     "workbox-core": "^7.3.0",
     "workbox-expiration": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typescript": "^5.1.6",
     "uuid": "^9.0.0",
     "vite-plugin-pwa": "^0.21.1",
-    "wallet-common": "git+https://github.com/wwWallet/wallet-common.git#c7b487b4bd99a5ee2800b330bfe077d7896d1ac9",
+    "wallet-common": "git+https://github.com/wwWallet/wallet-common.git#2f50827283f70668ed326b69e62046857258128a",
     "web-vitals": "^2.1.4",
     "workbox-core": "^7.3.0",
     "workbox-expiration": "^7.3.0",

--- a/src/lib/services/OpenID4VCI/CredentialRequest.ts
+++ b/src/lib/services/OpenID4VCI/CredentialRequest.ts
@@ -263,7 +263,7 @@ export function useCredentialRequest() {
 				credentialRequestEncryptionSupportedErrors.push(`No supported credential_request_encryption keys found. Keys using Alg values[${credentialRequestWalletSupportedAlg.join(', ')}] are supported.`);
 			}
 
-			const credentialRequestWalletSupportedEnc = ['A128GCM'];
+			const credentialRequestWalletSupportedEnc = ['A128GCM', 'A256GCM'];
 			const credentialRequestIssuerSupportedEnc = credentialIssuerMetadata.metadata.credential_request_encryption.enc_values_supported;
 			credentialRequestEncryptionEnc = credentialRequestWalletSupportedEnc.find(enc => credentialRequestIssuerSupportedEnc.includes(enc));
 			if (!credentialRequestEncryptionEnc) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7101,9 +7101,9 @@ w3c-xmlserializer@^5.0.0:
   dependencies:
     xml-name-validator "^5.0.0"
 
-"wallet-common@git+https://github.com/wwWallet/wallet-common.git#c7b487b4bd99a5ee2800b330bfe077d7896d1ac9":
+"wallet-common@git+https://github.com/wwWallet/wallet-common.git#2f50827283f70668ed326b69e62046857258128a":
   version "0.0.1"
-  resolved "git+https://github.com/wwWallet/wallet-common.git#c7b487b4bd99a5ee2800b330bfe077d7896d1ac9"
+  resolved "git+https://github.com/wwWallet/wallet-common.git#2f50827283f70668ed326b69e62046857258128a"
   dependencies:
     "@noble/curves" "^2.2.0"
     "@owf/mdoc" "^0.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7101,9 +7101,9 @@ w3c-xmlserializer@^5.0.0:
   dependencies:
     xml-name-validator "^5.0.0"
 
-"wallet-common@git+https://github.com/wwWallet/wallet-common.git#2f50827283f70668ed326b69e62046857258128a":
+"wallet-common@git+https://github.com/wwWallet/wallet-common.git#9df178665980ea7e7cbe2a441a3e6dbcec9dff6c":
   version "0.0.1"
-  resolved "git+https://github.com/wwWallet/wallet-common.git#2f50827283f70668ed326b69e62046857258128a"
+  resolved "git+https://github.com/wwWallet/wallet-common.git#9df178665980ea7e7cbe2a441a3e6dbcec9dff6c"
   dependencies:
     "@noble/curves" "^2.2.0"
     "@owf/mdoc" "^0.6.0"


### PR DESCRIPTION
Awaiting https://github.com/wwWallet/wallet-common/pull/117

This PR slightly modifies credential response encryption by sorting the available supported response encryption algorithms by strength. It always prioritizes A256GCM when available, as per [HAIP section 5](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0-final.html#section-5-2.5), and alternatively chooses A192GCM over A128GCM, when both exist