### PR TITLE
Precache injected branding assets for consistent runtime updates

### DIFF
--- a/config/_cli_.ts
+++ b/config/_cli_.ts
@@ -16,10 +16,11 @@ import { Tag } from './utils/resources';
 		throw new Error('Destination directory flag --dest is required.');
 	}
 
-	const brandingHash = getBrandingHash(resolve('branding')); // Compute branding hash from your branding folder
-	env.BRANDING_HASH = brandingHash;
-
 	const config = EnvConfigMapSchema.parse(env);
+	const brandingHash = getBrandingHash(resolve('branding'), {
+		walletName: config.WALLET_NAME || 'wwWallet',
+	});
+	env.BRANDING_HASH = brandingHash;
 
 	const tagsToInject = new Map<string, Tag>();
 

--- a/config/branding.ts
+++ b/config/branding.ts
@@ -145,16 +145,20 @@ export function findLogoFiles(sourceDir: string): LogoFiles {
 // ============================================
 
 /**
- * Computes a stable hash from all branding inputs.
- * Changes ONLY when branding files change.
+ * Computes a stable hash from all branding and generation inputs.
  *
  * @param brandingDir Branding source directory.
  */
-export function getBrandingHash(brandingDir: string): string {
+export function getBrandingHash(
+	brandingDir: string,
+	generationInputs: Record<string, string | undefined> = {},
+): string {
 	const hash = crypto.createHash("sha256");
 
 	function walk(dir: string) {
-		const entries = fs.readdirSync(dir, { withFileTypes: true });
+		const entries = fs
+			.readdirSync(dir, { withFileTypes: true })
+			.sort((a, b) => a.name.localeCompare(b.name));
 
 		for (const entry of entries) {
 			const fullPath = path.join(dir, entry.name);
@@ -162,13 +166,18 @@ export function getBrandingHash(brandingDir: string): string {
 			if (entry.isDirectory()) {
 				walk(fullPath);
 			} else {
-				hash.update(fullPath);
+				hash.update(path.relative(brandingDir, fullPath));
 				hash.update(fs.readFileSync(fullPath));
 			}
 		}
 	}
 
 	walk(brandingDir);
+
+	for (const [key, value] of Object.entries(generationInputs).sort(([a], [b]) => a.localeCompare(b))) {
+		hash.update(key);
+		hash.update(value ?? '');
+	}
 
 	// 10 chars is enough to avoid collisions and keep URLs short
 	return hash.digest("hex").slice(0, 10);

--- a/config/files/manifest.ts
+++ b/config/files/manifest.ts
@@ -7,7 +7,7 @@ import { type EnvConfigMap } from '../config';
 import { type Tag } from '../utils/resources';
 import { pathWithBase } from '../utils/paths';
 
-const MANIFEST_ICON_SIZES = [16, 32, 64, 192, 512];
+export const MANIFEST_ICON_SIZES = [16, 32, 64, 192, 512];
 
 /**
  * Generates a web app manifest and icons, and injects them into the build output.
@@ -71,7 +71,7 @@ export function getManifestRevision({ brandingHash, name }: { brandingHash?: str
 	}), null, 2));
 }
 
-function getManifestRevisionFromContent(manifestContent: string) {
+export function getManifestRevisionFromContent(manifestContent: string) {
 	return crypto
 		.createHash('sha256')
 		.update(manifestContent)

--- a/config/files/runtime-precache.test.ts
+++ b/config/files/runtime-precache.test.ts
@@ -1,0 +1,97 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { findLogoFiles, getBrandingHash } from '../branding';
+import { getManifestRevisionFromContent } from './manifest';
+import runtimePrecache from './runtime-precache';
+
+type RuntimePrecacheEntry = {
+	url: string;
+	revision: null;
+};
+
+function parseRuntimePrecache(output: string): RuntimePrecacheEntry[] {
+	const assignment = output.match(/self\.__RUNTIME_PRECACHE_MANIFEST = ([\s\S]+);\s*$/);
+	expect(assignment).not.toBeNull();
+	return JSON.parse(assignment![1]);
+}
+
+describe('runtimePrecache', () => {
+	it('writes exact query-versioned URLs for every generated branding asset', async () => {
+		const destDir = await mkdtemp(join(tmpdir(), 'wwwallet-runtime-precache-'));
+		const manifestContent = JSON.stringify({ name: 'Injected Wallet' });
+
+		try {
+			await writeFile(join(destDir, 'manifest.json'), manifestContent, 'utf-8');
+			await runtimePrecache(destDir, 'brand/hash');
+
+			const output = await readFile(join(destDir, 'runtime-precache.js'), 'utf-8');
+			const { logo_light: logoLight, logo_dark: logoDark } = findLogoFiles(resolve('branding'));
+			const version = 'brand%2Fhash';
+
+			expect(parseRuntimePrecache(output)).toEqual([
+				{
+					url: `./manifest.json?v=${getManifestRevisionFromContent(manifestContent)}`,
+					revision: null,
+				},
+				{ url: `./theme.css?v=${version}`, revision: null },
+				{ url: `./${logoLight.filename}?v=${version}`, revision: null },
+				{ url: `./${logoDark.filename}?v=${version}`, revision: null },
+				{ url: `./favicon.ico?v=${version}`, revision: null },
+				{ url: `./image.png?v=${version}`, revision: null },
+				{ url: `./icons/apple-touch-icon.png?v=${version}`, revision: null },
+				{ url: `./icons/icon-16x16.png?v=${version}`, revision: null },
+				{ url: `./icons/icon-32x32.png?v=${version}`, revision: null },
+				{ url: `./icons/icon-64x64.png?v=${version}`, revision: null },
+				{ url: `./icons/icon-192x192.png?v=${version}`, revision: null },
+				{ url: `./icons/icon-192x192-maskable.png?v=${version}`, revision: null },
+				{ url: `./icons/icon-512x512.png?v=${version}`, revision: null },
+				{ url: `./icons/icon-512x512-maskable.png?v=${version}`, revision: null },
+				{ url: `./screenshots/screen_mobile_1.png?v=${version}`, revision: null },
+				{ url: `./screenshots/screen_mobile_2.png?v=${version}`, revision: null },
+				{ url: `./screenshots/screen_tablet_1.png?v=${version}`, revision: null },
+				{ url: `./screenshots/screen_tablet_2.png?v=${version}`, revision: null },
+			]);
+		} finally {
+			await rm(destDir, { recursive: true, force: true });
+		}
+	});
+
+	it('produces a location-independent hash that changes with branding content', async () => {
+		const firstDir = await mkdtemp(join(tmpdir(), 'wwwallet-branding-a-'));
+		const secondDir = await mkdtemp(join(tmpdir(), 'wwwallet-branding-b-'));
+
+		try {
+			await Promise.all([
+				mkdir(join(firstDir, 'custom')),
+				mkdir(join(secondDir, 'custom')),
+			]);
+			await Promise.all([
+				writeFile(join(firstDir, 'logo.svg'), '<svg>same</svg>'),
+				writeFile(join(secondDir, 'logo.svg'), '<svg>same</svg>'),
+				writeFile(join(firstDir, 'custom', 'theme.json'), '{"brand":"same"}'),
+				writeFile(join(secondDir, 'custom', 'theme.json'), '{"brand":"same"}'),
+			]);
+
+			const firstHash = getBrandingHash(firstDir);
+			expect(getBrandingHash(secondDir)).toBe(firstHash);
+
+			await writeFile(join(secondDir, 'custom', 'theme.json'), '{"brand":"changed"}');
+			expect(getBrandingHash(secondDir)).not.toBe(firstHash);
+		} finally {
+			await Promise.all([
+				rm(firstDir, { recursive: true, force: true }),
+				rm(secondDir, { recursive: true, force: true }),
+			]);
+		}
+	});
+
+	it('changes the branding hash when an output generation input changes', () => {
+		const brandingDir = resolve('branding');
+		const firstHash = getBrandingHash(brandingDir, { walletName: 'Wallet A' });
+		const secondHash = getBrandingHash(brandingDir, { walletName: 'Wallet B' });
+
+		expect(firstHash).not.toBe(secondHash);
+	});
+});

--- a/config/files/runtime-precache.ts
+++ b/config/files/runtime-precache.ts
@@ -1,0 +1,70 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { findLogoFiles } from '../branding';
+import { getManifestRevisionFromContent, MANIFEST_ICON_SIZES } from './manifest';
+
+type RuntimePrecacheEntry = {
+	url: string;
+	revision: null;
+};
+
+const SCREENSHOT_FILES = [
+	'screen_mobile_1.png',
+	'screen_mobile_2.png',
+	'screen_tablet_1.png',
+	'screen_tablet_2.png',
+];
+
+function withVersion(pathname: string, version: string): RuntimePrecacheEntry {
+	return {
+		url: `./${pathname}?v=${encodeURIComponent(version)}`,
+		revision: null,
+	};
+}
+
+/**
+ * Writes the inject-time Workbox precache entries consumed by the service worker.
+ *
+ * Keeping this in a separate imported worker script means a branding-only change
+ * changes the service worker dependency graph without rebuilding the application.
+ */
+export default async function runtimePrecache(destDir: string, brandingHash: string) {
+	const manifestContent = await readFile(resolve(destDir, 'manifest.json'), 'utf-8');
+	const manifestRevision = getManifestRevisionFromContent(manifestContent);
+	const { logo_light: logoLight, logo_dark: logoDark } = findLogoFiles(resolve('branding'));
+
+	const iconFiles = MANIFEST_ICON_SIZES.flatMap((size) => {
+		const sizeString = `${size}x${size}`;
+		const files = [`icons/icon-${sizeString}.png`];
+
+		if (size === 192 || size === 512) {
+			files.push(`icons/icon-${sizeString}-maskable.png`);
+		}
+
+		return files;
+	});
+
+	const brandingFiles = [
+		'theme.css',
+		logoLight.filename,
+		logoDark.filename,
+		'favicon.ico',
+		'image.png',
+		'icons/apple-touch-icon.png',
+		...iconFiles,
+		...SCREENSHOT_FILES.map((filename) => `screenshots/${filename}`),
+	];
+
+	const entries: RuntimePrecacheEntry[] = [
+		withVersion('manifest.json', manifestRevision),
+		...brandingFiles.map((pathname) => withVersion(pathname, brandingHash)),
+	];
+
+	const contents = [
+		'/* Generated at environment injection time. Do not edit. */',
+		`self.__RUNTIME_PRECACHE_MANIFEST = ${JSON.stringify(entries, null, 2)};`,
+		'',
+	].join('\n');
+
+	await writeFile(resolve(destDir, 'runtime-precache.js'), contents, 'utf-8');
+}

--- a/config/inject.ts
+++ b/config/inject.ts
@@ -9,6 +9,7 @@ import sitemapXml from './files/sitemap';
 import brandingManifest from './files/manifest';
 import themeCSS from './files/theme';
 import metadataImage from './files/metadata-image';
+import runtimePrecache from './files/runtime-precache';
 import { Tag, TagsMap } from './utils/resources';
 import { configMetaTag, getTagSortingPriority, insertTag } from './utils/tags';
 import { pathWithBase } from './utils/paths';
@@ -44,6 +45,12 @@ export async function injectConfigFiles({ destDir, config, tagsToInject }: Injec
 		themeCSS(destDir, config, tagsToInject, brandingHash),
 		metadataImage(destDir, config, tagsToInject, brandingHash),
 	]);
+
+	if (!brandingHash) {
+		throw new Error('BRANDING_HASH is required to generate the runtime precache manifest.');
+	}
+
+	await runtimePrecache(destDir, brandingHash);
 }
 
 export type InjectHtmlOptions = {

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-restricted-globals */
+/* global importScripts */
 
 import { clientsClaim } from "workbox-core";
 import { ExpirationPlugin } from "workbox-expiration";
@@ -6,15 +7,27 @@ import { cleanupOutdatedCaches, precacheAndRoute } from "workbox-precaching";
 import { registerRoute } from "workbox-routing";
 import { StaleWhileRevalidate, CacheFirst, NetworkFirst } from "workbox-strategies";
 
+// Build/injection regenerates this file; byte changes trigger a service worker update.
+const runtimePrecachePolicy = self.trustedTypes?.createPolicy("sw-register", {
+	createScriptURL: (url) => url,
+});
+importScripts(
+	runtimePrecachePolicy?.createScriptURL("./runtime-precache.js")
+	?? "./runtime-precache.js"
+);
+
 const basePath = new URL(self.registration.scope).pathname.replace(/\/?$/, '/') || '/';
 const appShellCacheName = `app-shell:${basePath}`;
 const appShellBypassPaths = import.meta.env.VITE_APP_SHELL_BYPASS_PATHS;
+const runtimePrecacheManifest = self.__RUNTIME_PRECACHE_MANIFEST || [];
 
 clientsClaim();
+cleanupOutdatedCaches();
 
-precacheAndRoute(self.__WB_MANIFEST, {
-	ignoreURLParametersMatching: [/^v$/],
-});
+precacheAndRoute([
+	...self.__WB_MANIFEST,
+	...runtimePrecacheManifest,
+]);
 
 const SPA_ROUTE_ALLOWLIST = [
 	/^\/$/,                              // Home
@@ -129,9 +142,6 @@ self.addEventListener('install', (event) => {
 self.addEventListener("activate", (event) => {
 	event.waitUntil(
 		(async () => {
-			// Clean old Workbox precache caches
-			await cleanupOutdatedCaches();
-
 			// Delete the old unscoped app shell cache.
 			const cacheNames = await caches.keys();
 			await Promise.all(

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -89,27 +89,16 @@ registerRoute(
 );
 
 registerRoute(
-	({ request, url }) =>
-		request.destination === "style" &&
-		url.pathname.endsWith("theme.css"),
-	new StaleWhileRevalidate({
-		cacheName: "theme",
-		plugins: [
-			new ExpirationPlugin({
-				maxEntries: 5,
-			}),
-		],
-	})
-);
-
-registerRoute(
 	({ url }) =>
-		url.pathname.endsWith(".ico") ||
-		url.pathname.endsWith(".png") ||
-		url.pathname.endsWith(".jpg") ||
-		url.pathname.endsWith(".jpeg") ||
-		url.pathname.endsWith(".svg") ||
-		url.pathname.endsWith(".webp"),
+		!url.searchParams.has("v") &&
+		(
+			url.pathname.endsWith(".ico") ||
+			url.pathname.endsWith(".png") ||
+			url.pathname.endsWith(".jpg") ||
+			url.pathname.endsWith(".jpeg") ||
+			url.pathname.endsWith(".svg") ||
+			url.pathname.endsWith(".webp")
+		),
 	new StaleWhileRevalidate({
 		cacheName: "images",
 		plugins: [
@@ -142,13 +131,23 @@ self.addEventListener('install', (event) => {
 self.addEventListener("activate", (event) => {
 	event.waitUntil(
 		(async () => {
-			// Delete the old unscoped app shell cache.
+			// Delete caches replaced by the scoped app shell and branding precache.
 			const cacheNames = await caches.keys();
 			await Promise.all(
 				cacheNames
-					.filter((name) => name === "app-shell")
+					.filter((name) => name === "app-shell" || name === "theme")
 					.map((name) => caches.delete(name))
 			);
+
+			if (cacheNames.includes("images")) {
+				const imageCache = await caches.open("images");
+				const imageRequests = await imageCache.keys();
+				await Promise.all(
+					imageRequests
+						.filter((request) => new URL(request.url).searchParams.has("v"))
+						.map((request) => imageCache.delete(request))
+				);
+			}
 
 			// Claim and reload clients
 			await self.clients.claim();

--- a/src/sw-register.js
+++ b/src/sw-register.js
@@ -31,7 +31,11 @@ if ('serviceWorker' in navigator) {
 
 		const trustedSwUrl = swPolicy ? swPolicy.createScriptURL(swPath) : swPath;
 		navigator.serviceWorker
-			.register(trustedSwUrl, { scope: swScope })
+			.register(trustedSwUrl, {
+				scope: swScope,
+				// Always revalidate imports during service worker update checks.
+				updateViaCache: 'none',
+			})
 			.catch(err => {
 				console.error('Service worker registration failed:', err);
 			});

--- a/vite-plugins/inject-config.ts
+++ b/vite-plugins/inject-config.ts
@@ -8,7 +8,9 @@ export function InjectConfigPlugin(env: Record<string, string>): Plugin {
 
 	const tagsToInject = new Map<string, Tag>();
 
-	const brandingHash = getBrandingHash(resolve('branding')); // Compute branding hash from your branding folder
+	const brandingHash = getBrandingHash(resolve('branding'), {
+		walletName: config.WALLET_NAME || 'wwWallet',
+	});
 	process.env.BRANDING_HASH = brandingHash; // import.meta.env.BRANDING_HASH works in TS/JS
 	env.BRANDING_HASH = brandingHash; // BRANDING_HASH% works in index.html
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,8 +9,6 @@ import checker from 'vite-plugin-checker';
 import { VitePWA } from 'vite-plugin-pwa';
 import tailwindcss from '@tailwindcss/vite';
 import { InjectConfigPlugin } from './vite-plugins';
-import { getManifestRevision } from './config/files/manifest';
-import { getBrandingHash } from './config/branding';
 
 type LocalViteConfig = Partial<UserConfig>;
 
@@ -51,12 +49,6 @@ export default defineConfig(async ({ mode }) => {
 	const appShellBypassPaths = Object.keys(localViteConfig.server?.proxy ?? {})
 		.filter((path) => path.startsWith('/'))
 		.map((path) => path.replace(/\/+$/, '') || '/');
-	const brandingHash = getBrandingHash(resolve('branding'));
-	const manifestRevision = getManifestRevision({
-		brandingHash,
-		name: env.WALLET_NAME || 'wwWallet',
-	});
-
 	mkdirSync(resolve('public'), { recursive: true });
 
 	const baseConfig: UserConfig = {
@@ -84,10 +76,7 @@ export default defineConfig(async ({ mode }) => {
 				manifest: false, // Vite will use `public/manifest.json` automatically
 				injectManifest: {
 					maximumFileSizeToCacheInBytes: env.GENERATE_SOURCEMAP === 'true' ? 12 * 1024 * 1024 : 4 * 1024 * 1024,
-					globIgnores: ['theme.css', 'index.html'],
-					additionalManifestEntries: [
-						{ url: './manifest.json', revision: manifestRevision },
-					],
+					globIgnores: ['theme.css', 'index.html', 'runtime-precache.js'],
 				},
 			}),
 


### PR DESCRIPTION
### Summary

Ensure branding files generated during environment injection are versioned, detected by the service worker, and served consistently from the precache during both online and offline use.

### Changes

- Generate `runtime-precache.js` during build and environment injection.
- Precache the manifest, theme, logos, favicon, metadata image, icons, and screenshots.
- Preserve `?v=hash` URLs for reliable cache invalidation.
- Include branding generation inputs in the branding hash.
- Revalidate imported service-worker files during update checks.
- Remove the redundant runtime theme cache.
- Prevent versioned branding images from entering the generic image cache.
- Clean legacy theme and duplicate versioned image cache entries during activation.

### Behavior

When branding changes during environment injection:

1. A new versioned runtime precache manifest is generated.
2. The browser detects the changed service-worker import during its next online update check.
3. The new service worker downloads and precaches all updated branding assets before activation.
4. Subsequent online and offline requests use the updated assets from the Workbox precache.

An online visit is required once after injection so the browser can detect and download the new branding version.