### PR TITLE
Replace mobile switch-account full-screen takeover with an animated bottom sheet

### DIFF
--- a/src/components/Auth/CachedUsersList.tsx
+++ b/src/components/Auth/CachedUsersList.tsx
@@ -54,7 +54,7 @@ const CachedUsersList = ({
 
 			<div className="text-sm flex justify-start pt-3">
 				<Link onClick={onSwitchAccount} disabled={disabled}>
-					{t('loginSignup.otherAccount')}
+					{t('loginSignup.otherAccounts')}
 				</Link>
 			</div>
 		</>

--- a/src/components/Auth/CachedUsersList.tsx
+++ b/src/components/Auth/CachedUsersList.tsx
@@ -54,7 +54,7 @@ const CachedUsersList = ({
 
 			<div className="text-sm flex justify-start pt-3">
 				<Link onClick={onSwitchAccount} disabled={disabled}>
-					{t('loginSignup.switchAccount')}
+					{t('loginSignup.otherAccount')}
 				</Link>
 			</div>
 		</>

--- a/src/components/Auth/WebauthnSignupLogin.tsx
+++ b/src/components/Auth/WebauthnSignupLogin.tsx
@@ -362,10 +362,10 @@ const WebauthnSignupLogin = ({
 			<div className="flex items-start justify-between gap-4 text-lm-gray-900 dark:text-dm-gray-100">
 				<div className="min-w-0">
 					<h2 className="text-xl font-bold leading-tight tracking-tight text-lm-gray-900 md:text-2xl dark:text-white">
-						{t('loginSignup.otherAccount')}
+						{t('loginSignup.otherAccounts')}
 					</h2>
 					<p className="mb-4 mt-1 text-sm text-lm-gray-900 dark:text-dm-gray-100">
-						{t('loginSignup.otherAccountDescription')}
+						{t('loginSignup.otherAccountsDescription')}
 					</p>
 				</div>
 				{showCancelButton && (
@@ -389,7 +389,7 @@ const WebauthnSignupLogin = ({
 					{renderSwitcherHeader(true)}
 					<AccountSwitcherList
 						variant="desktop"
-						ariaLabel={t('loginSignup.otherAccountDescription')}
+						ariaLabel={t('loginSignup.otherAccountsDescription')}
 						items={accountListItems}
 						showFade={loginableCachedUsers.length > 3}
 					/>
@@ -573,12 +573,12 @@ const WebauthnSignupLogin = ({
 				<BottomSheet
 					isOpen={isAccountSwitcherOpen}
 					onClose={closeSwitcher}
-					contentLabel={t('loginSignup.otherAccount')}
+					contentLabel={t('loginSignup.otherAccounts')}
 				>
 					{renderSwitcherHeader(false, true)}
 					<AccountSwitcherList
 						variant="mobile"
-						ariaLabel={t('loginSignup.otherAccountDescription')}
+						ariaLabel={t('loginSignup.otherAccountsDescription')}
 						items={accountListItems}
 						showFade={loginableCachedUsers.length > 3}
 					/>

--- a/src/components/Auth/WebauthnSignupLogin.tsx
+++ b/src/components/Auth/WebauthnSignupLogin.tsx
@@ -1,6 +1,5 @@
 import React, { useContext, useEffect, useState, ChangeEventHandler } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import Modal from 'react-modal';
 
 import type { CachedUser } from '../../services/LocalStorageKeystore';
 import { calculateByteSize, coerce } from '../../util';
@@ -12,6 +11,7 @@ import useScreenType from '@/hooks/useScreenType';
 import Button, { Variant } from '../../components/Buttons/Button';
 import CachedUsersList from './CachedUsersList';
 import SeparatorLine from '../Shared/SeparatorLine';
+import BottomSheet from '../Popups/BottomSheet';
 
 import checkForUpdates from '../../offlineUpdateSW';
 
@@ -82,12 +82,12 @@ const AccountSwitcherList = ({
 	items: React.ReactNode,
 	showFade: boolean,
 }) => (
-	<div className={`relative ${variant === 'mobile' ? 'flex-1 min-h-0 flex flex-col' : ''}`}>
+	<div className="relative">
 		<ul
 			aria-label={ariaLabel}
 			className={
 				variant === 'mobile'
-					? 'flex flex-col gap-2 flex-1 min-h-0 overflow-y-auto overflow-x-hidden overscroll-contain pb-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'
+					? 'flex flex-col gap-2 max-h-[50dvh] overflow-y-auto overflow-x-hidden overscroll-contain pb-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'
 					: 'flex flex-col gap-2 max-h-[40dvh] overflow-y-auto overflow-x-hidden overscroll-contain pr-2 pb-4 [scrollbar-gutter:stable]'
 			}
 		>
@@ -375,45 +375,16 @@ const WebauthnSignupLogin = ({
 
 	return (
 		<form onSubmit={onSubmit}>
-			{isAccountSwitcherOpen ? (
-				screenType === 'desktop' ? (
-					<div>
-						{renderSwitcherHeader(true)}
-						<AccountSwitcherList
-							variant="desktop"
-							ariaLabel={t('loginSignup.switchAccountDescription')}
-							items={accountListItems}
-							showFade={loginableCachedUsers.length > 3}
-						/>
-					</div>
-				) : (
-					<Modal
-						isOpen={true}
-						onRequestClose={closeSwitcher}
-						shouldCloseOnOverlayClick={false}
-						contentLabel={t('loginSignup.switchAccount')}
-						className="w-full h-full flex flex-col bg-lm-gray-100 dark:bg-dm-gray-900 p-6 pt-8 outline-none"
-						overlayClassName="fixed inset-0 z-50 bg-lm-gray-100 dark:bg-dm-gray-900"
-						bodyOpenClassName="overflow-hidden"
-					>
-						{renderSwitcherHeader(false)}
-						<AccountSwitcherList
-							variant="mobile"
-							ariaLabel={t('loginSignup.switchAccountDescription')}
-							items={accountListItems}
-							showFade={loginableCachedUsers.length > 3}
-						/>
-						<Button
-							id="back-switch-account-bottom-loginsignup"
-							onClick={closeSwitcher}
-							variant="outline"
-							additionalClassName="w-full mt-4 shrink-0"
-						>
-							<ChevronLeft size={18} className="inline mr-1" />
-							{t('common.back')}
-						</Button>
-					</Modal>
-				)
+			{isAccountSwitcherOpen && screenType === 'desktop' ? (
+				<div>
+					{renderSwitcherHeader(true)}
+					<AccountSwitcherList
+						variant="desktop"
+						ariaLabel={t('loginSignup.switchAccountDescription')}
+						items={accountListItems}
+						showFade={loginableCachedUsers.length > 3}
+					/>
+				</div>
 			) : inProgress || retrySignupFrom
 				? (
 					needPrfRetry
@@ -588,6 +559,31 @@ const WebauthnSignupLogin = ({
 					</>
 				)
 			}
+
+			{isAccountSwitcherOpen && screenType !== 'desktop' && (
+				<BottomSheet
+					isOpen={true}
+					onClose={closeSwitcher}
+					contentLabel={t('loginSignup.switchAccount')}
+				>
+					{renderSwitcherHeader(false)}
+					<AccountSwitcherList
+						variant="mobile"
+						ariaLabel={t('loginSignup.switchAccountDescription')}
+						items={accountListItems}
+						showFade={loginableCachedUsers.length > 3}
+					/>
+					<Button
+						id="back-switch-account-bottom-loginsignup"
+						onClick={closeSwitcher}
+						variant="outline"
+						additionalClassName="w-full mt-4 shrink-0"
+					>
+						<ChevronLeft size={18} className="inline" />
+						{t('common.back')}
+					</Button>
+				</BottomSheet>
+			)}
 		</form>
 	);
 };

--- a/src/components/Auth/WebauthnSignupLogin.tsx
+++ b/src/components/Auth/WebauthnSignupLogin.tsx
@@ -15,7 +15,7 @@ import BottomSheet from '../Popups/BottomSheet';
 
 import checkForUpdates from '../../offlineUpdateSW';
 
-import { Check, ChevronLeft, KeyRoundIcon, User, Wallet, X } from 'lucide-react';
+import { ChevronLeft, KeyRoundIcon, User, Wallet, X } from 'lucide-react';
 import { UsbStickDotIcon } from '@/components/Shared/CustomIcons';
 import PolicyLinks from '@/components/Shared/PolicyLinks';
 import { usePolicyLinks } from '@/hooks/usePolicyLinks';
@@ -137,10 +137,7 @@ const WebauthnSignupLogin = ({
 
 	const cachedUsers = keystore.getCachedUsers();
 	const loginableCachedUsers = cachedUsers.filter((cachedUser) => cachedUser?.prfKeys?.length > 0);
-	const [selectedCachedUser, setSelectedCachedUser] = useState<CachedUser | null>(null);
-	const activeCachedUser = loginableCachedUsers.find(
-		(cachedUser) => cachedUser.userHandleB64u === selectedCachedUser?.userHandleB64u
-	) ?? loginableCachedUsers[0] ?? null;
+	const activeCachedUser = loginableCachedUsers[0] ?? null;
 
 	useEffect(
 		() => {
@@ -311,20 +308,19 @@ const WebauthnSignupLogin = ({
 	const nameByteLimitApproaching = nameByteLength >= nameByteLimit / 2;
 
 	const accountListItems = loginableCachedUsers.map((cachedUser, index) => {
-		const isActive = cachedUser.userHandleB64u === activeCachedUser?.userHandleB64u;
 		return (
 			<li key={cachedUser.userHandleB64u} className="w-full flex items-center gap-4">
 			<button
-				id={`switch-select-cached-user-${index}-loginsignup`}
+				id={`switch-login-cached-user-${index}-loginsignup`}
 				type="button"
-				onClick={() => {
-					setSelectedCachedUser(cachedUser);
+				onClick={async () => {
 					setIsAccountSwitcherOpen(false);
+					await onLoginCachedUser(cachedUser);
 				}}
 				disabled={isSubmitting}
-				aria-label={t('loginSignup.selectUser', { name: cachedUser.displayName })}
-				title={t('loginSignup.selectUser', { name: cachedUser.displayName })}
-				className={`flex-1 min-w-0 flex items-center gap-3 px-3 py-2.5 text-left rounded-lg border transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-offset-2 ${isActive ? 'border-primary dark:border-white' : 'border-lm-gray-400 dark:border-dm-gray-600'} bg-lm-gray-200 dark:bg-dm-gray-800 ${isSubmitting ? 'opacity-75 cursor-not-allowed' : 'cursor-pointer hover:bg-lm-gray-300 dark:hover:bg-dm-gray-700'}`}
+				aria-label={t('loginSignup.loginAsUser', { name: cachedUser.displayName })}
+				title={t('loginSignup.loginAsUser', { name: cachedUser.displayName })}
+				className={`flex-1 min-w-0 flex items-center gap-3 px-3 py-2.5 text-left rounded-lg border border-lm-gray-400 dark:border-dm-gray-600 transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-offset-2 bg-lm-gray-200 dark:bg-dm-gray-800 ${isSubmitting ? 'opacity-75 cursor-not-allowed' : 'cursor-pointer hover:bg-lm-gray-300 dark:hover:bg-dm-gray-700'}`}
 			>
 				<div aria-hidden="true" className="w-8 h-8 rounded-full bg-primary text-white flex items-center justify-center shrink-0 select-none">
 					<User size={20} />
@@ -332,7 +328,6 @@ const WebauthnSignupLogin = ({
 				<span className="flex-1 min-w-0 text-sm font-semibold text-lm-gray-900 dark:text-white truncate">
 					{cachedUser.displayName}
 				</span>
-				{isActive && <Check size={18} aria-hidden="true" className="shrink-0 text-primary dark:text-white" />}
 			</button>
 			<button
 				id={`switch-forget-cached-user-${index}-loginsignup`}

--- a/src/components/Auth/WebauthnSignupLogin.tsx
+++ b/src/components/Auth/WebauthnSignupLogin.tsx
@@ -560,9 +560,9 @@ const WebauthnSignupLogin = ({
 				)
 			}
 
-			{isAccountSwitcherOpen && screenType !== 'desktop' && (
+			{screenType !== 'desktop' && (
 				<BottomSheet
-					isOpen={true}
+					isOpen={isAccountSwitcherOpen}
 					onClose={closeSwitcher}
 					contentLabel={t('loginSignup.switchAccount')}
 				>

--- a/src/components/Auth/WebauthnSignupLogin.tsx
+++ b/src/components/Auth/WebauthnSignupLogin.tsx
@@ -365,10 +365,10 @@ const WebauthnSignupLogin = ({
 				</button>
 			)}
 			<h2 className="text-xl font-bold leading-tight tracking-tight text-lm-gray-900 md:text-2xl dark:text-white">
-				{t('loginSignup.switchAccount')}
+				{t('loginSignup.otherAccount')}
 			</h2>
 			<p className="mb-4 mt-1 text-sm text-lm-gray-900 dark:text-dm-gray-100">
-				{t('loginSignup.switchAccountDescription')}
+				{t('loginSignup.otherAccountDescription')}
 			</p>
 		</>
 	);
@@ -380,7 +380,7 @@ const WebauthnSignupLogin = ({
 					{renderSwitcherHeader(true)}
 					<AccountSwitcherList
 						variant="desktop"
-						ariaLabel={t('loginSignup.switchAccountDescription')}
+						ariaLabel={t('loginSignup.otherAccountDescription')}
 						items={accountListItems}
 						showFade={loginableCachedUsers.length > 3}
 					/>
@@ -564,12 +564,12 @@ const WebauthnSignupLogin = ({
 				<BottomSheet
 					isOpen={isAccountSwitcherOpen}
 					onClose={closeSwitcher}
-					contentLabel={t('loginSignup.switchAccount')}
+					contentLabel={t('loginSignup.otherAccount')}
 				>
 					{renderSwitcherHeader(false)}
 					<AccountSwitcherList
 						variant="mobile"
-						ariaLabel={t('loginSignup.switchAccountDescription')}
+						ariaLabel={t('loginSignup.otherAccountDescription')}
 						items={accountListItems}
 						showFade={loginableCachedUsers.length > 3}
 					/>

--- a/src/components/Auth/WebauthnSignupLogin.tsx
+++ b/src/components/Auth/WebauthnSignupLogin.tsx
@@ -346,7 +346,7 @@ const WebauthnSignupLogin = ({
 
 	const closeSwitcher = () => setIsAccountSwitcherOpen(false);
 
-	const renderSwitcherHeader = (showBackButton: boolean) => (
+	const renderSwitcherHeader = (showBackButton: boolean, showCancelButton = false) => (
 		<>
 			{showBackButton && (
 				<button
@@ -359,12 +359,26 @@ const WebauthnSignupLogin = ({
 					{t('common.back')}
 				</button>
 			)}
-			<h2 className="text-xl font-bold leading-tight tracking-tight text-lm-gray-900 md:text-2xl dark:text-white">
-				{t('loginSignup.otherAccount')}
-			</h2>
-			<p className="mb-4 mt-1 text-sm text-lm-gray-900 dark:text-dm-gray-100">
-				{t('loginSignup.otherAccountDescription')}
-			</p>
+			<div className="flex items-start justify-between gap-4 text-lm-gray-900 dark:text-dm-gray-100">
+				<div className="min-w-0">
+					<h2 className="text-xl font-bold leading-tight tracking-tight text-lm-gray-900 md:text-2xl dark:text-white">
+						{t('loginSignup.otherAccount')}
+					</h2>
+					<p className="mb-4 mt-1 text-sm text-lm-gray-900 dark:text-dm-gray-100">
+						{t('loginSignup.otherAccountDescription')}
+					</p>
+				</div>
+				{showCancelButton && (
+					<button
+						id="cancel-switch-account-bottom-loginsignup"
+						type="button"
+						onClick={closeSwitcher}
+						className="-mr-2 shrink-0 px-2 py-1.5 rounded-lg text-sm font-semibold text-lm-gray-900 dark:text-dm-gray-100 cursor-pointer hover:bg-lm-gray-200 dark:hover:bg-dm-gray-800 transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-offset-2"
+					>
+						{t('common.cancel')}
+					</button>
+				)}
+			</div>
 		</>
 	);
 
@@ -561,22 +575,13 @@ const WebauthnSignupLogin = ({
 					onClose={closeSwitcher}
 					contentLabel={t('loginSignup.otherAccount')}
 				>
-					{renderSwitcherHeader(false)}
+					{renderSwitcherHeader(false, true)}
 					<AccountSwitcherList
 						variant="mobile"
 						ariaLabel={t('loginSignup.otherAccountDescription')}
 						items={accountListItems}
 						showFade={loginableCachedUsers.length > 3}
 					/>
-					<Button
-						id="back-switch-account-bottom-loginsignup"
-						onClick={closeSwitcher}
-						variant="outline"
-						additionalClassName="w-full mt-4 shrink-0"
-					>
-						<ChevronLeft size={18} className="inline" />
-						{t('common.back')}
-					</Button>
 				</BottomSheet>
 			)}
 		</form>

--- a/src/components/Popups/BottomSheet.tsx
+++ b/src/components/Popups/BottomSheet.tsx
@@ -1,7 +1,8 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Modal from 'react-modal';
 
 const DEFAULT_DISMISS_THRESHOLD_PX = 100;
+const TRANSITION_MS = 200;
 
 const BottomSheet = ({
 	isOpen,
@@ -18,13 +19,20 @@ const BottomSheet = ({
 	dismissThresholdPx?: number,
 	shouldCloseOnOverlayClick?: boolean,
 }) => {
+	const [hasEntered, setHasEntered] = useState(false);
 	const [dragY, setDragY] = useState(0);
 	const [isDragging, setIsDragging] = useState(false);
 	const dragStartYRef = useRef(0);
 
-	if (!isOpen) {
-		return null;
-	}
+	useEffect(() => {
+		if (!isOpen) {
+			setHasEntered(false);
+			const timeout = setTimeout(() => setDragY(0), TRANSITION_MS);
+			return () => clearTimeout(timeout);
+		}
+		const raf = requestAnimationFrame(() => setHasEntered(true));
+		return () => cancelAnimationFrame(raf);
+	}, [isOpen]);
 
 	const onHandlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
 		event.currentTarget.setPointerCapture(event.pointerId);
@@ -41,23 +49,29 @@ const BottomSheet = ({
 		setIsDragging(false);
 		if (dragY > dismissThresholdPx) {
 			onClose();
+		} else {
+			setDragY(0);
 		}
-		setDragY(0);
 	};
 
 	return (
 		<Modal
-			isOpen={true}
+			isOpen={isOpen}
 			onRequestClose={onClose}
 			shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
 			contentLabel={contentLabel}
+			closeTimeoutMS={TRANSITION_MS}
 			className="w-full max-h-[85dvh] flex flex-col bg-lm-gray-100 dark:bg-dm-gray-900 rounded-t-2xl shadow-2xl p-6 pt-3 outline-none"
 			overlayClassName="fixed inset-0 z-50 flex items-end justify-center bg-lm-gray-900/50 dark:bg-dm-gray-500/50 backdrop-blur-xs"
 			bodyOpenClassName="overflow-hidden"
 			style={{
+				overlay: {
+					opacity: hasEntered ? 1 : 0,
+					transition: `opacity ${TRANSITION_MS}ms ease-out`,
+				},
 				content: {
-					transform: `translateY(${dragY}px)`,
-					transition: isDragging ? 'none' : 'transform 0.2s ease-out',
+					transform: hasEntered ? `translateY(${dragY}px)` : 'translateY(100%)',
+					transition: isDragging ? 'none' : `transform ${TRANSITION_MS}ms ease-out`,
 				},
 			}}
 		>

--- a/src/components/Popups/BottomSheet.tsx
+++ b/src/components/Popups/BottomSheet.tsx
@@ -1,0 +1,77 @@
+import React, { useRef, useState } from 'react';
+import Modal from 'react-modal';
+
+const DEFAULT_DISMISS_THRESHOLD_PX = 100;
+
+const BottomSheet = ({
+	isOpen,
+	onClose,
+	contentLabel,
+	children,
+	dismissThresholdPx = DEFAULT_DISMISS_THRESHOLD_PX,
+	shouldCloseOnOverlayClick = true,
+}: {
+	isOpen: boolean,
+	onClose: () => void,
+	contentLabel: string,
+	children: React.ReactNode,
+	dismissThresholdPx?: number,
+	shouldCloseOnOverlayClick?: boolean,
+}) => {
+	const [dragY, setDragY] = useState(0);
+	const [isDragging, setIsDragging] = useState(false);
+	const dragStartYRef = useRef(0);
+
+	if (!isOpen) {
+		return null;
+	}
+
+	const onHandlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+		event.currentTarget.setPointerCapture(event.pointerId);
+		dragStartYRef.current = event.clientY;
+		setIsDragging(true);
+	};
+
+	const onHandlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+		if (!isDragging) return;
+		setDragY(Math.max(0, event.clientY - dragStartYRef.current));
+	};
+
+	const onHandlePointerUp = () => {
+		setIsDragging(false);
+		if (dragY > dismissThresholdPx) {
+			onClose();
+		}
+		setDragY(0);
+	};
+
+	return (
+		<Modal
+			isOpen={true}
+			onRequestClose={onClose}
+			shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
+			contentLabel={contentLabel}
+			className="w-full max-h-[85dvh] flex flex-col bg-lm-gray-100 dark:bg-dm-gray-900 rounded-t-2xl shadow-2xl p-6 pt-3 outline-none"
+			overlayClassName="fixed inset-0 z-50 flex items-end justify-center bg-lm-gray-900/50 dark:bg-dm-gray-500/50 backdrop-blur-xs"
+			bodyOpenClassName="overflow-hidden"
+			style={{
+				content: {
+					transform: `translateY(${dragY}px)`,
+					transition: isDragging ? 'none' : 'transform 0.2s ease-out',
+				},
+			}}
+		>
+			<div
+				aria-hidden="true"
+				className="mx-auto mb-2 h-1.5 w-10 shrink-0 rounded-full bg-lm-gray-400 dark:bg-dm-gray-600 cursor-grab active:cursor-grabbing touch-none"
+				onPointerDown={onHandlePointerDown}
+				onPointerMove={onHandlePointerMove}
+				onPointerUp={onHandlePointerUp}
+				onPointerCancel={onHandlePointerUp}
+			/>
+			{children}
+		</Modal>
+	);
+};
+
+export default BottomSheet;

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -96,8 +96,8 @@
 		"signUpWithPasskey": "Δημιουργία λογαριασμού με κλειδί πρόσβασης",
 		"signUpWithSecurityKey": "Χρήση κλειδιού ασφαλείας",
 		"submitting": "Υποβολή...",
-		"switchAccount": "Αλλαγή λογαριασμού",
-		"switchAccountDescription": "Επιλέξτε έναν λογαριασμό για να συνεχίσετε.",
+		"otherAccount": "Άλλος λογαριασμός",
+		"otherAccountDescription": "Επιλέξτε έναν λογαριασμό για να συνεχίσετε.",
 		"welcomeMessage": "Καλώς ήρθατε στο <highlight>$t(common.walletName)</highlight>"
 	},
 	"loginState": {

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -96,8 +96,8 @@
 		"signUpWithPasskey": "Δημιουργία λογαριασμού με κλειδί πρόσβασης",
 		"signUpWithSecurityKey": "Χρήση κλειδιού ασφαλείας",
 		"submitting": "Υποβολή...",
-		"otherAccount": "Άλλος λογαριασμός",
-		"otherAccountDescription": "Επιλέξτε έναν λογαριασμό για να συνεχίσετε.",
+		"otherAccounts": "Άλλοι λογαριασμοί",
+		"otherAccountsDescription": "Επιλέξτε έναν λογαριασμό για να συνεχίσετε.",
 		"welcomeMessage": "Καλώς ήρθατε στο <highlight>$t(common.walletName)</highlight>"
 	},
 	"loginState": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -106,8 +106,8 @@
 		"signUpWithPasskey": "Create account with a Passkey",
 		"signUpWithSecurityKey": "Use a Security Key",
 		"submitting": "Submitting...",
-		"switchAccount": "Switch account",
-		"switchAccountDescription": "Choose an account to continue.",
+		"otherAccount": "Other account",
+		"otherAccountDescription": "Choose an account to continue.",
 		"welcomeMessage": "Welcome to <highlight>$t(common.walletName)</highlight>"
 	},
 	"loginState": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -106,8 +106,8 @@
 		"signUpWithPasskey": "Create account with a Passkey",
 		"signUpWithSecurityKey": "Use a Security Key",
 		"submitting": "Submitting...",
-		"otherAccount": "Other account",
-		"otherAccountDescription": "Choose an account to continue.",
+		"otherAccounts": "Other accounts",
+		"otherAccountsDescription": "Choose an account to continue.",
 		"welcomeMessage": "Welcome to <highlight>$t(common.walletName)</highlight>"
 	},
 	"loginState": {

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -90,8 +90,8 @@
 		"signUpWithPasskey": "Criar conta com uma chave de acesso",
 		"signUpWithSecurityKey": "Usar uma chave de segurança",
 		"submitting": "A submeter...",
-		"switchAccount": "Mudar de conta",
-		"switchAccountDescription": "Escolha uma conta para continuar.",
+		"otherAccount": "Outra conta",
+		"otherAccountDescription": "Escolha uma conta para continuar.",
 		"welcomeMessage": "Bem-vindo(a) à <highlight>$t(common.walletName)</highlight>"
 	},
 	"loginState": {

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -90,8 +90,8 @@
 		"signUpWithPasskey": "Criar conta com uma chave de acesso",
 		"signUpWithSecurityKey": "Usar uma chave de segurança",
 		"submitting": "A submeter...",
-		"otherAccount": "Outra conta",
-		"otherAccountDescription": "Escolha uma conta para continuar.",
+		"otherAccounts": "Outras contas",
+		"otherAccountsDescription": "Escolha uma conta para continuar.",
 		"welcomeMessage": "Bem-vindo(a) à <highlight>$t(common.walletName)</highlight>"
 	},
 	"loginState": {

--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import StatusContext from '@/context/StatusContext';
 import SessionContext from '@/context/SessionContext';
+import useScreenType from '@/hooks/useScreenType';
 
 import Link from '../../components/Links/Link';
 
@@ -20,6 +21,8 @@ const Login = () => {
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [isAwaitingRedirect, setIsAwaitingRedirect] = useState(false);
 	const [isAccountSwitcherOpen, setIsAccountSwitcherOpen] = useState(false);
+	const screenType = useScreenType();
+	const isDesktopSwitcherOpen = isAccountSwitcherOpen && screenType === 'desktop';
 
 	const navigate = useNavigate();
 	const { search } = useLocation();
@@ -36,7 +39,7 @@ const Login = () => {
 
 	return (
 		<AuthCard
-			heading={isAccountSwitcherOpen ? null : t('loginSignup.signIn')}
+			heading={isDesktopSwitcherOpen ? null : t('loginSignup.signIn')}
 			showPasskeyInfoPopup={false}
 		>
 			<WebauthnSignupLogin
@@ -49,7 +52,7 @@ const Login = () => {
 				isAccountSwitcherOpen={isAccountSwitcherOpen}
 				setIsAccountSwitcherOpen={setIsAccountSwitcherOpen}
 			/>
-			{!isAccountSwitcherOpen && (
+			{!isDesktopSwitcherOpen && (
 				<p className="text-sm text-center font-light text-lm-gray-900 dark:text-dm-gray-100">
 					{t('loginSignup.newHereQuestion')}
 					<Link


### PR DESCRIPTION
- On mobile/tablet, "Switch account" opened a full-viewport modal that fully replaced the login page. It now opens as a bottom sheet that sits over the dimmed, still-visible login page, matching native iOS/Android patterns.
- The sheet slides up/fades in on open and reverses on close (via Back, backdrop tap, or dragging the handle down past a threshold), instead of just popping in and out instantly.
- Desktop is unaffected, it still swaps the panel content inline as before.

## Test plan
1. On a mobile viewport, open "Switch account" from the login page and confirm the sheet slides up from the bottom over a dimmed login page
2. Confirm dragging the handle down past ~100px dismisses the sheet with a smooth slide-down/fade-out, a smaller drag snaps back open
3. Confirm tapping the dimmed backdrop and the "Back" button both close the sheet with the same animation
4. Confirm selecting a cached account still logs in correctly, and "Forget" still removes an account from the list
5. Confirm desktop behavior (inline switcher panel, no modal) is unchanged
