### PR TITLE
Fix mobile sidebar flash during navigation

### DIFF
--- a/src/components/Layout/Navigation/Sidebar.jsx
+++ b/src/components/Layout/Navigation/Sidebar.jsx
@@ -55,7 +55,9 @@ const Sidebar = ({ isOpen, toggle }) => {
 
 	const handleNavigate = (path) => {
 		if (location.pathname === path) {
-			window.location.reload();
+			if (screenType !== 'desktop') {
+				toggle();
+			}
 		} else {
 			React.startTransition(() => {
 				if (screenType !== 'desktop') {

--- a/src/components/Layout/Navigation/Sidebar.jsx
+++ b/src/components/Layout/Navigation/Sidebar.jsx
@@ -57,10 +57,12 @@ const Sidebar = ({ isOpen, toggle }) => {
 		if (location.pathname === path) {
 			window.location.reload();
 		} else {
-			navigate(path);
-			if (screenType !== 'desktop') {
-				toggle();
-			}
+			React.startTransition(() => {
+				if (screenType !== 'desktop') {
+					toggle();
+				}
+				navigate(path);
+			});
 		}
 	};
 


### PR DESCRIPTION
### Issue

On mobile screens, navigating to Settings through the profile sidebar caused a brief flash. The sidebar was closed and the route was changed as separate UI updates, which could briefly display the previous page before Settings appeared.

Additionally, selecting the navigation item for the current page caused an unnecessary full-page reload.

### Fix

The sidebar close and route navigation now run within the same React transition, preventing intermediate UI states from being displayed.

Selecting the active navigation item no longer reloads the page:

- On mobile, it only closes the sidebar/profile.
- On desktop, no action is performed.