### PR TITLE
Display PID MDOC using PID SVG template

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typescript": "^5.1.6",
     "uuid": "^9.0.0",
     "vite-plugin-pwa": "^0.21.1",
-    "wallet-common": "git+https://github.com/wwWallet/wallet-common.git#9df178665980ea7e7cbe2a441a3e6dbcec9dff6c",
+    "wallet-common": "git+https://github.com/wwWallet/wallet-common.git#4d1abc1f464e0ba34a63afcfea5b477fc4b6eca6",
     "web-vitals": "^2.1.4",
     "workbox-core": "^7.3.0",
     "workbox-expiration": "^7.3.0",

--- a/src/components/Credentials/CredentialInfo.jsx
+++ b/src/components/Credentials/CredentialInfo.jsx
@@ -1,12 +1,11 @@
 import React, { useMemo, useState } from 'react';
-import { formatDate } from 'wallet-common';
+import { formatDate, imageValueToDataUri, isCborDate } from 'wallet-common';
 import { getLanguage } from '@/i18n';
 import { useTranslation } from 'react-i18next';
 import JsonViewer from '../JsonViewer/JsonViewer';
 import useScreenType from '../../hooks/useScreenType';
 import FullscreenPopup from '../Popups/FullscreenImg';
 import { Asterisk, Send } from 'lucide-react';
-import { isCborDate } from 'wallet-common';
 
 const Legend = ({ showRequired, showRequested, t }) => {
 	if (!showRequired && !showRequested) return null;
@@ -168,38 +167,14 @@ const formatClaimValue = (value, imageAlt, fullscreenTitle, onImageClick) => {
 
 	if (typeof value === 'boolean') return String(value);
 
+	const imageDataUri = imageValueToDataUri(value);
+	if (imageDataUri) return renderImg(imageDataUri);
+
 	// String handling
 	if (typeof value === 'string') {
-		const lower = value.toLowerCase();
-
-		// Image data URI
-		if (lower.startsWith('data:image/')) {
-			return renderImg(value);
-		}
 		// Long string fallback
 		if (!value.includes(' ') && value.length > 30) {
 			return value.slice(0, 30) + '…';
-		}
-	}
-
-	// Handle raw image bytes
-	if (
-		typeof value === 'object' &&
-		value !== null &&
-		Object.keys(value).length > 0 &&
-		Object.keys(value).every(k => !isNaN(Number(k))) &&
-		Object.values(value).every(v => typeof v === 'number')
-	) {
-		try {
-			const uint8Array = new Uint8Array(Object.values(value));
-			const base64 = btoa(
-				String.fromCharCode.apply(null, Array.from(uint8Array))
-			);
-			const src = `data:image/jpeg;base64,${base64}`;
-			return renderImg(src);
-		} catch {
-			// fallback if conversion fails
-			return renderJson(value);
 		}
 	}
 

--- a/src/components/Credentials/CredentialInfo.test.jsx
+++ b/src/components/Credentials/CredentialInfo.test.jsx
@@ -381,4 +381,47 @@ describe('CredentialInfo Component', () => {
 		expect(screen.getByText('Βαθμίδα:')).toBeInTheDocument();
 		expect(screen.getByText('8')).toBeInTheDocument();
 	});
+
+	it('renders a PID mdoc portrait byte string as an image', () => {
+		const parsedCredential = {
+			signedClaims: {
+				'eu.europa.ec.eudi.pid.1': {
+					portrait: new Uint8Array([0xff, 0xd8, 0xff, 0x00]),
+				},
+			},
+			metadata: {
+				credential: {
+					TypeMetadata: {
+						claims: [{
+							path: ['eu.europa.ec.eudi.pid.1', 'portrait'],
+							display: [{ locale: 'en-US', label: 'Portrait Image' }],
+						}],
+					},
+				},
+			},
+		};
+
+		const { container } = render(<CredentialInfo parsedCredential={parsedCredential} />);
+		expect(container.querySelector('img')).toHaveAttribute('src', 'data:image/jpeg;base64,/9j/AA==');
+	});
+
+	it('renders a Base64 SVG QR code claim as an image', () => {
+		const qrCode = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IHdpZHRoPSIxIiBoZWlnaHQ9IjEiLz48L3N2Zz4=';
+		const parsedCredential = {
+			signedClaims: { QRCode: qrCode },
+			metadata: {
+				credential: {
+					TypeMetadata: {
+						claims: [{
+							path: ['QRCode'],
+							display: [{ locale: 'en-US', label: 'QR code' }],
+						}],
+					},
+				},
+			},
+		};
+
+		const { container } = render(<CredentialInfo parsedCredential={parsedCredential} />);
+		expect(container.querySelector('img')).toHaveAttribute('src', qrCode);
+	});
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7101,9 +7101,9 @@ w3c-xmlserializer@^5.0.0:
   dependencies:
     xml-name-validator "^5.0.0"
 
-"wallet-common@git+https://github.com/wwWallet/wallet-common.git#9df178665980ea7e7cbe2a441a3e6dbcec9dff6c":
+"wallet-common@git+https://github.com/wwWallet/wallet-common.git#4d1abc1f464e0ba34a63afcfea5b477fc4b6eca6":
   version "0.0.1"
-  resolved "git+https://github.com/wwWallet/wallet-common.git#9df178665980ea7e7cbe2a441a3e6dbcec9dff6c"
+  resolved "git+https://github.com/wwWallet/wallet-common.git#4d1abc1f464e0ba34a63afcfea5b477fc4b6eca6"
   dependencies:
     "@noble/curves" "^2.2.0"
     "@owf/mdoc" "^0.6.0"


### PR DESCRIPTION
Depends on https://github.com/wwWallet/wallet-common/pull/119.

This PR updates credential details rendering to display binary PID mdoc portraits and other supported image claims through the shared `wallet-common` image utility.

## Changes

- Replace the frontend’s JPEG-specific byte conversion with `imageValueToDataUri`.
- Render supported typed-array and serialized-byte image claims.
- Preserve support for safe Base64-encoded SVG claims such as QR codes.
- Use image signature detection rather than treating every numeric object as JPEG.
- Fall back to normal claim rendering for invalid or unsupported image values.

## Manual verification

1. Import or issue a PID mdoc containing a portrait.
2. Open its credential details.
3. Confirm the portrait is displayed and can be opened in the fullscreen image view.
4. Open a credential containing an SVG QR-code claim and confirm it still renders.
5. Confirm non-image objects continue to use the normal JSON representation.