### PR TITLE
Update debian version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bullseye-slim AS builder-base
+FROM node:24-bookworm-slim AS builder-base
 
 RUN apt-get update -y && apt-get install -y git fontconfig && rm -rf /var/lib/apt/lists/*
 

--- a/tests.Dockerfile
+++ b/tests.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bullseye-slim AS builder-base
+FROM node:24-bookworm-slim AS builder-base
 
 RUN apt-get update -y && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This PR bumps the docker image Debian version to Debian 12 "bookworm", since Debian 11 "bullseye" was deprecated. Additionally, node 22 was updated to node 24 (LTS), for consistency with other wwwallet repositories.