### PR TITLE
Pin editorconfig checker action to v3.0.0

### DIFF
--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up editorconfig-checker
-      uses: editorconfig-checker/action-editorconfig-checker@v2
+      uses: editorconfig-checker/action-editorconfig-checker@v3.0.0
 
     - name: Check code formatting
       run: editorconfig-checker

--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
 
     - name: Set up editorconfig-checker
       uses: editorconfig-checker/action-editorconfig-checker@v3.0.0


### PR DESCRIPTION
This PR pins the editorconfig-checker github action to v.3.0.0 to avoid a breaking change between previous v2 and v.3.0.0 and later, which caused actions to fail in all Pull Requests.