### PR TITLE
Correct cached account state synchronization

### DIFF
--- a/src/services/LocalStorageKeystore.test.tsx
+++ b/src/services/LocalStorageKeystore.test.tsx
@@ -3,7 +3,7 @@ import { act, cleanup, render, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { LocalStorageKeystore } from "./LocalStorageKeystore";
-import { shouldMergeOpenKeystore, useLocalStorageKeystore } from "./LocalStorageKeystore";
+import { useLocalStorageKeystore } from "./LocalStorageKeystore";
 import * as keystoreApi from "./keystore";
 import { CurrentSchema, foldState, mergeEventHistories } from "./WalletStateSchema";
 import { getItem } from "../indexedDB";

--- a/src/services/LocalStorageKeystore.test.tsx
+++ b/src/services/LocalStorageKeystore.test.tsx
@@ -1,0 +1,130 @@
+import React from "react";
+import { act, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { LocalStorageKeystore } from "./LocalStorageKeystore";
+import { useLocalStorageKeystore } from "./LocalStorageKeystore";
+
+const mocks = vi.hoisted(() => {
+	let resolveWrite: (() => void) | undefined;
+	let resolveWriteStarted: (() => void) | undefined;
+	let writeStarted = Promise.resolve();
+	const read = vi.fn(async () => ({ content: {
+		prfKeys: [{ credentialId: new Uint8Array([0xaa]) }],
+		jwe: "user-a",
+	} }));
+	const write = vi.fn(async () => await mocks.setWritePending());
+	const destroy = vi.fn(async () => undefined);
+
+	return {
+		db: { read, write, destroy },
+		resetWriteGate: () => {
+			writeStarted = new Promise<void>((resolve) => {
+				resolveWriteStarted = resolve;
+			});
+		},
+		waitForWriteStarted: () => writeStarted,
+		resolveWrite: () => resolveWrite?.(),
+		setWritePending: () => new Promise<void>((resolve) => {
+			resolveWriteStarted?.();
+			resolveWrite = resolve;
+		}),
+	};
+});
+
+vi.mock("react-router-dom", () => ({
+	useNavigate: () => vi.fn(),
+}));
+
+vi.mock("../hooks/useIndexedDb", () => ({
+	useIndexedDb: () => mocks.db,
+}));
+
+vi.mock("../indexedDB", () => ({
+	getItem: vi.fn(async () => null),
+}));
+
+vi.mock("./WalletStateSchema", () => ({
+	foldState: vi.fn(() => ({ user: "unlocked" })),
+	mergeEventHistories: vi.fn(),
+}));
+
+vi.mock("./keystore", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./keystore")>();
+	return {
+		...actual,
+		initPrf: vi.fn(async () => ({
+			mainKey: { id: "user-b-main-key" },
+			keyInfo: { id: "user-b-key-info" },
+		})),
+		init: vi.fn(async () => ({
+			mainKey: { id: "user-b-main-key" },
+			privateData: {
+				prfKeys: [{ credentialId: new Uint8Array([0xbb]) }],
+				jwe: "user-b",
+			},
+		})),
+		openPrivateData: vi.fn(async () => [{}, {}, {}]),
+		importMainKey: vi.fn(async () => ({})),
+		exportMainKey: vi.fn(async () => new Uint8Array([0xbb])),
+	};
+});
+
+const eventTarget = new EventTarget();
+
+function KeystoreProbe({ onReady }: { onReady: (keystore: LocalStorageKeystore) => void }) {
+	onReady(useLocalStorageKeystore(eventTarget));
+	return null;
+}
+
+describe("useLocalStorageKeystore", () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+		window.sessionStorage.clear();
+		mocks.resetWriteGate();
+		mocks.resolveWrite();
+
+		window.localStorage.setItem("cachedUsers", JSON.stringify([
+			{
+				displayName: "User A",
+				userHandleB64u: "user-a",
+				prfKeys: [{ credentialId: { $b64u: "qg" } }],
+			},
+		]));
+		window.localStorage.setItem("userHandle", JSON.stringify("user-a"));
+		window.localStorage.setItem("globalTabId", JSON.stringify("tab-a"));
+		window.sessionStorage.setItem("userHandle", JSON.stringify("user-a"));
+		window.sessionStorage.setItem("tabId", JSON.stringify("tab-a"));
+	});
+
+	it("does not update user A's cached PRF keys while unlocking user B", async () => {
+		let keystore: LocalStorageKeystore | undefined;
+		render(<KeystoreProbe onReady={(value) => { keystore = value; }} />);
+
+		// Let the initial effect load user A's existing private data.
+		await act(async () => { await Promise.resolve(); });
+
+		const unlockPromise = keystore!.initPrf(
+			{} as PublicKeyCredential,
+			new Uint8Array([0xbb]),
+			async () => false,
+			{ displayName: "User B", userHandle: new TextEncoder().encode("user-b") },
+		);
+
+		try {
+			// The IndexedDB write is intentionally pending. The cache-sync effect must
+			// not observe B's private data with A's still-current user handle.
+			await act(async () => { await mocks.waitForWriteStarted(); });
+
+			expect(keystore!.getCachedUsers().find((user) => user.userHandleB64u === "user-a")?.prfKeys)
+				.toEqual([{
+					credentialId: new Uint8Array([0xaa]),
+					transports: undefined,
+					prfSalt: undefined,
+				}]);
+		} finally {
+			mocks.resolveWrite();
+			await act(async () => { await unlockPromise; });
+		}
+	});
+});

--- a/src/services/LocalStorageKeystore.test.tsx
+++ b/src/services/LocalStorageKeystore.test.tsx
@@ -3,7 +3,7 @@ import { act, cleanup, render, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { LocalStorageKeystore } from "./LocalStorageKeystore";
-import { useLocalStorageKeystore } from "./LocalStorageKeystore";
+import { shouldMergeOpenKeystore, useLocalStorageKeystore } from "./LocalStorageKeystore";
 import * as keystoreApi from "./keystore";
 import { CurrentSchema, foldState, mergeEventHistories } from "./WalletStateSchema";
 import { getItem } from "../indexedDB";
@@ -215,6 +215,37 @@ describe("unlocking with locally cached encrypted private data", () => {
 		expect(getItem).toHaveBeenCalledWith("users", "merge-user");
 		expect(keystoreApi.parsePrivateData).not.toHaveBeenCalled();
 		expectRemoteFallback(result, encrypted);
+	});
+
+	it.each([false, true])("does not merge user A's open wallet when logging in as user B (cached user: %s)", async (cachedUser) => {
+		const userA = { displayName: "User A", userHandle: new TextEncoder().encode("user-a") };
+		const credentialA = { id: toBase64Url(new Uint8Array([0xbb])) } as PublicKeyCredential;
+		vi.mocked(keystoreApi.unlockPrf).mockResolvedValueOnce([{ privateData: local, mainKey: oldKey }, null]);
+		vi.mocked(foldState).mockReturnValueOnce(localState.S);
+		const { result } = renderHook(() => useLocalStorageKeystore(eventTarget));
+
+		await act(async () => {
+			await result.current.unlockPrf(local, credentialA, promptForPrfRetry, userA);
+		});
+		expect(result.current.isOpen()).toBe(true);
+		expect(result.current.getUserHandleB64u()).toBe(toBase64Url(userA.userHandle));
+		expect(result.current.getCalculatedWalletState()).toBe(localState.S);
+
+		// A second login can return B's passkey while A's keystore is still open.
+		// Use the same mounted hook so its current handle, private data and key remain A's.
+		vi.clearAllMocks();
+		let unlocked: Awaited<ReturnType<LocalStorageKeystore["unlockPrf"]>>;
+		await act(async () => {
+			unlocked = await result.current.unlockPrf(remote, credential, promptForPrfRetry,
+				cachedUser ? { displayName: user.displayName, userHandleB64u: toBase64Url(userHandle), prfKeys: [] } : user);
+		});
+
+		expect(getItem).toHaveBeenCalledWith("users", "merge-user");
+		expect(keystoreApi.openPrivateData).toHaveBeenCalledOnce();
+		expect(keystoreApi.openPrivateData).toHaveBeenCalledWith(remoteKey, remote);
+		expect(put).toHaveBeenCalledOnce();
+		expect(result.current.getUserHandleB64u()).toBe(toBase64Url(userHandle));
+		expectRemoteFallback(result, unlocked![0]);
 	});
 
 	it("skips local decryption when the JWE matches even if PRF metadata differs", async () => {

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -49,6 +49,15 @@ export enum KeystoreEvent {
 }
 
 export type CommitCallback = () => Promise<void>;
+
+export function shouldMergeOpenKeystore(
+	hasOpenKeystore: boolean,
+	currentUserHandleB64u: string | null,
+	targetUserHandleB64u: string,
+): boolean {
+	return hasOpenKeystore && currentUserHandleB64u === targetUserHandleB64u;
+}
+
 export interface LocalStorageKeystore {
 	isOpen(): boolean,
 	close(): Promise<void>,
@@ -332,13 +341,15 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 		promptForPrfRetry: () => Promise<boolean | AbortSignal>,
 	): Promise<keystore.EncryptedContainer> => {
 		if (user) {
-			const userHandleB64u = ("prfKeys" in user
+			const targetUserHandleB64u = ("prfKeys" in user
 				? user.userHandleB64u
 				: toBase64Url(user.userHandle)
 			);
 			let newEncryptedContainer: keystore.EncryptedContainer;
+			let newMainKeyExport: BufferSource | null = null;
+			let newCalculatedWalletState: WalletState | null = null;
 
-			if (privateData && mainKey) { // keystore is already opened
+			if (shouldMergeOpenKeystore(Boolean(privateData && mainKey), userHandleB64u, targetUserHandleB64u)) {
 				const [localPrivateData, localMainKey] = await assertKeystoreOpen();
 				const [remoteContainer, remoteMainKey,] = await keystore.openPrivateData(unlockSuccess.mainKey, unlockSuccess.privateData);
 				const [localContainer, ,] = await keystore.openPrivateData(localMainKey, localPrivateData);
@@ -348,7 +359,7 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 					remoteMainKey,
 				], mergedContainer as CurrentSchema.WalletStateContainer);
 				const [newPrivateDataEncryptedContainer, newMainKey] = newContainer;
-				await writePrivateDataOnIdb(newPrivateDataEncryptedContainer, userHandleB64u);
+				await writePrivateDataOnIdb(newPrivateDataEncryptedContainer, targetUserHandleB64u);
 				setPrivateData(newPrivateDataEncryptedContainer);
 				newEncryptedContainer = newPrivateDataEncryptedContainer;
 				setMainKey(await keystore.exportMainKey(newMainKey));
@@ -357,7 +368,7 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 			}
 			else {
 				async function mergeWithLocalEncryptedPrivateData(container: [EncryptedContainer, CryptoKey, WalletStateContainerGeneric]): Promise<[EncryptedContainer, CryptoKey, WalletStateContainerGeneric]> {
-					const userId = UserId.fromUserHandle(fromBase64Url(userHandleB64u));
+					const userId = UserId.fromUserHandle(new Uint8Array(fromBase64Url(targetUserHandleB64u)));
 					const localUser = await getItem("users", userId.id);
 					if (!localUser) {
 						return container;
@@ -386,23 +397,21 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 				const [encryptedContainer, newMainKey, decryptedWalletState] = await mergeWithLocalEncryptedPrivateData([privateData, mainKey, unlockedContainer]);
 				const foldedState = foldState(decryptedWalletState as CurrentSchema.WalletStateContainer);
 				newEncryptedContainer = encryptedContainer;
-				setPrivateData(encryptedContainer);
-				setMainKey(await keystore.exportMainKey(newMainKey));
-				await writePrivateDataOnIdb(encryptedContainer, userHandleB64u);
-				// after private data update, the calculated wallet state must be re-computed
-				setCalculatedWalletState(foldedState);
+				await writePrivateDataOnIdb(encryptedContainer, targetUserHandleB64u);
+				newMainKeyExport = await keystore.exportMainKey(newMainKey);
+				newCalculatedWalletState = foldedState;
 			}
 
 			const newUser = ("prfKeys" in user
 				? user
 				: {
 					displayName: user.displayName,
-					userHandleB64u,
+					userHandleB64u: targetUserHandleB64u,
 					prfKeys: [], // Placeholder - will be updated by useEffect above
 				}
 			);
 
-			setUserHandleB64u(userHandleB64u);
+			setUserHandleB64u(targetUserHandleB64u);
 
 			const newTabId = tabId ?? WalletStateUtils.getRandomUint32().toString();
 			setTabId(newTabId);
@@ -411,13 +420,19 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 			// This must happen before setPrivateData in order to prevent the
 			// useEffect updating cachedUsers from corrupting cache entries for other
 			// users logged in in other tabs.
-			setGlobalUserHandleB64u(userHandleB64u);
+			setGlobalUserHandleB64u(targetUserHandleB64u);
 
 			setCachedUsers((cachedUsers) => {
 				// Move most recently used user to front of list
 				const otherUsers = (cachedUsers || []).filter((cu) => cu.userHandleB64u !== newUser.userHandleB64u);
 				return [newUser, ...otherUsers];
 			});
+
+			if (newMainKeyExport) {
+				setPrivateData(newEncryptedContainer);
+				setMainKey(newMainKeyExport);
+				setCalculatedWalletState(newCalculatedWalletState);
+			}
 
 			return newEncryptedContainer;
 		}
@@ -434,7 +449,8 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 		writePrivateDataOnIdb,
 		assertKeystoreOpen,
 		privateData,
-		mainKey
+		mainKey,
+		userHandleB64u
 	]);
 
 


### PR DESCRIPTION
This PR fixes an issue with local keystore handling where, under some circumstances, two users' data could be synchronized.

Now, the user handle is verified to be correct and the wallet state is calculated after all other actions, to ensure integrity.

The change is accompanied by a test suite.