### PR TITLE
Ensure Device Signing Cose Key type is bstr

### DIFF
--- a/src/utils/mdocHolderContext.test.ts
+++ b/src/utils/mdocHolderContext.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { exportJWK } from "jose";
-import { cborDecode, Holder, IssuerSigned } from "@owf/mdoc";
+import { cborDecode, CoseKeyParameter, Holder, IssuerSigned } from "@owf/mdoc";
 import {
 	createDeviceResponseForDcql,
 	mdocContext,
@@ -47,8 +47,8 @@ describe("mdoc device signing COSE key", () => {
 
 		expect(capturedKey).toBeDefined();
 		const encodedKey = cborDecode<Map<number, unknown>>(capturedKey.encode());
-		expect(encodedKey.get(2)).toBeInstanceOf(Uint8Array);
-		expect(Array.from(encodedKey.get(2) as Uint8Array)).toEqual(
+		expect(encodedKey.get(CoseKeyParameter.KeyId)).toBeInstanceOf(Uint8Array);
+		expect(Array.from(encodedKey.get(CoseKeyParameter.KeyId) as Uint8Array)).toEqual(
 			Array.from(Uint8Array.from(new TextEncoder().encode("device-key-1"))),
 		);
 

--- a/src/utils/mdocHolderContext.test.ts
+++ b/src/utils/mdocHolderContext.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { exportJWK } from "jose";
+import { cborDecode, Holder, IssuerSigned } from "@owf/mdoc";
+import {
+	createDeviceResponseForDcql,
+	mdocContext,
+} from "./mdocHolderContext";
+
+const createFakeCredential = (): IssuerSigned => Object.create(IssuerSigned.prototype) as IssuerSigned;
+
+const createParams = async (namedCurve: "P-256" | "P-384" | "P-521", alg: string, kid: string) => {
+	const keyPair = await crypto.subtle.generateKey(
+		{ name: "ECDSA", namedCurve },
+		true,
+		["sign", "verify"],
+	);
+	const privateKeyJwk = await exportJWK(keyPair.privateKey);
+	return {
+		keyPair,
+		privateKeyJwk,
+		params: {
+		mdocCredential: { documents: [{ issuerSigned: createFakeCredential() }] },
+			dcqlQuery: {
+				credentials: [{ id: "mdl", meta: { doctype_value: "org.iso.18013.5.1.mDL" }, claims: [] }],
+			},
+			selectedCredentialId: "mdl",
+			sessionTranscript: new Uint8Array([1, 2, 3]),
+			privateKeyJwk,
+			alg,
+			kid,
+		},
+	};
+};
+
+describe("mdoc device signing COSE key", () => {
+	afterEach(() => { vi.restoreAllMocks(); });
+
+	it("encodes kid as a CBOR byte string and signs with the supplied key", async () => {
+		const { keyPair, params } = await createParams("P-256", "ES256", "device-key-1");
+		let capturedKey: any;
+		vi.spyOn(Holder, "createDeviceResponseForDeviceRequest").mockImplementation(async (options) => {
+			capturedKey = options.signature?.signingKey;
+			return {} as any;
+		});
+
+		await createDeviceResponseForDcql(params);
+
+		expect(capturedKey).toBeDefined();
+		const encodedKey = cborDecode<Map<number, unknown>>(capturedKey.encode());
+		expect(encodedKey.get(2)).toBeInstanceOf(Uint8Array);
+		expect(Array.from(encodedKey.get(2) as Uint8Array)).toEqual(
+			Array.from(Uint8Array.from(new TextEncoder().encode("device-key-1"))),
+		);
+
+		const payload = new TextEncoder().encode("device-authentication");
+		const signature = await mdocContext.cose.sign1.sign({ key: capturedKey, toBeSigned: payload });
+		const publicKey = await crypto.subtle.importKey(
+			"jwk",
+			await exportJWK(keyPair.publicKey),
+			{ name: "ECDSA", namedCurve: "P-256" },
+			false,
+			["verify"],
+		);
+		expect(signature).toHaveLength(64);
+		expect(await crypto.subtle.verify(
+			{ name: "ECDSA", hash: "SHA-256" },
+			publicKey,
+			signature,
+			payload,
+		)).toBe(true);
+	});
+
+	it("does not mutate the private JWK", async () => {
+		const { params } = await createParams("P-256", "ES256", "original-kid");
+		const original = structuredClone(params.privateKeyJwk);
+		vi.spyOn(Holder, "createDeviceResponseForDeviceRequest").mockResolvedValue({} as any);
+
+		await createDeviceResponseForDcql(params);
+
+		expect(params.privateKeyJwk).toEqual(original);
+	});
+});

--- a/src/utils/mdocHolderContext.ts
+++ b/src/utils/mdocHolderContext.ts
@@ -3,6 +3,7 @@ import { p256, p384, p521 } from "@noble/curves/nist.js";
 import {
 	cborEncode,
 	CoseKey,
+	CoseKeyParameter,
 	DeviceRequest,
 	DocRequest,
 	Holder,
@@ -12,10 +13,10 @@ import {
 	type MdocContext,
 } from "@owf/mdoc";
 
-/** Fix for @owf/mdoc 0.6.0 kid (COSE header 4), which must be a bstr (not a tstr). */
+/** Fix for @owf/mdoc 0.6.0 kid, which must be a bstr, not a tstr. */
 class DeviceSigningCoseKey extends CoseKey {
 	get keyId(): any {
-		const keyId = this.decodedStructure.get(2);
+		const keyId = this.decodedStructure.get(CoseKeyParameter.KeyId);
 		return keyId instanceof Uint8Array ? keyId : undefined;
 	}
 }
@@ -24,7 +25,7 @@ function createDeviceSigningCoseKey(jwk: Record<string, unknown>): CoseKey {
 	const { kid, ...jwkWithoutKid } = jwk;
 	const key = CoseKey.fromJwk(jwkWithoutKid);
 	if (typeof kid === "string") {
-		key.decodedStructure.set(2, Uint8Array.from(new TextEncoder().encode(kid)));
+		key.decodedStructure.set(CoseKeyParameter.KeyId, Uint8Array.from(new TextEncoder().encode(kid)));
 	}
 	Object.setPrototypeOf(key, DeviceSigningCoseKey.prototype);
 	return key;

--- a/src/utils/mdocHolderContext.ts
+++ b/src/utils/mdocHolderContext.ts
@@ -21,7 +21,11 @@ class DeviceSigningCoseKey extends CoseKey {
 }
 
 function createDeviceSigningCoseKey(jwk: Record<string, unknown>): CoseKey {
-	const key = CoseKey.fromJwk(jwk);
+	const { kid, ...jwkWithoutKid } = jwk;
+	const key = CoseKey.fromJwk(jwkWithoutKid);
+	if (typeof kid === "string") {
+		key.decodedStructure.set(2, Uint8Array.from(new TextEncoder().encode(kid)));
+	}
 	Object.setPrototypeOf(key, DeviceSigningCoseKey.prototype);
 	return key;
 }

--- a/src/utils/mdocHolderContext.ts
+++ b/src/utils/mdocHolderContext.ts
@@ -12,6 +12,20 @@ import {
 	type MdocContext,
 } from "@owf/mdoc";
 
+/** Fix for @owf/mdoc 0.6.0 kid (COSE header 4), which must be a bstr (not a tstr). */
+class DeviceSigningCoseKey extends CoseKey {
+	get keyId(): any {
+		const keyId = this.decodedStructure.get(2);
+		return keyId instanceof Uint8Array ? keyId : undefined;
+	}
+}
+
+function createDeviceSigningCoseKey(jwk: Record<string, unknown>): CoseKey {
+	const key = CoseKey.fromJwk(jwk);
+	Object.setPrototypeOf(key, DeviceSigningCoseKey.prototype);
+	return key;
+}
+
 export type MDoc = DeviceResponse | {
 	documents?: any[];
 	encode?: () => Uint8Array;
@@ -44,7 +58,10 @@ function convertDerToCompact(signature: Uint8Array, profile: EcdsaProfile): Uint
 }
 
 async function importSigningKeyFromCoseKey(key: CoseKey): Promise<CryptoKey> {
-	const jwk = key.jwk as JsonWebKey;
+	const jwk = { ...key.jwk } as JsonWebKey & { kid?: string | Uint8Array };
+	if (jwk.kid instanceof Uint8Array) {
+		jwk.kid = new TextDecoder().decode(jwk.kid);
+	}
 	const { namedCurve } = getEcdsaProfileFromJwk(jwk);
 	return await crypto.subtle.importKey(
 		"jwk",
@@ -181,7 +198,7 @@ export async function createDeviceResponseForDcql(params: {
 			sessionTranscript: params.sessionTranscript,
 			issuerSigned: [issuerSigned],
 			signature: {
-				signingKey: CoseKey.fromJwk({
+				signingKey: createDeviceSigningCoseKey({
 					...params.privateKeyJwk,
 					alg: params.alg,
 					kid: params.kid,


### PR DESCRIPTION
This PR ensures the type of Device Signing Cose Key is `bstr`, not `tstr`, aligning with [RFC 9052](https://datatracker.ietf.org/doc/html/rfc9052.html#name-common-header-parameters).