### PR TITLE
Restore cached images after offline reload

### DIFF
--- a/src/lib/services/HttpProxy/HttpProxy.ts
+++ b/src/lib/services/HttpProxy/HttpProxy.ts
@@ -93,7 +93,19 @@ export function useHttpProxy(): IHttpProxy {
 				const fallback = await getItem('proxyCache', cacheKey, 'proxyCache');
 
 				if (fallback?.data) {
-					return fallback.data;
+					const cachedData = fallback.data;
+
+					if (isBinaryRequest && cachedData.__binary) {
+						const blob = new Blob([toU8(cachedData.bytes)], { type: cachedData.contentType || 'application/octet-stream' });
+
+						return {
+							status: cachedData.status || 200,
+							headers: cachedData.headers || {},
+							data: URL.createObjectURL(blob),
+						};
+					}
+
+					return cachedData;
 				}
 
 				return {

--- a/src/lib/services/HttpProxy/HttpProxy.ts
+++ b/src/lib/services/HttpProxy/HttpProxy.ts
@@ -15,6 +15,16 @@ const inFlightRequests = new Map<string, Promise<any>>();
 const sessionCache = new Map<string, { data: any; expiry: number }>();
 const TIMEOUT = 3 * 1000;
 
+const restoreBinaryResponse = (cachedData: any) => {
+	const blob = new Blob([toU8(cachedData.bytes)], { type: cachedData.contentType || 'application/octet-stream' });
+
+	return {
+		status: cachedData.status || 200,
+		headers: cachedData.headers || {},
+		data: URL.createObjectURL(blob),
+	};
+};
+
 const parseCacheControl = (header: string) =>
 	Object.fromEntries(
 		header
@@ -68,15 +78,7 @@ export function useHttpProxy(): IHttpProxy {
 							if (isBinaryRequest && !cachedData?.__binary) {
 								// do nothing -> fall through to fetch
 							} else if (isBinaryRequest && cachedData?.__binary) {
-								// RECONSTRUCT a fresh Blob URL from the stored bytes and type
-								const blob = new Blob([toU8(cachedData.bytes)], { type: cachedData.contentType || 'application/octet-stream' });
-								const blobUrl = URL.createObjectURL(blob);
-
-								return {
-									status: cachedData.status || 200,
-									headers: cachedData.headers || {},
-									data: blobUrl,
-								};
+								return restoreBinaryResponse(cachedData);
 							} else {
 								return cachedData;
 							}
@@ -96,13 +98,7 @@ export function useHttpProxy(): IHttpProxy {
 					const cachedData = fallback.data;
 
 					if (isBinaryRequest && cachedData.__binary) {
-						const blob = new Blob([toU8(cachedData.bytes)], { type: cachedData.contentType || 'application/octet-stream' });
-
-						return {
-							status: cachedData.status || 200,
-							headers: cachedData.headers || {},
-							data: URL.createObjectURL(blob),
-						};
+						return restoreBinaryResponse(cachedData);
 					}
 
 					return cachedData;


### PR DESCRIPTION
Rebuild cached binary images as Blob URLs so Add page images display after an offline reload.

### Test Plan

1. Build and run the frontend in preview mode.
2. Sign in and open the **Add Credentials** page.
3. Confirm that the credential and issuer images are visible.
4. Switch the browser network to **Offline**.
5. Reload the page.
6. Verify that the cached images remain visible.

Before this fix, the images disappeared after the offline reload.