### PR TITLE
Redirect to original destination after login controlled by allowlist

### DIFF
--- a/src/components/Auth/PrivateRoute.tsx
+++ b/src/components/Auth/PrivateRoute.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import { Navigate } from 'react-router-dom';
 import SessionContext from '@/context/SessionContext';
+import { withLoginRedirect } from './loginRedirect';
 
 const PrivateRoute = ({ children }: { children?: React.ReactNode }): React.ReactElement => {
 	const { isLoggedIn, keystore } = useContext(SessionContext);
@@ -21,10 +22,11 @@ const PrivateRoute = ({ children }: { children?: React.ReactNode }): React.React
 	};
 
 	if (!isLoggedIn) {
+		const search = withLoginRedirect(window.location.pathname, window.location.search);
 		if (state && userExistsInCache(state)) {
-			return <Navigate to={`/login-state${window.location.search}`} replace />;
+			return <Navigate to={`/login-state${search}`} replace />;
 		} else {
-			return <Navigate to={`/login${window.location.search}`} replace />;
+			return <Navigate to={`/login${search}`} replace />;
 		}
 	}
 

--- a/src/components/Auth/loginRedirect.test.ts
+++ b/src/components/Auth/loginRedirect.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveLoginRedirect, withLoginRedirect } from './loginRedirect';
+
+describe('withLoginRedirect', () => {
+	it('records a known route as a token, keeping the existing params', () => {
+		const params = new URLSearchParams(withLoginRedirect('/settings', '?tab=privacy'));
+		expect(params.get('redirect')).toBe('settings');
+		expect(params.get('tab')).toBe('privacy');
+	});
+
+	it('records a known route that carries no params of its own', () => {
+		expect(withLoginRedirect('/settings', '')).toBe('?redirect=settings');
+	});
+
+	it('leaves the search untouched for routes with no token', () => {
+		expect(withLoginRedirect('/add', '?credential_offer=abc')).toBe('?credential_offer=abc');
+		expect(withLoginRedirect('/', '')).toBe('');
+	});
+});
+
+describe('resolveLoginRedirect', () => {
+	it('restores a known route and drops the token', () => {
+		expect(resolveLoginRedirect('?redirect=settings&tab=privacy')).toBe('/settings?tab=privacy');
+		expect(resolveLoginRedirect('?redirect=settings')).toBe('/settings');
+	});
+
+	it('falls back to home, keeping the remaining params', () => {
+		expect(resolveLoginRedirect('?credential_offer=abc')).toBe('/?credential_offer=abc');
+		expect(resolveLoginRedirect('')).toBe('/');
+	});
+
+	it('rejects unknown tokens', () => {
+		expect(resolveLoginRedirect('?redirect=add')).toBe('/');
+		expect(resolveLoginRedirect('?redirect=')).toBe('/');
+	});
+
+	it('rejects tokens inherited from Object.prototype', () => {
+		expect(resolveLoginRedirect('?redirect=__proto__')).toBe('/');
+		expect(resolveLoginRedirect('?redirect=constructor')).toBe('/');
+		expect(resolveLoginRedirect('?redirect=toString')).toBe('/');
+	});
+
+	it('rejects anything URL-shaped, including a bare path', () => {
+		expect(resolveLoginRedirect('?redirect=%2Fsettings')).toBe('/');
+		expect(resolveLoginRedirect('?redirect=https%3A%2F%2Fevil.com%2Fsettings')).toBe('/');
+		expect(resolveLoginRedirect('?redirect=%2F%2Fevil.com%2Fsettings')).toBe('/');
+		expect(resolveLoginRedirect('?redirect=%2F%5Cevil.com%2Fsettings')).toBe('/');
+		expect(resolveLoginRedirect('?redirect=javascript%3Aalert(1)')).toBe('/');
+	});
+
+	it('drops params the target does not declare', () => {
+		expect(resolveLoginRedirect('?redirect=settings&credential_offer=abc')).toBe('/settings');
+		expect(resolveLoginRedirect('?redirect=settings&code=abc&state=xyz')).toBe('/settings');
+		expect(resolveLoginRedirect('?redirect=settings&tab=privacy&credential_offer=abc'))
+			.toBe('/settings?tab=privacy');
+	});
+
+	it('drops declared params whose value fails validation', () => {
+		expect(resolveLoginRedirect('?redirect=settings&tab=evil')).toBe('/settings');
+		expect(resolveLoginRedirect('?redirect=settings&tab=')).toBe('/settings');
+	});
+
+	it('always lands on a known same-origin route', () => {
+		const hostile = [
+			'/settings', '//evil.com/settings', '/\\evil.com/settings',
+			// eslint-disable-next-line no-script-url -- rejecting this is the point
+			'https://evil.com/settings', 'javascript:alert(1)', 'http://[',
+			'__proto__', 'constructor', '', '   ', '%%%', 'settings',
+		];
+
+		for (const target of hostile) {
+			const result = resolveLoginRedirect(`?redirect=${encodeURIComponent(target)}`);
+			const url = new URL(result, window.location.origin);
+			expect(url.origin).toBe(window.location.origin);
+			expect(['/', '/settings']).toContain(url.pathname);
+		}
+	});
+});
+
+describe('withLoginRedirect + resolveLoginRedirect', () => {
+	const roundTrip = (pathname: string, search: string) => (
+		resolveLoginRedirect(withLoginRedirect(pathname, search))
+	);
+
+	it('restores exactly what it recorded', () => {
+		expect(roundTrip('/settings', '?tab=privacy')).toBe('/settings?tab=privacy');
+		expect(roundTrip('/settings', '?tab=account')).toBe('/settings?tab=account');
+		expect(roundTrip('/settings', '')).toBe('/settings');
+	});
+
+	it('leaves routes it cannot restore on the home page, params intact', () => {
+		expect(roundTrip('/add', '?credential_offer=abc')).toBe('/?credential_offer=abc');
+		expect(roundTrip('/', '')).toBe('/');
+	});
+});

--- a/src/components/Auth/loginRedirect.ts
+++ b/src/components/Auth/loginRedirect.ts
@@ -1,0 +1,68 @@
+import { SETTINGS_TAB_IDS } from '@/pages/Settings/tabs';
+
+const LOGIN_REDIRECT_PARAM = 'redirect';
+
+type RedirectTarget = {
+	path: string,
+	params: Record<string, readonly string[]>,
+};
+
+/**
+ * The routes that may be restored after login, keyed by the opaque token that
+ * travels in the URL. Nothing user-supplied is ever parsed as a URL or used to
+ * build a path
+ */
+const REDIRECT_TARGETS = new Map<string, RedirectTarget>([
+	['settings', { path: '/settings', params: { tab: SETTINGS_TAB_IDS } }],
+]);
+
+function tokenForPath(pathname: string): string | null {
+	for (const [token, target] of REDIRECT_TARGETS) {
+		if (target.path === pathname) {
+			return token;
+		}
+	}
+	return null;
+}
+
+export function withLoginRedirect(pathname: string, search: string): string {
+	const token = tokenForPath(pathname);
+	if (!token) {
+		return search;
+	}
+
+	const params = new URLSearchParams(search);
+	params.set(LOGIN_REDIRECT_PARAM, token);
+	return `?${params.toString()}`;
+}
+
+/**
+ * Resolve where to send a freshly authenticated user, given the login page's
+ * query string. Returns the requested route if its token is a known one, and
+ * otherwise the home page carrying the remaining params.
+ */
+export function resolveLoginRedirect(search: string): string {
+	const params = new URLSearchParams(search);
+	const token = params.get(LOGIN_REDIRECT_PARAM);
+
+	params.delete(LOGIN_REDIRECT_PARAM);
+	const rest = params.toString();
+	const fallback = rest ? `/?${rest}` : '/';
+
+	const target = token && REDIRECT_TARGETS.get(token);
+	if (!target) {
+		return fallback;
+	}
+
+	// Rebuild the query
+	const restored = new URLSearchParams();
+	for (const [name, allowedValues] of Object.entries(target.params)) {
+		const value = params.get(name);
+		if (value !== null && allowedValues.includes(value)) {
+			restored.set(name, value);
+		}
+	}
+
+	const query = restored.toString();
+	return query ? `${target.path}?${query}` : target.path;
+}

--- a/src/context/CredentialsContextProvider.tsx
+++ b/src/context/CredentialsContextProvider.tsx
@@ -7,6 +7,7 @@ import CredentialsContext, { ExtendedVcEntity, Instance } from "./CredentialsCon
 import { useOpenID4VCIHelper } from "@/lib/services/OpenID4VCIHelper";
 import { CurrentSchema } from '@/services/WalletStateSchema';
 import { setAppBadgeCount } from '@/utils';
+import i18n from '@/i18n';
 
 type WalletStateCredential = CurrentSchema.WalletStateCredential;
 
@@ -215,6 +216,18 @@ export const CredentialsContextProvider = ({ children }: React.PropsWithChildren
 		console.log("Triggerring getData()")
 		getData();
 	}, [getData, getCalculatedWalletState, credentialEngine, isLoggedIn]);
+
+	useEffect(() => {
+		if (!isLoggedIn || !vcEntityList?.length) return;
+
+		void Promise.allSettled(vcEntityList.map((vcEntity) =>
+			vcEntity.parsedCredential.metadata.credential.image.dataUri(
+				undefined,
+				[...i18n.languages],
+				{ orientation: 'landscape' },
+			)
+		));
+	}, [isLoggedIn, vcEntityList]);
 
 	if (isLoggedIn && !credentialEngine) {
 		return (

--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -11,6 +11,7 @@ import Link from '../../components/Links/Link';
 import Spinner from '../../components/Shared/Spinner';
 import AuthCard from '../../components/Auth/AuthCard';
 import WebauthnSignupLogin from '../../components/Auth/WebauthnSignupLogin';
+import { resolveLoginRedirect } from '../../components/Auth/loginRedirect';
 
 const Login = () => {
 	const { isOnline } = useContext(StatusContext);
@@ -29,7 +30,7 @@ const Login = () => {
 
 	useEffect(() => {
 		if (isLoggedIn) {
-			navigate(`/${window.location.search}`, { replace: true });
+			navigate(resolveLoginRedirect(window.location.search), { replace: true });
 		}
 	}, [isLoggedIn, navigate]);
 

--- a/src/pages/Auth/LoginState.jsx
+++ b/src/pages/Auth/LoginState.jsx
@@ -7,6 +7,7 @@ import SessionContext from '@/context/SessionContext';
 import Button from '../../components/Buttons/Button';
 import AuthCard from '../../components/Auth/AuthCard';
 import checkForUpdates from '../../offlineUpdateSW';
+import { resolveLoginRedirect } from '../../components/Auth/loginRedirect';
 import { UserLock } from 'lucide-react';
 
 const WebauthnLogin = ({
@@ -129,7 +130,7 @@ const LoginState = () => {
 	if (!filteredUser) {
 		return <Navigate to="/login" replace />;
 	} else if ((isLoggedIn && !forceAuthenticate) || (forceAuthenticate === true && authenticated)) {
-		return <Navigate to={`/${window.location.search}`} replace />;
+		return <Navigate to={resolveLoginRedirect(window.location.search)} replace />;
 	}
 
 	return (

--- a/src/pages/Auth/Register.tsx
+++ b/src/pages/Auth/Register.tsx
@@ -11,6 +11,7 @@ import checkForUpdates from '../../offlineUpdateSW';
 import Spinner from '../../components/Shared/Spinner';
 import AuthCard from '../../components/Auth/AuthCard';
 import WebauthnSignupLogin from '../../components/Auth/WebauthnSignupLogin';
+import { resolveLoginRedirect } from '../../components/Auth/loginRedirect';
 
 const Register = () => {
 	const { updateOnlineStatus } = useContext(StatusContext);
@@ -26,7 +27,7 @@ const Register = () => {
 
 	useEffect(() => {
 		if (isLoggedIn) {
-			navigate(`/${window.location.search}`, { replace: true });
+			navigate(resolveLoginRedirect(window.location.search), { replace: true });
 		}
 	}, [isLoggedIn, navigate]);
 

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -26,6 +26,7 @@ import SettingsSection from './components/SettingsSection';
 import SettingsRow from './components/SettingsRow';
 import SettingsSelect from './components/SettingsSelect';
 import SettingsTabs, { SettingsTab } from './components/SettingsTabs';
+import { SETTINGS_TAB_IDS } from './tabs';
 import WebauthnRegistration from './components/WebauthnRegistration';
 import WebauthnCredentialItem, { useWebauthnCredentialNickname } from './components/WebauthnCredentialItem';
 
@@ -44,8 +45,6 @@ type UpgradePrfState = (
 		webauthnCredential: WebauthnCredential,
 	}
 );
-
-const SETTINGS_TAB_IDS = ['general', 'account', 'privacy'];
 
 const Settings = () => {
 	const { isOnline, updateAvailable } = useContext(StatusContext);

--- a/src/pages/Settings/tabs.ts
+++ b/src/pages/Settings/tabs.ts
@@ -1,0 +1,3 @@
+// The tab ids the Settings page accepts in its `?tab=` param
+// Also used to validate postlogin redirects
+export const SETTINGS_TAB_IDS = ['general', 'account', 'privacy'];


### PR DESCRIPTION
PR https://github.com/wwWallet/wallet-frontend/pull/1167 adds a `tab` param on settings pages to allow direct linking of tabs. This is useful for FAQ and documentation pages sending users to a specific setting. However, in most of those cases user will have to login and currently there is no post-login redirect mechanism. 

This PR introduces a mechanism that allows urls to pages on a allowlist to be restored after the user logins. Allowed urls are determined by a Map and currently only settings pages are allowed.

```ts
const REDIRECT_TARGETS = new Map<string, RedirectTarget>([
	['settings', { path: '/settings', params: { tab: SETTINGS_TAB_IDS } }],
]);
``` 

Validated URLs are recreated and user is navigated on their initial target.

### Test
Try to access `http://<WALLET_BASE>/settings?tab=account` on a new tab.