### PR TITLE
Fix History: handle loading state and invalid presentation data

### DIFF
--- a/src/hooks/useFetchPresentations.js
+++ b/src/hooks/useFetchPresentations.js
@@ -7,7 +7,7 @@ import CredentialsContext from '@/context/CredentialsContext';
 import { CredentialVerificationError, VerifiableCredentialFormat } from "wallet-common";
 
 const useFetchPresentations = (keystore, batchId = null, transactionId = null) => {
-	const [history, setHistory] = useState({});
+	const [history, setHistory] = useState(null);
 	const { parseCredential, credentialEngine } = useContext(CredentialsContext);
 
 	useEffect(() => {
@@ -92,6 +92,7 @@ const useFetchPresentations = (keystore, batchId = null, transactionId = null) =
 				setHistory(presentationsGroupedByTransactionId);
 			} catch (error) {
 				console.error('Error fetching presentations:', error);
+				setHistory([]);
 			}
 		};
 

--- a/src/hooks/useFetchPresentations.js
+++ b/src/hooks/useFetchPresentations.js
@@ -65,7 +65,7 @@ const useFetchPresentations = (keystore, batchId = null, transactionId = null) =
 						});
 
 						const result = await (async () => {
-							switch (parsedCredential.metadata.credential.format) {
+							switch (parsedCredential?.metadata?.credential?.format) {
 								case VerifiableCredentialFormat.VC_SDJWT:
 									return credentialEngine.sdJwtVerifier.verify({ rawCredential: presentation.data, opts: {} });
 								case VerifiableCredentialFormat.DC_SDJWT:
@@ -81,7 +81,7 @@ const useFetchPresentations = (keystore, batchId = null, transactionId = null) =
 							presentation,
 							parsedCredential,
 							result,
-							isExpired: result.success === false && result.error === CredentialVerificationError.ExpiredCredential,
+							isExpired: result?.success === false && result.error === CredentialVerificationError.ExpiredCredential,
 						}
 					})
 				);

--- a/src/pages/History/History.jsx
+++ b/src/pages/History/History.jsx
@@ -24,13 +24,13 @@ const History = () => {
 			<H1 heading={t('common.navItemHistory')} />
 			<PageDescription description={t('pageHistory.description')} />
 
-			{history.length === 0 ? (
+			{(history !== null && history.length === 0 ? (
 				<p className="text-lm-gray-800 dark:text-dm-gray-200 mt-4">
 					{t('pageHistory.noFound')}
 				</p>
 			) : (
 				<HistoryList history={history}/>
-			)}
+			))}
 		</div>
 	);
 };

--- a/src/pages/Home/Credential.jsx
+++ b/src/pages/Home/Credential.jsx
@@ -186,7 +186,7 @@ const Credential = () => {
 
 	const presentationsContent = (
 		<>
-			{history.length === 0 ? (
+			{history !== null && (history.length === 0 ? (
 				<p className="text-lm-gray-900 dark:text-white">
 					{t('pageHistory.noFound')}
 				</p>
@@ -194,7 +194,7 @@ const Credential = () => {
 				<div className="max-h-[45vh] overflow-y-auto custom-scrollbar pr-2">
 					<HistoryList batchId={batchId} history={history} />
 				</div>
-			)}
+			))}
 		</>
 	);
 

--- a/src/pages/Home/CredentialHistory.jsx
+++ b/src/pages/Home/CredentialHistory.jsx
@@ -22,13 +22,13 @@ const CredentialHistory = () => {
 	return (
 		<>
 			<CredentialLayout title={t('pageCredentials.presentationsTitle')}>
-				{history.length === 0 ? (
+				{history !== null && (history.length === 0 ? (
 					<p className="text-lm-gray-800 dark:text-dm-gray-200 mt-4">
 						{t('pageHistory.noFound')}
 					</p>
 				) : (
 					<HistoryList batchId={batchId} history={history} />
-				)}
+				))}
 			</CredentialLayout>
 
 		</>


### PR DESCRIPTION
- Distinguish the initial loading state from an empty presentation history.
- Prevent the empty-state message from appearing while history is loading.
- Safely handle null or incomplete parsed credentials.
- Guard against missing verification results.
- Fall back to an empty history when fetching presentations fails.