### PR TITLE
Fix history popup showing wrong transaction on click

### DIFF
--- a/src/components/History/HistoryList.jsx
+++ b/src/components/History/HistoryList.jsx
@@ -1,5 +1,5 @@
 // components/History/HistoryList.jsx
-import React, { useState, useContext, useEffect, useMemo } from 'react';
+import React, { useState, useContext, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useScreenType from '../../hooks/useScreenType';
 import { H3 } from '../Shared/Heading';
@@ -17,7 +17,7 @@ import { prettyDomain } from '@/utils';
 import Button from '../Buttons/Button';
 
 /** ------------------ Pure view (NO data fetching here) ------------------ */
-function HistoryListView({ batchId = null, title = '', limit = null, history = {} }) {
+function HistoryListView({ title = '', limit = null, history = {} }) {
 	const navigate = useNavigate();
 	const screenType = useScreenType();
 
@@ -28,13 +28,7 @@ function HistoryListView({ batchId = null, title = '', limit = null, history = {
 	}, [history]);
 
 	const [isImageModalOpen, setImageModalOpen] = useState(false);
-	const [selectedByBatch, setSelectedByBatch] = useState(null);
 	const [selectedByTx, setSelectedByTx] = useState(null);
-
-	useEffect(() => {
-		if (batchId !== null && groups.length > 0) setSelectedByBatch(groups[0]);
-		else setSelectedByBatch(null);
-	}, [batchId, groups]);
 
 	const handleHistoryItemClick = (item) => {
 		const transactionId = item[0].presentation.transactionId;
@@ -80,7 +74,7 @@ function HistoryListView({ batchId = null, title = '', limit = null, history = {
 			<HistoryDetailPopup
 				isOpen={isImageModalOpen}
 				onClose={() => setImageModalOpen(false)}
-				historyItem={selectedByBatch ?? selectedByTx ?? []}
+				historyItem={selectedByTx ?? []}
 			/>
 		</>
 	);
@@ -89,13 +83,13 @@ function HistoryListView({ batchId = null, title = '', limit = null, history = {
 function HistoryListFetcher({ batchId = null, title = '', limit = null }) {
 	const { keystore } = useContext(SessionContext);
 	const history = useFetchPresentations(keystore, batchId, null);
-	return <HistoryListView batchId={batchId} title={title} limit={limit} history={history} />;
+	return <HistoryListView title={title} limit={limit} history={history} />;
 }
 
 /** If `history` prop is provided → no hook call. Otherwise fetcher calls the hook. */
 export default function HistoryList({ batchId = null, title = '', limit = null, history = null }) {
 	if (history) {
-		return <HistoryListView batchId={batchId} title={title} limit={limit} history={history} />;
+		return <HistoryListView title={title} limit={limit} history={history} />;
 	}
 	return <HistoryListFetcher batchId={batchId} title={title} limit={limit} />;
 }


### PR DESCRIPTION
## Summary
- In batchId-scoped history lists (Home's "Recent History" widget, Credential page's "Presentations" tab), clicking any item in the list on desktop always opened the popup for the *most recent* transaction instead of the one actually clicked.
- Root cause: `selectedByBatch` state was set via effect to `groups[0]` (the most recent transaction) whenever a `batchId` was passed, and `historyItem={selectedByBatch ?? selectedByTx ?? []}` let it silently win over `selectedByTx`, which the click handler already sets correctly. `selectedByBatch` had no other purpose, the popup only opens via the click handler regardless.
- Removed the `selectedByBatch` state/effect and the now-unused `batchId` prop on the internal `HistoryListView`. The public `HistoryList` is unchanged, so no caller needed updating.

### Test plan

1. On desktop, open a credential with 2+ history entries and click the *second* item in "Recent History" on Home, confirm the popup shows the transaction that was clicked, not the most recent one
2. Same check from the Credential page's "Presentations" tab
3. Confirm the standalone History page (`/history`) still opens the correct transaction (was already unaffected, should remain correct)
4. Confirm mobile still navigates to `/history/:transactionId` on click, unaffected by this change