### PR TITLE
Fix service worker handling for Vite proxy routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ Once the development server is running, you can access the app by visiting http:
 
 ## ⚙️Local Vite Config
 
-For local development, you can create an optional `vite.config.local.ts` file in the project root. This file is ignored by git and is merged into the main Vite config when present.
+For local development or downstream builds, you can create an optional `vite.config.local.ts` file in the project root. This file is ignored by git and is merged into the main Vite config when present.
 
-This is useful for machine-specific settings, such as custom dev server proxy rules, without editing the committed `vite.config.ts`.
+This is useful for machine-specific settings, such as custom dev server proxy rules or navigation paths served by another application, without editing the committed `vite.config.ts`.
 
 Example:
 
@@ -165,6 +165,14 @@ export const localViteConfig: Partial<UserConfig> = {
   },
 };
 ```
+
+At build time, string path keys from `server.proxy` are added to the service
+worker's app-shell bypass list. Navigations to these paths go directly to the
+server instead of loading the wallet app shell. Regex proxy keys are ignored.
+Browser caching follows the response's HTTP cache headers; configure the server
+to send `Cache-Control: no-store` when these pages must never be reused.
+The local config must be present during the build because Vite cannot inspect
+the production server's proxy configuration at runtime.
 
 If `vite.config.local.ts` does not exist, the app uses the default Vite config unchanged.
 

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -2,12 +2,13 @@
 
 import { clientsClaim } from "workbox-core";
 import { ExpirationPlugin } from "workbox-expiration";
-import { precacheAndRoute, cleanupOutdatedCaches } from "workbox-precaching";
+import { cleanupOutdatedCaches, precacheAndRoute } from "workbox-precaching";
 import { registerRoute } from "workbox-routing";
 import { StaleWhileRevalidate, CacheFirst, NetworkFirst } from "workbox-strategies";
 
 const basePath = new URL(self.registration.scope).pathname.replace(/\/?$/, '/') || '/';
 const appShellCacheName = `app-shell:${basePath}`;
+const appShellBypassPaths = import.meta.env.VITE_APP_SHELL_BYPASS_PATHS;
 
 clientsClaim();
 
@@ -38,9 +39,21 @@ const appShellStrategy = new NetworkFirst({
 	networkTimeoutSeconds: 3,
 });
 
+const matchesPathPrefix = (pathname, pathPrefix) =>
+	pathPrefix === "/" ||
+	pathname === pathPrefix ||
+	pathname.startsWith(`${pathPrefix}/`);
+
 registerRoute(
 	({ request, url }) => {
 		if (request.mode !== "navigate") return false;
+
+		const scopeRelativePathname = url.pathname.slice(basePath.length - 1);
+		const bypassesAppShell = appShellBypassPaths.some((pathPrefix) =>
+			matchesPathPrefix(scopeRelativePathname, pathPrefix)
+		);
+		if (bypassesAppShell) return false;
+
 		if (url.pathname.startsWith("/_")) return false;
 		if (/\.[a-zA-Z0-9]+$/.test(url.pathname)) return false;
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,6 +48,9 @@ const mergeViteConfig = (baseConfig: UserConfig, localConfig: LocalViteConfig): 
 export default defineConfig(async ({ mode }) => {
 	const env = loadEnv(mode, process.cwd(), '');
 	const localViteConfig = await loadLocalViteConfig();
+	const appShellBypassPaths = Object.keys(localViteConfig.server?.proxy ?? {})
+		.filter((path) => path.startsWith('/'))
+		.map((path) => path.replace(/\/+$/, '') || '/');
 	const brandingHash = getBrandingHash(resolve('branding'));
 	const manifestRevision = getManifestRevision({
 		brandingHash,
@@ -60,6 +63,7 @@ export default defineConfig(async ({ mode }) => {
 		base: './',
 		define: {
 			'import.meta.env.VITE_APP_VERSION': JSON.stringify(process.env.npm_package_version),
+			'import.meta.env.VITE_APP_SHELL_BYPASS_PATHS': JSON.stringify(appShellBypassPaths),
 		},
 		plugins: [
 			InjectConfigPlugin(env),


### PR DESCRIPTION
### Changes
- Derive app-shell bypass paths from the Vite `server.proxy` configuration.
- Exclude matching document navigations from the wallet service worker’s SPA route.
- Allow proxied pages such as `/example` to be handled directly by the browser and server.
- Normalize trailing slashes and ignore non-path proxy keys.
- Document the local proxy and browser-cache behavior.

### Why

The service worker previously treated for a example a `/example` as a wallet SPA route and could serve the cached app shell instead of the externally proxied page. This caused the wallet page to intercept the route until a hard reload.

Proxy navigation paths now bypass the app-shell handler without adding another service-worker caching strategy or fallback page.

Browser caching for proxied pages is controlled through server response headers such as `Cache-Control`.
