### PR TITLE
Preload credential images when logging in to non-home routes

### DIFF
--- a/src/context/CredentialsContextProvider.tsx
+++ b/src/context/CredentialsContextProvider.tsx
@@ -7,6 +7,7 @@ import CredentialsContext, { ExtendedVcEntity, Instance } from "./CredentialsCon
 import { useOpenID4VCIHelper } from "@/lib/services/OpenID4VCIHelper";
 import { CurrentSchema } from '@/services/WalletStateSchema';
 import { setAppBadgeCount } from '@/utils';
+import i18n from '@/i18n';
 
 type WalletStateCredential = CurrentSchema.WalletStateCredential;
 
@@ -215,6 +216,18 @@ export const CredentialsContextProvider = ({ children }: React.PropsWithChildren
 		console.log("Triggerring getData()")
 		getData();
 	}, [getData, getCalculatedWalletState, credentialEngine, isLoggedIn]);
+
+	useEffect(() => {
+		if (!isLoggedIn || !vcEntityList?.length) return;
+
+		void Promise.allSettled(vcEntityList.map((vcEntity) =>
+			vcEntity.parsedCredential.metadata.credential.image.dataUri(
+				undefined,
+				[...i18n.languages],
+				{ orientation: 'landscape' },
+			)
+		));
+	}, [isLoggedIn, vcEntityList]);
 
 	if (isLoggedIn && !credentialEngine) {
 		return (


### PR DESCRIPTION
Preload credential images after credentials are parsed, regardless of the route opened after login.

This ensures SVG templates and PNG assets are cached for offline use when the user navigates directly to a route such as `/settings` without first visiting the home page.

The preload invokes the existing credential image resolver directly without rendering hidden `CredentialImage` components.